### PR TITLE
cheri_compartment: Warn if return type is void or return value is unused

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -883,6 +883,10 @@ public:
     return getInnerTypeLoc();
   }
 
+  TypeLoc getEquivalentTypeLoc() const {
+    return TypeLoc(getTypePtr()->getEquivalentType(), getNonLocalData());
+  }
+
   /// The type attribute.
   const Attr *getAttr() const {
     return getLocalData()->TypeAttr;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -158,10 +158,11 @@ def CHERIPrototypesStrict: DiagGroup<"cheri-prototypes-strict">;
 // Remarks about setting/not setting subobject bounds
 def CheriSubobjectBoundsSuspicous : DiagGroup<"cheri-subobject-bounds-suspicious">;
 def CheriSubobjectBoundsRemarks : DiagGroup<"cheri-subobject-bounds">;
+def CHERICompartmentReturnVoid : DiagGroup<"cheri-compartment-return-void">;
 
 def CheriAll : DiagGroup<"cheri",
      [CHERICaps, CHERIBitwiseOps, CHERIMisaligned, CHERIImplicitConversion, CheriSubobjectBoundsSuspicous,
-      CHERIProvenance, CHERIImplicitConversionSign, CHERIPrototypes]>;
+      CHERIProvenance, CHERIImplicitConversionSign, CHERIPrototypes, CHERICompartmentReturnVoid]>;
 // CHERI warnings that are too noisy to turn on by default
 def CHERICapabilityToIntegerCast : DiagGroup<"capability-to-integer-cast">;
 def CheriPedantic : DiagGroup<"cheri-pedantic", [CHERICapabilityToIntegerCast, CHERIPrototypesStrict, CHERIProvenancePedantic]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2338,11 +2338,13 @@ def note_var_fixit_add_initialization : Note<
   "initialize the variable %0 to silence this warning">;
 def warn_cheri_compartment_void_return_type : Warning <
   "void return on a cross-compartment call makes it impossible for callers to detect failure">,
-  InGroup<CHERICompartmentReturnVoid>;
+  InGroup<CHERICompartmentReturnVoid>,
+  DefaultIgnore;
 def note_cheri_compartment_void_return_type : Note<"replace void return type with int">;
 def warn_cheri_compartment_return_void_or_falloff : Warning <
   "cross-compartement calls that always succeed should return 0 instead">,
-  InGroup<CHERICompartmentReturnVoid>;
+  InGroup<CHERICompartmentReturnVoid>,
+  DefaultIgnore;
 def note_uninit_fixit_remove_cond : Note<
   "remove the %select{'%1' if its condition|condition if it}0 "
   "is always %select{false|true}2">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2336,6 +2336,13 @@ def note_in_reference_temporary_list_initializer : Note<
   "list-initialize this reference">;
 def note_var_fixit_add_initialization : Note<
   "initialize the variable %0 to silence this warning">;
+def warn_cheri_compartment_void_return_type : Warning <
+  "void return on a cross-compartment call makes it impossible for callers to detect failure">,
+  InGroup<CHERICompartmentReturnVoid>;
+def note_cheri_compartment_void_return_type : Note<"replace void return type with int">;
+def warn_cheri_compartment_return_void_or_falloff : Warning <
+  "cross-compartement calls that always succeed should return 0 instead">,
+  InGroup<CHERICompartmentReturnVoid>;
 def note_uninit_fixit_remove_cond : Note<
   "remove the %select{'%1' if its condition|condition if it}0 "
   "is always %select{false|true}2">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4717,8 +4717,16 @@ public:
     bool IgnoreTypeAttributes;
   };
 
