### PR TITLE
[CHERIoT] Fix problems introduced in last commit.

### DIFF
--- a/llvm/test/CodeGen/RISCV/cheri/cheri-mcu-ccall.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheri-mcu-ccall.ll
@@ -82,13 +82,13 @@ entry:
   ; Check that we have the right relocations and stack layout.
   ; BOTH-LABEL: testcall8:
   ; BOTH:  auicgp  ct0, %cheriot_compartment_hi(testcall8.stack_arg)
-  ; BOTH:  cincoffset      ct0, ct0, %cheriot_compartment_lo_i(testcall8.stack_arg)
+  ; BOTH:  cincoffset      ct0, ct0, %cheriot_compartment_lo_i
   ; BOTH:  csetbounds      ct0, ct0, %cheriot_compartment_size(testcall8.stack_arg)
   ; BOTH:  csc     ct0, 8(csp)
   ; BOTH:  auipcc  ct1, %cheriot_compartment_hi(__import_other_test8callee)
-  ; BOTH:  clc     ct1, %cheriot_compartment_lo_i(.LBB3_2)(ct1)
+  ; BOTH:  clc     ct1, %cheriot_compartment_lo_i
   ; BOTH:  auipcc  ct2, %cheriot_compartment_hi(.compartment_switcher)
-  ; BOTH:  clc     ct2, %cheriot_compartment_lo_i(.LBB3_1)(ct2)
+  ; BOTH:  clc     ct2, %cheriot_compartment_lo_i
   ; BOTH:  c.cjalr ct2
   %args = alloca [8 x i32], align 4, addrspace(200)
   %0 = bitcast [8 x i32] addrspace(200)* %args to i8 addrspace(200)*

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-globals.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-globals.ll
@@ -16,7 +16,7 @@ entry:
   ; CHECK: auicgp
   ; CHECK-SAME: %cheriot_compartment_hi(x)
   ; CHECK: cincoffset
-  ; CHECK-SAME: %cheriot_compartment_lo_i(x)
+  ; CHECK-SAME: %cheriot_compartment_lo_i
   ; CHECK: csetbounds ca0, ca0, %cheriot_compartment_size(x)
   ret i32 addrspace(200)* @x
 }
@@ -29,7 +29,7 @@ entry:
   ; XCHECK: auicgp
   ; XCHECK-SAME: %cheriot_compartment_hi(x)
   ; XCHECK: clw 
-  ; XCHECK-SAME: %cheriot_compartment_lo_i(x)
+  ; XCHECK-SAME: %cheriot_compartment_lo_i
   ; XCHECK-NEXT: cret
   %0 = load i32, i32 addrspace(200)* @x, align 4, !tbaa !5
   ret i32 %0

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-load-store-relocs.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-load-store-relocs.ll
@@ -16,7 +16,7 @@ entry:
   ; CHECK-SAME: %cheriot_compartment_hi(temp)
   ; XCHECK: clw
   ; CHECK: cincoffset
-  ; CHECK-SAME: %cheriot_compartment_lo_i(temp)
+  ; CHECK-SAME: %cheriot_compartment_lo_i
   %0 = load i32, i32 addrspace(200)* @temp, align 4, !tbaa !5
   %inc = add nsw i32 %0, 1
   store i32 %inc, i32 addrspace(200)* @temp, align 4, !tbaa !5


### PR DESCRIPTION
Unifying AUIPCC and AUICGP relocations meant that the LO relocation now needed to point to the AUI{PCC,CGP} instruction.  This was not done and so CGP-relative LO relocations still pointed to their target.  This meant that the case of rewriting AUICGP to AUIPCC was broken (as was the bit masking used to do this) because it would point to the wrong location.  This broke the motivating case: a global that's defined as const but not declared as const (or not marked as constant when used as an extern in C++).

Fixing this then triggered another issue: we relax AUICGP and, in the typical case, delete the AUICGP instruction entirely (we have a full 4 KiB range for CGP-relative loads and stores because CGP is biased and points to the middle of the region).  If we delete the AUICGP instruction, then finding the relocation attached to it (unsurprisingly) fails.  This is subsequently fixed by adding a pass that rewrites all of the LO relocations that point to a HI relocation that points to a CGP-relative symbol to point directly to that symbol before doing any relaxations.

The new code also accepts CGP-relative LO relocations pointing directly to the correct symbol.  This works in all of the cases where it worked before (if the HI relocation is against an auicgp instruction and the target is CGP-relative), which should let us avoid a second flag day.