### PR TITLE
Add missing InputSectionBase::relaxAux initialization.

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -73,6 +73,7 @@ InputSectionBase::InputSectionBase(InputFile *file, uint64_t flags,
 
   numRelocations = 0;
   areRelocsRela = false;
+  relaxAux = nullptr;
 
   // The ELF spec states that a value of 0 means the section has
   // no alignment constraints.


### PR DESCRIPTION
Under complicated conditions Arch/RISCV.cpp:initSymbolAnchors() can encounter an InputSection with an uninitialized relaxAux pointer. Safeguard against this by always initializing relaxAux.