+  enum DeclAttributeLocation {
+    DAL_Unspecified,
+    DAL_DeclSpec,
+    DAL_DeclChunk,
+    DAL_Decl,
+  };
+
   void ProcessDeclAttributeList(Scope *S, Decl *D,
                                 const ParsedAttributesView &AttrList,
+                                DeclAttributeLocation DAL = DAL_Unspecified,
                                 const ProcessDeclAttributeOptions &Options =
                                     ProcessDeclAttributeOptions());
   bool ProcessAccessDeclAttributeList(AccessSpecDecl *ASDecl,

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -713,12 +713,13 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
       else if (!ReturnsVoid)
         EmitDiag(RBrace, CD.diag_MaybeFallThrough_ReturnsNonVoid);
 
-      if (HasCHERICompartmentName)
+      if (HasCHERICompartmentName) {
         if (!ReturnsVoid)
           S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff);
         else
           S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff)
               << FixItHint::CreateInsertion(RBrace, "return 0;");
+      }
       break;
     case AlwaysFallThrough:
       if (HasNoReturn)
@@ -726,12 +727,13 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
       else if (!ReturnsVoid)
         EmitDiag(RBrace, CD.diag_AlwaysFallThrough_ReturnsNonVoid);
 
-      if (HasCHERICompartmentName)
+      if (HasCHERICompartmentName) {
         if (!ReturnsVoid)
           S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff);
         else
           S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff)
               << FixItHint::CreateInsertion(RBrace, "return 0;");
