### PR TITLE
[cheriot] Treat empty parameter lists as void.

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -198,6 +198,9 @@ protected:
   bool VLASupported;
   bool NoAsmVariants;  // True if {|} are normal characters.
   bool CapabilityABI = false;
+  /// True if empty parameter lists should be treated as no-argument functions
+  /// in all language dialects (not just C++ and C23).
+  bool EmptyParameterListIsVoid = false;
   bool HasLegalHalfType; // True if the backend supports operations on the half
                          // LLVM IR type.
   bool HasFloat128;
@@ -1463,6 +1466,7 @@ public:
   bool isLittleEndian() const { return !BigEndian; }
 
   bool areAllPointersCapabilities() const { return CapabilityABI; }
+  bool areEmptyParameterListsVoid() const { return EmptyParameterListIsVoid; }
 
   /// Whether the option -fextend-arguments={32,64} is supported on the target.
   virtual bool supportsExtendIntArgs() const { return false; }

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -34,6 +34,8 @@ class RISCVTargetInfo : public TargetInfo {
         Layout = "e-m:e-pf200:64:64:64:32-p:32:32-i64:64-n32-S128";
       else
         Layout = "e-m:e-p:32:32-i64:64-n32-S128";
+      if (ABI == "cheriot")
+        EmptyParameterListIsVoid = true;
     } else if (ABI == "lp64" || ABI == "lp64f" || ABI == "lp64d" ||
                ABI == "l64pc128" || ABI == "l64pc128f" || ABI == "l64pc128d") {
       if (HasCheri)

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -5266,7 +5266,15 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
       FunctionType::ExtInfo EI(
           getCCForDeclaratorChunk(S, D, DeclType.getAttrs(), FTI, chunkIndex));
 
+      // In some ABIs (currently, just cheriot), treat functions with no
+      // parameters as void (as C23 and C++ do).
+      // FIXME: Clang 16 defaults to this behaviour, this special case can be
+      // removed on the next upstream merge.
+      bool TargetC23Prototypes =
+        S.getASTContext().getTargetInfo().areEmptyParameterListsVoid();
+
       if (!FTI.NumParams && !FTI.isVariadic && !LangOpts.CPlusPlus
+                                            && !TargetC23Prototypes
                                             && !LangOpts.OpenCL) {
         // Simple void foo(), where the incoming T is the result type.
         T = Context.getFunctionNoProtoType(T, EI);


### PR DESCRIPTION
C23 and C++ treat a function declaration that ends `()` as equivalent to `(void)`.  Earlier dialects of C treated this as a compatibility mode with K&R C and passed all parameters as variadic.

The latter model causes various problems for CHERIoT and it's almost always a bug.