### PR TITLE
[Support] Add missing <cstdint> header to Signals.h

### DIFF
--- a/llvm/include/llvm/Support/Signals.h
+++ b/llvm/include/llvm/Support/Signals.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_SIGNALS_H
 #define LLVM_SUPPORT_SIGNALS_H
 
+#include <cstdint>
 #include <string>
 
 namespace llvm {


### PR DESCRIPTION
The build fails on my system without this change.

The same fix was pushed to the LLVM upstream a while ago: https://github.com/llvm/llvm-project/commit/ff1681ddb303223973653f7f5f3f3435b48a1983