+      }
       break;
     case NeverFallThroughOrReturn:
       if (ReturnsVoid && !HasNoReturn && CD.diag_NeverFallThroughOrReturn) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2390,9 +2390,6 @@ static void handleCHERIMethodSuffix(Sema &S, Decl *D, const ParsedAttr &Attr) {
 
 static void handleCHERICompartmentName(Sema &S, Decl *D, const ParsedAttr &Attr,
                                        Sema::DeclAttributeLocation DAL) {
-  if (DAL != Sema::DAL_DeclSpec && DAL != Sema::DAL_Unspecified)
-    return;
-
   // cheri_compartment is both:
   //
   // * a Declaration attribute: marks the function as a compartment entry point

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2388,11 +2388,39 @@ static void handleCHERIMethodSuffix(Sema &S, Decl *D, const ParsedAttr &Attr) {
   D->addAttr(::new (S.Context) CHERIMethodSuffixAttr(S.Context, Attr, Str));
 }
 
-static void handleCHERICompartmentName(Sema &S, Decl *D, const ParsedAttr &Attr) {
+static void handleCHERICompartmentName(Sema &S, Decl *D, const ParsedAttr &Attr,
+                                       Sema::DeclAttributeLocation DAL) {
+  if (DAL != Sema::DAL_DeclSpec && DAL != Sema::DAL_Unspecified)
+    return;
+
+  // cheri_compartment is both:
+  //
+  // * a Declaration attribute: marks the function as a compartment entry point
+  // * a Function Type attribute: affects the calling convention
+  //
+  // That's the reason why we don't short-circuit with hasDeclarator
+  // (as other handlers do).
+
   StringRef Str;
   SourceLocation LiteralLoc;
   if (!S.checkStringLiteralArgumentAttr(Attr, 0, Str, &LiteralLoc))
     return;
+
+  // cheri_compartment is considered as function type attribute
+
+  const auto *FD = dyn_cast<FunctionDecl>(D);
+
+  if (FD && FD->getReturnType()->isVoidType()) {
+    S.Diag(Attr.getLoc(), diag::warn_cheri_compartment_void_return_type);
+
+    if (SourceRange SR = FD->getReturnTypeSourceRange(); SR.isValid()) {
+      S.Diag(SR.getBegin(), diag::note_cheri_compartment_void_return_type)
+          << FixItHint::CreateReplacement(SR, "int");
+    }
+  } else
+    D->addAttr(::new (S.Context) WarnUnusedResultAttr(
+        S.Context, Attr, "CHERI compartment call"));
+
   D->addAttr(::new (S.Context) CHERICompartmentNameAttr(S.Context, Attr, Str));
 }
 
@@ -8932,7 +8960,8 @@ static bool MustDelayAttributeArguments(const ParsedAttr &AL) {
 /// silently ignore it if a GNU attribute.
 static void
 ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
-                     const Sema::ProcessDeclAttributeOptions &Options) {
+                     const Sema::ProcessDeclAttributeOptions &Options,
+                     Sema::DeclAttributeLocation DAL = Sema::DAL_Unspecified) {
   if (AL.isInvalid() || AL.getKind() == ParsedAttr::IgnoredAttribute)
     return;
 
@@ -9441,7 +9470,7 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     handleCHERIMethodSuffix(S, D, AL);
     break;
   case ParsedAttr::AT_CHERICompartmentName:
-    handleCHERICompartmentName(S, D, AL);
+    handleCHERICompartmentName(S, D, AL, DAL);
     break;
   case ParsedAttr::AT_InterruptState:
     handleInterruptState(S, D, AL);
@@ -9755,12 +9784,13 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
 /// attribute list to the specified decl, ignoring any type attributes.
 void Sema::ProcessDeclAttributeList(
     Scope *S, Decl *D, const ParsedAttributesView &AttrList,
+    Sema::DeclAttributeLocation DAL,
     const ProcessDeclAttributeOptions &Options) {
   if (AttrList.empty())
     return;
 
   for (const ParsedAttr &AL : AttrList)
-    ProcessDeclAttribute(*this, S, D, AL, Options);
+    ProcessDeclAttribute(*this, S, D, AL, Options, DAL);
 
   // FIXME: We should be able to handle these cases in TableGen.
   // GCC accepts
@@ -10011,6 +10041,7 @@ void Sema::ProcessDeclAttributes(Scope *S, Decl *D, const Declarator &PD) {
   // Apply decl attributes from the DeclSpec if present.
   if (!PD.getDeclSpec().getAttributes().empty()) {
     ProcessDeclAttributeList(S, D, PD.getDeclSpec().getAttributes(),
+                             DAL_DeclSpec,
                              ProcessDeclAttributeOptions()
                                  .WithIncludeCXX11Attributes(false)
                                  .WithIgnoreTypeAttributes(true));
@@ -10022,13 +10053,14 @@ void Sema::ProcessDeclAttributes(Scope *S, Decl *D, const Declarator &PD) {
   // when X is a decl attribute.
   for (unsigned i = 0, e = PD.getNumTypeObjects(); i != e; ++i) {
     ProcessDeclAttributeList(S, D, PD.getTypeObject(i).getAttrs(),
+                             DAL_DeclChunk,
                              ProcessDeclAttributeOptions()
                                  .WithIncludeCXX11Attributes(false)
                                  .WithIgnoreTypeAttributes(true));
   }
 
   // Finally, apply any attributes on the decl itself.
-  ProcessDeclAttributeList(S, D, PD.getAttributes());
+  ProcessDeclAttributeList(S, D, PD.getAttributes(), DAL_Decl);
 
   // Apply additional attributes specified by '#pragma clang attribute'.
   AddPragmaAttributes(S, D);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2414,9 +2414,13 @@ static void handleCHERICompartmentName(Sema &S, Decl *D, const ParsedAttr &Attr,
       S.Diag(SR.getBegin(), diag::note_cheri_compartment_void_return_type)
           << FixItHint::CreateReplacement(SR, "int");
     }
-  } else
-    D->addAttr(::new (S.Context) WarnUnusedResultAttr(
-        S.Context, Attr, "CHERI compartment call"));
+  } else {
+    if (!S.Diags.isIgnored(diag::warn_cheri_compartment_void_return_type,
+                           LiteralLoc)) {
+      D->addAttr(::new (S.Context) WarnUnusedResultAttr(
+          S.Context, Attr, "CHERI compartment call"));
+    }
+  }
 
   D->addAttr(::new (S.Context) CHERICompartmentNameAttr(S.Context, Attr, Str));
 }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -4120,6 +4120,12 @@ StmtResult Sema::BuildReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
           return StmtError();
         RetValExp = ER.get();
       }
+    } else if (getCurFunctionOrMethodDecl()
+                   ->hasAttr<CHERICompartmentNameAttr>()) {
+      SourceLocation AfterReturnLoc = getLocForEndOfToken(ReturnLoc);
+      /* Compartment call */
+      Diag(ReturnLoc, diag::warn_cheri_compartment_return_void_or_falloff)
+          << FixItHint::CreateInsertion(AfterReturnLoc, " 0");
     }
 
     Result = ReturnStmt::Create(Context, ReturnLoc, RetValExp,

--- a/clang/test/CodeGen/cheri/cheri-mcu-interrupts.c
+++ b/clang/test/CodeGen/cheri/cheri-mcu-interrupts.c
@@ -23,10 +23,11 @@ int inherit(void)
 
 // The default for exported functions should be interrupts enabled
 //
-// CHECK: define dso_local chericcallcce void @_Z21default_enable_calleev() local_unnamed_addr addrspace(200) #[[DEFEN:[0-9]]]
+// CHECK: define dso_local chericcallcce i32 @_Z21default_enable_calleev() local_unnamed_addr addrspace(200) #[[DEFEN:[0-9]]]
 __attribute__((cheri_compartment("example")))
-void default_enable_callee(void)
+int default_enable_callee(void)
 {
+  return 0;
 }
 
 // CHECK: define dso_local chericcallcc void @default_enable_callback() local_unnamed_addr addrspace(200) #[[DEFEN]]
@@ -37,11 +38,12 @@ void default_enable_callback(void)
 
 // Explicitly setting interrupt status should override the default
 
-// CHECK: define dso_local chericcallcce void @_Z23explicit_disable_calleev() local_unnamed_addr addrspace(200) #[[EXPDIS:[0-9]]]
+// CHECK: define dso_local chericcallcce i32 @_Z23explicit_disable_calleev() local_unnamed_addr addrspace(200) #[[EXPDIS:[0-9]]]
 __attribute__((cheri_interrupt_state(disabled)))
 __attribute__((cheri_compartment("example")))
-void explicit_disable_callee(void)
+int explicit_disable_callee(void)
 {
+  return 0;
 }
 
 // CHECK: define dso_local chericcallcc void @explicit_disable_callback() local_unnamed_addr addrspace(200) #[[EXPDIS]]

--- a/clang/test/Sema/cheri/cheri-compartment-warn-if-return-void-or-unused.c
+++ b/clang/test/Sema/cheri/cheri-compartment-warn-if-return-void-or-unused.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 %s -o - -triple riscv32-unknown-unknown -emit-llvm -mframe-pointer=none -mcmodel=small -target-cpu cheriot -target-feature +xcheri -target-feature -64bit -target-feature -relax -target-feature -xcheri-rvc -target-feature -save-restore -target-abi cheriot -Oz -cheri-compartment=example -verify -fsyntax-only
+// RUN: %clang_cc1 %s -o - -triple riscv32-unknown-unknown -emit-llvm -mframe-pointer=none -mcmodel=small -target-cpu cheriot -target-feature +xcheri -target-feature -64bit -target-feature -relax -target-feature -xcheri-rvc -target-feature -save-restore -target-abi cheriot -Oz -cheri-compartment=example -fdiagnostics-parseable-fixits -fsyntax-only 2>&1 | FileCheck %s
+
+__attribute__((cheri_compartment("example"))) void void_return_type_f(int a) // expected-warning{{void return on a cross-compartment call makes it impossible for callers to detect failure}} expected-note{{replace void return type with int}}
+{
+  if (a) {
+    /// CHECK: fix-it:"{{.*}}":{[[@LINE+1]]:[[COL:[0-9]+]]-[[@LINE+1]]:[[COL]]}:" 0"
+    return; // expected-warning{{cross-compartement calls that always succeed should return 0 instead}}
+  }
+} // expected-warning{{cross-compartement calls that always succeed should return 0 instead}}
+
+__attribute__((cheri_compartment("example"))) int int_return_type_f() {
+  return 0;
+}
+
+void unused_int_return_type_f() {
+  int_return_type_f(); // expected-warning{{ignoring return value of function declared with 'nodiscard' attribute: CHERI compartment call}}
+}


### PR DESCRIPTION
Reapply https://github.com/CHERIoT-Platform/llvm-project/pull/47

Changes since that version:
- **Squashed history.
- **Removed early return that caused link errors.
- **Disable. warning by default while CheriotRTOS transitions.
