### PR TITLE
[CHERIoT] Allow __cheri_libcall annotations on function pointers.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2482,7 +2482,7 @@ def CHERICompartmentName : DeclOrTypeAttr {
 def CHERILibCall : DeclOrTypeAttr {
   let Spellings = [GNU<"cheri_libcall">];
   let Documentation = [Undocumented];
-  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Subjects = SubjectList<[Function, FunctionPointer], ErrorDiag>;
 }
 
 

--- a/clang/test/CodeGen/cheri/cheri-mcu-call-libcall.c
+++ b/clang/test/CodeGen/cheri/cheri-mcu-call-libcall.c
@@ -7,7 +7,7 @@ int add(int a, int b);
 LIBCALL
 int foo(void);
 
-// CHECK: define dso_local i32 @callFromNotLibcall() local_unnamed_addr addrspace(200) #0 {
+// CHECK-LABEL: define dso_local i32 @callFromNotLibcall() local_unnamed_addr addrspace(200) #0 {
 int callFromNotLibcall(void) {
   // CHECK: call cherilibcallcc i32 @_Z3addii(i32 noundef 1, i32 noundef 2) #2
   // CHECK: call cherilibcallcc i32 @_Z3foov() #2
@@ -16,6 +16,12 @@ int callFromNotLibcall(void) {
 
 // CHECK: declare cherilibcallcc i32 @_Z3addii(i32 noundef, i32 noundef) local_unnamed_addr addrspace(200) #1
 // CHECK: declare cherilibcallcc i32 @_Z3foov() local_unnamed_addr addrspace(200) #1
+
+// CHECK-LABEL: define dso_local i32 @callThroughFunctionPointer(ptr addrspace(200) nocapture noundef readonly %target) local_unnamed_addr addrspace(200) #0 {
+int callThroughFunctionPointer(LIBCALL int target(void)) {
+  // CHECK: call cherilibcallcc i32 %target()
+  return target();
+}
 
 // CHECK: attributes #0
 // CHECK-SAME: "cheri-compartment"="example"

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -32,7 +32,6 @@
 // CHECK-NEXT: CFUnknownTransfer (SubjectMatchRule_function)
 // CHECK-NEXT: CHERICCallee (SubjectMatchRule_function)
 // CHECK-NEXT: CHERICompartmentName (SubjectMatchRule_function)
-// CHECK-NEXT: CHERILibCall (SubjectMatchRule_function)
 // CHECK-NEXT: CHERISubobjectBoundsUseRemainingSize (SubjectMatchRule_field, SubjectMatchRule_record)
 // CHECK-NEXT: CPUDispatch (SubjectMatchRule_function)
 // CHECK-NEXT: CPUSpecific (SubjectMatchRule_function)


### PR DESCRIPTION
Fixes https://github.com/CHERIoT-Platform/llvm-project/issues/16
