### PR TITLE
[CHERIoT] Provide correct error messages for AUI{CGP,PCC}

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -1315,7 +1315,20 @@ bool RISCVAsmParser::MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
                                       "operand must be a symbol with "
                                       "%hi/%tprel_hi modifier or an integer in "
                                       "the range");
+  case Match_InvalidUImm20AUIGP:
+    return generateImmOutOfRangeError(
+        Operands, ErrorInfo, 0, (1 << 20) - 1,
+        "operand must be a symbol with a "
+        "%cheri_compartment_cgprel_hi modifier or "
+        "an integer in the range");
   case Match_InvalidUImm20AUIPC:
+    // FIXME: This should be keyed off an Xcheriot feature, not a CPU name.
+    if (getSTI().getCPU() == "cheriot")
+      return generateImmOutOfRangeError(
+          Operands, ErrorInfo, 0, (1 << 20) - 1,
+          "operand must be a symbol with a "
+          "%cheri_compartment_pccrel_hi modifier or "
+          "an integer in the range");
     return generateImmOutOfRangeError(
         Operands, ErrorInfo, 0, (1 << 20) - 1,
         "operand must be a symbol with a "

--- a/llvm/test/MC/RISCV/cheri/cheriot-invalid-auipcccgp.s
+++ b/llvm/test/MC/RISCV/cheri/cheriot-invalid-auipcccgp.s
@@ -1,0 +1,9 @@
+# RUN: not llvm-mc %s -triple=riscv32 -mcpu=cheriot -mattr=+xcheri -riscv-no-aliases -show-encoding \
+# RUN:   2>&1  | FileCheck %s
+hello:
+	auipcc csp, 1<<20 # CHECK: :[[@LINE]]:14: error: operand must be a symbol with
+	# CHECK-SAME: cheri_compartment_pccrel_hi
+	# CHECK-SAME: or an integer in the range [0, 1048575]
+	auicgp csp, 1<<20 # CHECK: :[[@LINE]]:14: error: operand must be a symbol with
+	# CHECK-SAME: cheri_compartment_cgprel_hi
+	# CHECK-SAME: or an integer in the range [0, 1048575]


### PR DESCRIPTION
If these are out of range, we should report an error (not crash, as we did with AUICGP).  The AUIPCC errors were reporting the valid relocations for AUIPC, so fix those to report the correct ones for CHERIoT.

This is slightly wrong because we currently use CHERIoT as a CPU name not an extension name.  We should fix that soon.

Fixes CHERIoT-Platform/llvm-project#8