### PR TITLE
[CHERIoT] Zero sret pointers before cross-compartment calls.

### DIFF
--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -508,6 +508,9 @@ namespace llvm {
   /// Create CHERI pass to bound alloca.s
   ModulePass *createCheriBoundAllocasPass();
 
+  /// Create CHERIoT pass to zero on-stack returns in cross-compartment calls.
+  FunctionPass *createCheriotZeroSRetPass();
+
   /// This pass inserts pseudo probe annotation for callsite profiling.
   FunctionPass *createPseudoProbeInserter();
 

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -114,6 +114,7 @@ void initializeCallSiteSplittingLegacyPassPass(PassRegistry&);
 void initializeCalledValuePropagationLegacyPassPass(PassRegistry &);
 void initializeCheckDebugMachineModulePass(PassRegistry &);
 void initializeCheriBoundAllocasPass(PassRegistry &);
+void initializeCheriotZeroSRetPass(PassRegistry &);
 void initializeCodeGenPreparePass(PassRegistry&);
 void initializeConstantHoistingLegacyPassPass(PassRegistry&);
 void initializeConstantMergeLegacyPassPass(PassRegistry&);

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_component_library(LLVMCodeGen
   CFGuardLongjmp.cpp
   CFIInstrInserter.cpp
   CheriBoundAllocas.cpp
+  CheriotZeroSRet.cpp
   CodeGen.cpp
   CodeGenPassBuilder.cpp
   CodeGenPrepare.cpp

--- a/llvm/lib/CodeGen/CheriotZeroSRet.cpp
+++ b/llvm/lib/CodeGen/CheriotZeroSRet.cpp
@@ -1,0 +1,100 @@
+//===- llvm/CodeGen/CherotZeroSRet.cpp - Zero sret pointers ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass that zeroes objects passed as sret pointers for
+// CHERIoT cross-compartment calls.  Normally, sret pointers point to memory
+// that is uninitialised.  It is the responsibility of the callee to initialise
+// them.  For cross-compartment calls, this can cause information leakage and
+// so we must zero them before the call.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Analysis/Utils/Local.h"
+#include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/CodeGen/TargetPassConfig.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Target/TargetMachine.h"
+
+#define DEBUG_TYPE "cheriot-zero-sret"
+using namespace llvm;
+
+namespace {
+
+class CheriotZeroSRet : public FunctionPass,
+                        public InstVisitor<CheriotZeroSRet> {
+  llvm::SmallVector<CallBase *, 16> Calls;
+
+public:
+  static char ID;
+  CheriotZeroSRet() : FunctionPass(ID) {
+    initializeCheriotZeroSRetPass(*PassRegistry::getPassRegistry());
+  }
+  StringRef getPassName() const override { return "CHERIoT zero sret "; }
+  void visitCallBase(CallBase &Call) {
+    auto *Type = Call.getFunctionType();
+    if (Type->getNumParams() == 0)
+      return;
+    if (Call.getCallingConv() != CallingConv::CHERI_CCall)
+      return;
+    if (Call.paramHasAttr(0, Attribute::StructRet)) {
+      Calls.push_back(&Call);
+    }
+  }
+  bool runOnFunction(Function &Fn) override {
+    if (auto *ABIStr = dyn_cast_or_null<MDString>(
+            Fn.getParent()->getModuleFlag("target-abi")))
+      if (ABIStr->getString() != "cheriot")
+        return false;
+    Calls.clear();
+    visit(Fn);
+    if (Calls.empty())
+      return false;
+    auto &DL = Fn.getParent()->getDataLayout();
+    Value *Zero = ConstantInt::get(Type::getInt8Ty(Fn.getContext()), 0);
+    for (auto *Call : Calls) {
+      IRBuilder<> Builder(Call);
+      unsigned Align = 0;
+      if (auto *Alloca = dyn_cast<AllocaInst>(
+              Call->getOperand(0)->stripPointerCastsAndAliases()))
+        Align = Alloca->getAlignment();
+      else if (auto *Arg = dyn_cast<Argument>(
+                   Call->getOperand(0)->stripPointerCastsAndAliases()))
+        Align = Arg->getParamAlignment();
+      Builder.CreateMemSet(
+          Call->getArgOperand(0), Zero,
+          DL.getTypeStoreSize(
+              Call->getParamAttr(0, Attribute::StructRet).getValueAsType()),
+          MaybeAlign(Align));
+    }
+    return true;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<TargetPassConfig>();
+    AU.setPreservesCFG();
+  }
+};
+
+} // anonymous namespace
+
+char CheriotZeroSRet::ID;
+INITIALIZE_PASS(CheriotZeroSRet, DEBUG_TYPE,
+                "CHERI add bounds to alloca instructions", false, false)
+
+FunctionPass *llvm::createCheriotZeroSRetPass(void) {
+  return new CheriotZeroSRet();
+}

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -186,6 +186,7 @@ TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
 
 void RISCVPassConfig::addIRPasses() {
   addPass(createAtomicExpandPass());
+  addPass(createCheriotZeroSRetPass());
   addPass(createCheriBoundAllocasPass());
   TargetPassConfig::addIRPasses();
 }

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-zero-sret.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-zero-sret.ll
@@ -1,0 +1,78 @@
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot  %s -mattr=+xcheri,+cap-mode -o - | FileCheck %s
+; ModuleID = 'sret.cc'
+source_filename = "sret.cc"
+target datalayout = "e-m:e-pf200:64:64:64:32-p:32:32-i64:64-n32-S128-A200-P200-G200"
+target triple = "riscv32-unknown-unknown"
+
+%struct.Smallish = type { i32, i32, i32 }
+%struct.Big = type { [128 x i8] }
+
+; Function Attrs: minsize mustprogress nounwind optsize
+define hidden i32 @_Z1hv() local_unnamed_addr addrspace(200) #0 {
+entry:
+  %ref.tmp = alloca %struct.Smallish, align 4, addrspace(200)
+  %0 = bitcast %struct.Smallish addrspace(200)* %ref.tmp to i8 addrspace(200)*
+  call void @llvm.lifetime.start.p200i8(i64 12, i8 addrspace(200)* nonnull %0) #3
+  ; CHECK-LABEL: _Z1hv:
+  ; Make sure that a 3-word struct is zeroed without a memset call.
+  ; CHECK: csw	zero, 8(ca0)
+  ; CHECK: csw	zero, 4(ca0)
+  ; CHECK: csw	zero, 0(ca0)
+  ; CHECK: auipcc	ct1, %cheriot_compartment_hi(__import_sret__Z1fv)
+  notail call chericcallcc void @_Z1fv(%struct.Smallish addrspace(200)* nonnull sret(%struct.Smallish) align 4 %ref.tmp) #4
+  %foo.sroa.0.0..sroa_idx = getelementptr inbounds %struct.Smallish, %struct.Smallish addrspace(200)* %ref.tmp, i32 0, i32 0
+  %foo.sroa.0.0.copyload = load i32, i32 addrspace(200)* %foo.sroa.0.0..sroa_idx, align 4, !tbaa.struct !4
+  call void @llvm.lifetime.end.p200i8(i64 12, i8 addrspace(200)* nonnull %0) #3
+  ret i32 %foo.sroa.0.0.copyload
+}
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p200i8(i64 immarg, i8 addrspace(200)* nocapture) addrspace(200) #1
+
+; Function Attrs: minsize optsize
+declare dso_local chericcallcc void @_Z1fv(%struct.Smallish addrspace(200)* sret(%struct.Smallish) align 4) local_unnamed_addr addrspace(200) #2
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p200i8(i64 immarg, i8 addrspace(200)* nocapture) addrspace(200) #1
+
+; Function Attrs: minsize mustprogress nounwind optsize
+define hidden i32 @_Z1iv() local_unnamed_addr addrspace(200) #0 {
+entry:
+  %ref.tmp = alloca %struct.Big, align 1, addrspace(200)
+  %0 = getelementptr inbounds %struct.Big, %struct.Big addrspace(200)* %ref.tmp, i32 0, i32 0, i32 0
+  call void @llvm.lifetime.start.p200i8(i64 128, i8 addrspace(200)* nonnull %0) #3
+  ; CHECK-LABEL: _Z1iv:
+  ; Check that we do a proper memset for a big struct.
+  ; CHECK: 	auipcc	ct2, %cheriot_compartment_hi(__library_import_libcalls__Z6memsetPvij)
+  notail call chericcallcc void @_Z1gv(%struct.Big addrspace(200)* nonnull sret(%struct.Big) align 1 %ref.tmp) #4
+  %foo.sroa.0.0.copyload = load i8, i8 addrspace(200)* %0, align 1, !tbaa.struct !9
+  call void @llvm.lifetime.end.p200i8(i64 128, i8 addrspace(200)* nonnull %0) #3
+  %conv = zext i8 %foo.sroa.0.0.copyload to i32
+  ret i32 %conv
+}
+
+; Function Attrs: minsize optsize
+declare dso_local chericcallcc void @_Z1gv(%struct.Big addrspace(200)* sret(%struct.Big) align 1) local_unnamed_addr addrspace(200) #2
+
+attributes #0 = { minsize mustprogress nounwind optsize "frame-pointer"="none" "min-legal-vector-width"="0" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+relax,+xcheri,+xcheri-rvc,-64bit,-save-restore" }
+attributes #1 = { argmemonly mustprogress nofree nosync nounwind willreturn }
+attributes #2 = { minsize optsize "cheri-compartment"="sret" "frame-pointer"="none" "interrupt-state"="enabled" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+relax,+xcheri,+xcheri-rvc,-64bit,-save-restore" }
+attributes #3 = { nounwind }
+attributes #4 = { minsize nobuiltin nounwind optsize "no-builtins" }
+
+!llvm.linker.options = !{}
+!llvm.module.flags = !{!0, !1, !2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 2}
+!1 = !{i32 1, !"target-abi", !"cheriot"}
+!2 = !{i32 1, !"SmallDataLimit", i32 8}
+!3 = !{!"clang version 13.0.0 (ssh://git@github.com/CHERIoT-Platform/llvm-project 42ccdb1bcc7eb0bf8cc8e493850359f828515495)"}
+!4 = !{i64 0, i64 4, !5, i64 4, i64 4, !5, i64 8, i64 4, !5}
+!5 = !{!6, !6, i64 0}
+!6 = !{!"int", !7, i64 0}
+!7 = !{!"omnipotent char", !8, i64 0}
+!8 = !{!"Simple C++ TBAA"}
+!9 = !{i64 0, i64 128, !10}
+!10 = !{!7, !7, i64 0}
+


### PR DESCRIPTION
Functions that use the sret variant of the calling convention pass a pointer to space for the callee to store their return values in.  When this is a cross-compartment call, we need to avoid information leakage.

It is generally better to pass an out parameter and pass a store-only pointer for this use, but we should still make this work correctly.