### PR TITLE
Fix error in last commit.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -310,10 +310,8 @@ void RISCVAsmPrinter::emitEndOfAsmFile(Module &M) {
       auto Sym = C.getOrCreateSymbol(Entry.ImportName);
       auto ExportSym = C.getOrCreateSymbol(Entry.ExportName);
       OutStreamer->emitSymbolAttribute(Sym, MCSA_ELF_TypeObject);
-      if (Entry.IsPublic) {
+      if (Entry.IsPublic)
         OutStreamer->emitSymbolAttribute(Sym, MCSA_Weak);
-        OutStreamer->emitSymbolAttribute(Sym, MCSA_Global);
-      }
       OutStreamer->emitValueToAlignment(8);
       OutStreamer->emitLabel(Sym);
       // Library imports have their low bit set.


### PR DESCRIPTION
Import entries (unlike exports) should never have .globl.  They should be .weak if they are COMDATs, otherwise they are private to the current compilation unit.