### PR TITLE
[CHERI] Fix indirect varargs.

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -391,7 +391,8 @@ static Address emitVoidPtrVAArg(CodeGenFunction &CGF, Address VAListAddr,
   // Cast the address we've calculated to the right type.
   llvm::Type *DirectTy = CGF.ConvertTypeForMem(ValueTy);
   if (IsIndirect)
-    DirectTy = DirectTy->getPointerTo(0);
+    DirectTy =
+        DirectTy->getPointerTo(CGF.CGM.getDataLayout().getAllocaAddrSpace());
 
   Address Addr = emitVoidPtrDirectVAArg(CGF, VAListAddr, DirectTy,
                                         DirectSize, DirectAlign,

--- a/clang/test/CodeGen/cheri/cheriot-variadic.c
+++ b/clang/test/CodeGen/cheri/cheriot-variadic.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" -std=c2x | FileCheck %s
+
+typedef __builtin_va_list va_list;
+#define va_start(v, l) __builtin_va_start((v), l)
+#define va_end __builtin_va_end
+#define va_arg __builtin_va_arg
+#define va_copy __builtin_va_copy
+
+typedef struct {
+  void *a;
+  int b;
+  char c[4];
+} bar_t;
+
+extern int onward(void *, int, char *);
+
+int foo(va_list ap) {
+  // Make sure that we don't see a memcpy in address space zero!
+  // CHECK-NOT: p0i8
+  bar_t x = va_arg(ap, bar_t);
+  return onward(x.a, x.b, x.c);
+}


### PR DESCRIPTION
These were being lowered as a memcpy from address-space 0.  On CHERIoT, this causes a failure in the back end because we don't support AS0.  On other CHERI platforms that do, it will silently do the wrong thing (and possibly trap).

Fixes #36