### PR TITLE
[CHERIoT] Use the libcall calling convention for builtins.

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -2612,9 +2612,9 @@ public:
   getCanonicalNestedNameSpecifier(NestedNameSpecifier *NNS) const;
 
   /// Retrieves the default calling convention for the current target.
-  CallingConv getDefaultCallingConvention(bool IsVariadic,
-                                          bool IsCXXMethod,
-                                          bool IsBuiltin = false) const;
+  CallingConv getDefaultCallingConvention(bool IsVariadic, bool IsCXXMethod,
+                                          bool IsBuiltin = false,
+                                          bool IsLibCall = false) const;
 
   /// Retrieves the "canonical" template name that refers to a
   /// given template.

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1483,6 +1483,12 @@ public:
     return CC_C;
   }
 
+  /// Gets the default calling convention for the given target for library
+  /// calls.
+  virtual CallingConv getLibcallCallingConv() const {
+    return getDefaultCallingConv();
+  }
+
   enum CallingConvCheckResult {
     CCCR_OK,
     CCCR_Warning,

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10940,7 +10940,7 @@ QualType ASTContext::GetBuiltinType(unsigned Id,
   bool Variadic = (TypeStr[0] == '.');
 
   FunctionType::ExtInfo EI(getDefaultCallingConvention(
-      Variadic, /*IsCXXMethod=*/false, /*IsBuiltin=*/true));
+      Variadic, /*IsCXXMethod=*/false, /*IsBuiltin=*/true, /*IsLibcall*/ true));
   if (BuiltinInfo.isNoReturn(Id)) EI = EI.withNoReturn(true);
 
 
@@ -11300,7 +11300,8 @@ void ASTContext::forEachMultiversionedFunctionVersion(
 
 CallingConv ASTContext::getDefaultCallingConvention(bool IsVariadic,
                                                     bool IsCXXMethod,
-                                                    bool IsBuiltin) const {
+                                                    bool IsBuiltin,
+                                                    bool IsLibcall) const {
   // Pass through to the C++ ABI object
   if (IsCXXMethod)
     return ABI->getDefaultMethodCallConv(IsVariadic);
@@ -11333,6 +11334,8 @@ CallingConv ASTContext::getDefaultCallingConvention(bool IsVariadic,
       break;
     }
   }
+  if (IsLibcall)
+    return Target->getLibcallCallingConv();
   return Target->getDefaultCallingConv();
 }
 

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -25,6 +25,7 @@ namespace targets {
 class RISCVTargetInfo : public TargetInfo {
   void setDataLayout() {
     StringRef Layout;
+    IsABICHERIoT = false;
 
     if (ABI == "ilp32" || ABI == "ilp32f" || ABI == "ilp32d" ||
         ABI == "ilp32e" || ABI == "cheriot" ||
@@ -34,8 +35,10 @@ class RISCVTargetInfo : public TargetInfo {
         Layout = "e-m:e-pf200:64:64:64:32-p:32:32-i64:64-n32-S128";
       else
         Layout = "e-m:e-p:32:32-i64:64-n32-S128";
-      if (ABI == "cheriot")
+      if (ABI == "cheriot") {
+        IsABICHERIoT = true;
         EmptyParameterListIsVoid = true;
+      }
     } else if (ABI == "lp64" || ABI == "lp64f" || ABI == "lp64d" ||
                ABI == "l64pc128" || ABI == "l64pc128f" || ABI == "l64pc128d") {
       if (HasCheri)
@@ -83,6 +86,7 @@ protected:
   bool HasZfh = false;
   bool HasZvamo = false;
   bool HasZvlsseg = false;
+  bool IsABICHERIoT = false;
 
   static const Builtin::Info BuiltinInfo[];
 
@@ -153,6 +157,10 @@ public:
   uint64_t getCHERICapabilityWidth() const override { return CapSize; }
 
   uint64_t getCHERICapabilityAlign() const override { return CapSize; }
+
+  CallingConv getLibcallCallingConv() const override {
+    return IsABICHERIoT ? CallingConv::CC_CHERILibCall : CallingConv::CC_C;
+  }
 
   uint64_t getPointerWidthV(unsigned AddrSpace) const override {
     return (AddrSpace == 200) ? CapSize : PointerWidth;

--- a/clang/test/CodeGen/cheri/cheriot-strlen-builtin.c
+++ b/clang/test/CodeGen/cheri/cheriot-strlen-builtin.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" -std=c2x | FileCheck %s
+unsigned __builtin_strlen(const char *str) __asm__("_Z6strlenPKc");
+
+long dynamic(const char *str) {
+  // CHECK: @dynamic
+  // CHECK: call cherilibcallcc i32 @_Z6strlenPKc
+  return __builtin_strlen(str);
+}
+
+long five(const char *str) {
+  // CHECK: @five
+  // CHECK: ret i32 5
+  return __builtin_strlen("hello");
+}


### PR DESCRIPTION
Libc++ uses `__builtin_strlen` to avoid including `string.h`.  This is expanded to a call to `strlen` in clang, but with the wrong calling convention.

Fixes #29