### PR TITLE
Combined fixes for #55 and #56

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -721,12 +721,22 @@ bool ItaniumMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
     if (FD->hasAttr<CHERICompartmentNameAttr>() ||
         FD->hasAttr<CHERILibCallAttr>()) {
       assert(getASTContext().getTargetInfo().getTargetOpts().ABI != "cheriot-baremetal");
-      return true;
+      return llvm::StringSwitch<bool>(FD->getName())
+        .Case("memcpy", false)
+        .Case("memmove", false)
+        .Case("memset", false)
+        .Case("memcmp", false)
+        .Default(true);
     }
 
     if (FD->getType()->castAs<FunctionType>()->getCallConv() == CC_CHERILibCall) {
       assert(getASTContext().getTargetInfo().getTargetOpts().ABI != "cheriot-baremetal");
-      return true;
+      return llvm::StringSwitch<bool>(FD->getName())
+        .Case("memcpy", false)
+        .Case("memmove", false)
+        .Case("memset", false)
+        .Case("memcmp", false)
+        .Default(true);
     }
 
     // "main" is not mangled.

--- a/clang/lib/AST/Mangle.cpp
+++ b/clang/lib/AST/Mangle.cpp
@@ -125,7 +125,12 @@ bool MangleContext::shouldMangleDeclName(const NamedDecl *D) {
   if (auto *FD = dyn_cast<FunctionDecl>(D))
     if (FD->getType()->castAs<FunctionType>()->getCallConv() == CC_CHERILibCall) {
       assert(ASTContext.getTargetInfo().getTargetOpts().ABI != "cheriot-baremetal");
-      return true;
+      return llvm::StringSwitch<bool>(FD->getName())
+        .Case("memcpy", false)
+        .Case("memmove", false)
+        .Case("memset", false)
+        .Case("memcmp", false)
+        .Default(true);
     }
 
   // In C, functions with no attributes never need to be mangled. Fastpath them.

--- a/clang/test/CodeGen/cheri/riscv/cheriot-freestanding.c
+++ b/clang/test/CodeGen/cheri/riscv/cheriot-freestanding.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 %s -o - "-triple" "riscv32cheriot-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" -std=c2x | FileCheck %s
+
+
+// CHECK: @memcpy
+void* __attribute__((cheri_libcall)) memcpy(void*, const void*, unsigned int) {
+    return 0;
+}
+
+// CHECK: @memmove
+void* __attribute__((cheri_libcall)) memmove(void*, const void*, unsigned int) {
+    return 0;
+}
+
+// CHECK: @memset
+void* __attribute__((cheri_libcall)) memset(void*, int, unsigned int) {
+    return 0;
+}
+
+// CHECK: @memcmp
+int __attribute__((cheri_libcall)) memcmp(const void*, const void*, unsigned int) {
+    return 0;
+}

--- a/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSelectionDAGInfo.cpp
@@ -81,8 +81,6 @@ SDValue EmitTargetCodeForMemOp(SelectionDAG &DAG, const SDLoc &dl,
   const char *memFnName = isMemCpy ?
     (RISCVABI::isCheriPureCapABI(STI.getTargetABI()) ?  "memcpy" : "memcpy_c") :
     (RISCVABI::isCheriPureCapABI(STI.getTargetABI()) ?  "memmove" : "memmove_c");
-  if (STI.getTargetABI() == RISCVABI::ABI_CHERIOT)
-	  memFnName = isMemCpy ? "_Z6memcpyPvPKvj" : "_Z7memmovePvPKvj";
   return callFunction(DAG, dl, Chain, memFnName, Dst, Src, Size);
 }
 }
@@ -212,7 +210,5 @@ SDValue RISCVSelectionDAGInfo::EmitTargetCodeForMemset(
 
   const char *memFnName =
       RISCVABI::isCheriPureCapABI(STI.getTargetABI()) ? "memset" : "memset_c";
-  if (STI.getTargetABI() == RISCVABI::ABI_CHERIOT)
-	  memFnName = "_Z6memsetPvij";
   return callFunction(DAG, dl, Chain, memFnName, Dst, Src, Size);
 }

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-zero-sret.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-zero-sret.ll
@@ -43,7 +43,7 @@ entry:
   call void @llvm.lifetime.start.p200i8(i64 128, i8 addrspace(200)* nonnull %0) #3
   ; CHECK-LABEL: _Z1iv:
   ; Check that we do a proper memset for a big struct.
-  ; CHECK: 	auipcc	ct2, %cheriot_compartment_hi(__library_import_libcalls__Z6memsetPvij)
+  ; CHECK: 	auipcc	ct2, %cheriot_compartment_hi(__library_import_libcalls_memset)
   notail call chericcallcc void @_Z1gv(%struct.Big addrspace(200)* nonnull sret(%struct.Big) align 1 %ref.tmp) #4
   %foo.sroa.0.0.copyload = load i8, i8 addrspace(200)* %0, align 1, !tbaa.struct !9
   call void @llvm.lifetime.end.p200i8(i64 128, i8 addrspace(200)* nonnull %0) #3


### PR DESCRIPTION
- **[CHERIoT] Don't mangle memcpy/memmove/memset/memcmp**
- **[CHERIoT][LLD] Provide a better error message when a compartment export annotation is omitted.**
