### PR TITLE
cheri_compartment: Warn if return type is void or return value is unused

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -883,6 +883,10 @@ public:
     return getInnerTypeLoc();
   }
 
+  TypeLoc getEquivalentTypeLoc() const {
+    return TypeLoc(getTypePtr()->getEquivalentType(), getNonLocalData());
+  }
+
   /// The type attribute.
   const Attr *getAttr() const {
     return getLocalData()->TypeAttr;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -158,10 +158,11 @@ def CHERIPrototypesStrict: DiagGroup<"cheri-prototypes-strict">;
 // Remarks about setting/not setting subobject bounds
 def CheriSubobjectBoundsSuspicous : DiagGroup<"cheri-subobject-bounds-suspicious">;
 def CheriSubobjectBoundsRemarks : DiagGroup<"cheri-subobject-bounds">;
+def CHERICompartmentReturnVoid : DiagGroup<"cheri-compartment-return-void">;
 
 def CheriAll : DiagGroup<"cheri",
      [CHERICaps, CHERIBitwiseOps, CHERIMisaligned, CHERIImplicitConversion, CheriSubobjectBoundsSuspicous,
-      CHERIProvenance, CHERIImplicitConversionSign, CHERIPrototypes]>;
+      CHERIProvenance, CHERIImplicitConversionSign, CHERIPrototypes, CHERICompartmentReturnVoid]>;
 // CHERI warnings that are too noisy to turn on by default
 def CHERICapabilityToIntegerCast : DiagGroup<"capability-to-integer-cast">;
 def CheriPedantic : DiagGroup<"cheri-pedantic", [CHERICapabilityToIntegerCast, CHERIPrototypesStrict, CHERIProvenancePedantic]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2336,6 +2336,15 @@ def note_in_reference_temporary_list_initializer : Note<
   "list-initialize this reference">;
 def note_var_fixit_add_initialization : Note<
   "initialize the variable %0 to silence this warning">;
+def warn_cheri_compartment_void_return_type : Warning <
+  "void return on a cross-compartment call makes it impossible for callers to detect failure">,
+  InGroup<CHERICompartmentReturnVoid>,
+  DefaultIgnore;
+def note_cheri_compartment_void_return_type : Note<"replace void return type with int">;
+def warn_cheri_compartment_return_void_or_falloff : Warning <
+  "cross-compartement calls that always succeed should return 0 instead">,
+  InGroup<CHERICompartmentReturnVoid>,
+  DefaultIgnore;
 def note_uninit_fixit_remove_cond : Note<
   "remove the %select{'%1' if its condition|condition if it}0 "
   "is always %select{false|true}2">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4717,8 +4717,16 @@ public:
     bool IgnoreTypeAttributes;
   };
 
+  enum DeclAttributeLocation {
+    DAL_Unspecified,
+    DAL_DeclSpec,
+    DAL_DeclChunk,
+    DAL_Decl,
+  };
+
   void ProcessDeclAttributeList(Scope *S, Decl *D,
                                 const ParsedAttributesView &AttrList,
+                                DeclAttributeLocation DAL = DAL_Unspecified,
                                 const ProcessDeclAttributeOptions &Options =
                                     ProcessDeclAttributeOptions());
   bool ProcessAccessDeclAttributeList(AccessSpecDecl *ASDecl,

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -621,7 +621,7 @@ struct CheckFallThroughDiagnostics {
   }
 
   bool checkDiagnostics(DiagnosticsEngine &D, bool ReturnsVoid,
-                        bool HasNoReturn) const {
+                        bool HasNoReturn, bool HasCHERICompartmentName) const {
     if (funMode == Function) {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_maybe_falloff_nonvoid_function,
@@ -630,7 +630,8 @@ struct CheckFallThroughDiagnostics {
               D.isIgnored(diag::warn_noreturn_function_has_return_expr,
                           FuncLoc)) &&
              (!ReturnsVoid ||
-              D.isIgnored(diag::warn_suggest_noreturn_block, FuncLoc));
+              D.isIgnored(diag::warn_suggest_noreturn_block, FuncLoc)) &&
+             !HasCHERICompartmentName;
     }
     if (funMode == Coroutine) {
       return (ReturnsVoid ||
@@ -658,6 +659,7 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
 
   bool ReturnsVoid = false;
   bool HasNoReturn = false;
+  bool HasCHERICompartmentName = false;
   bool IsCoroutine = FSI->isCoroutine();
 
   if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
@@ -666,6 +668,7 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
     else
       ReturnsVoid = FD->getReturnType()->isVoidType();
     HasNoReturn = FD->isNoReturn();
+    HasCHERICompartmentName = FD->hasAttr<CHERICompartmentNameAttr>();
   }
   else if (const auto *MD = dyn_cast<ObjCMethodDecl>(D)) {
     ReturnsVoid = MD->getReturnType()->isVoidType();
@@ -684,8 +687,9 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
   DiagnosticsEngine &Diags = S.getDiagnostics();
 
   // Short circuit for compilation speed.
-  if (CD.checkDiagnostics(Diags, ReturnsVoid, HasNoReturn))
-      return;
+  if (CD.checkDiagnostics(Diags, ReturnsVoid, HasNoReturn,
+                          HasCHERICompartmentName))
+    return;
   SourceLocation LBrace = Body->getBeginLoc(), RBrace = Body->getEndLoc();
   auto EmitDiag = [&](SourceLocation Loc, unsigned DiagID) {
     if (IsCoroutine)
@@ -708,12 +712,28 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
         EmitDiag(RBrace, CD.diag_MaybeFallThrough_HasNoReturn);
       else if (!ReturnsVoid)
         EmitDiag(RBrace, CD.diag_MaybeFallThrough_ReturnsNonVoid);
+
+      if (HasCHERICompartmentName) {
+        if (!ReturnsVoid)
+          S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff);
+        else
+          S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff)
+              << FixItHint::CreateInsertion(RBrace, "return 0;");
+      }
       break;
     case AlwaysFallThrough:
       if (HasNoReturn)
         EmitDiag(RBrace, CD.diag_AlwaysFallThrough_HasNoReturn);
       else if (!ReturnsVoid)
         EmitDiag(RBrace, CD.diag_AlwaysFallThrough_ReturnsNonVoid);
+
+      if (HasCHERICompartmentName) {
+        if (!ReturnsVoid)
+          S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff);
+        else
+          S.Diag(RBrace, diag::warn_cheri_compartment_return_void_or_falloff)
+              << FixItHint::CreateInsertion(RBrace, "return 0;");
+      }
       break;
     case NeverFallThroughOrReturn:
       if (ReturnsVoid && !HasNoReturn && CD.diag_NeverFallThroughOrReturn) {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -4120,6 +4120,12 @@ StmtResult Sema::BuildReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
           return StmtError();
         RetValExp = ER.get();
       }
+    } else if (getCurFunctionOrMethodDecl()
+                   ->hasAttr<CHERICompartmentNameAttr>()) {
+      SourceLocation AfterReturnLoc = getLocForEndOfToken(ReturnLoc);
+      /* Compartment call */
+      Diag(ReturnLoc, diag::warn_cheri_compartment_return_void_or_falloff)
+          << FixItHint::CreateInsertion(AfterReturnLoc, " 0");
     }
 
     Result = ReturnStmt::Create(Context, ReturnLoc, RetValExp,

--- a/clang/test/CodeGen/cheri/cheri-mcu-interrupts.c
+++ b/clang/test/CodeGen/cheri/cheri-mcu-interrupts.c
@@ -23,10 +23,11 @@ int inherit(void)
 
 // The default for exported functions should be interrupts enabled
 //
-// CHECK: define dso_local chericcallcce void @_Z21default_enable_calleev() local_unnamed_addr addrspace(200) #[[DEFEN:[0-9]]]
+// CHECK: define dso_local chericcallcce i32 @_Z21default_enable_calleev() local_unnamed_addr addrspace(200) #[[DEFEN:[0-9]]]
 __attribute__((cheri_compartment("example")))
-void default_enable_callee(void)
+int default_enable_callee(void)
 {
+  return 0;
 }
 
 // CHECK: define dso_local chericcallcc void @default_enable_callback() local_unnamed_addr addrspace(200) #[[DEFEN]]
@@ -37,11 +38,12 @@ void default_enable_callback(void)
 
 // Explicitly setting interrupt status should override the default
 
-// CHECK: define dso_local chericcallcce void @_Z23explicit_disable_calleev() local_unnamed_addr addrspace(200) #[[EXPDIS:[0-9]]]
+// CHECK: define dso_local chericcallcce i32 @_Z23explicit_disable_calleev() local_unnamed_addr addrspace(200) #[[EXPDIS:[0-9]]]
 __attribute__((cheri_interrupt_state(disabled)))
 __attribute__((cheri_compartment("example")))
-void explicit_disable_callee(void)
+int explicit_disable_callee(void)
 {
+  return 0;
 }
 
 // CHECK: define dso_local chericcallcc void @explicit_disable_callback() local_unnamed_addr addrspace(200) #[[EXPDIS]]

--- a/clang/test/Sema/cheri/cheri-compartment-warn-if-return-void-or-unused.c
+++ b/clang/test/Sema/cheri/cheri-compartment-warn-if-return-void-or-unused.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 %s -o - -triple riscv32-unknown-unknown -emit-llvm -mframe-pointer=none -mcmodel=small -target-cpu cheriot -target-feature +xcheri -target-feature -64bit -target-feature -relax -target-feature -xcheri-rvc -target-feature -save-restore -target-abi cheriot -Oz -cheri-compartment=example -Wcheri-compartment-return-void -verify -fsyntax-only
+// RUN: %clang_cc1 %s -o - -triple riscv32-unknown-unknown -emit-llvm -mframe-pointer=none -mcmodel=small -target-cpu cheriot -target-feature +xcheri -target-feature -64bit -target-feature -relax -target-feature -xcheri-rvc -target-feature -save-restore -target-abi cheriot -Oz -cheri-compartment=example -Wcheri-compartment-return-void -fdiagnostics-parseable-fixits -fsyntax-only 2>&1 | FileCheck %s
+
+__attribute__((cheri_compartment("example"))) void void_return_type_f(int a) // expected-warning{{void return on a cross-compartment call makes it impossible for callers to detect failure}} expected-note{{replace void return type with int}}
+{
+  if (a) {
+    /// CHECK: fix-it:"{{.*}}":{[[@LINE+1]]:[[COL:[0-9]+]]-[[@LINE+1]]:[[COL]]}:" 0"
+    return; // expected-warning{{cross-compartement calls that always succeed should return 0 instead}}
+  }
+} // expected-warning{{cross-compartement calls that always succeed should return 0 instead}}
+
+__attribute__((cheri_compartment("example"))) int int_return_type_f() {
+  return 0;
+}
+
+void unused_int_return_type_f() {
+  int_return_type_f(); // expected-warning{{ignoring return value of function declared with 'nodiscard' attribute: CHERI compartment call}}
+}

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -36,6 +36,8 @@ add_clang_unittest(ASTTests
   TemplateNameTest.cpp
   TypePrinterTest.cpp
   UnresolvedSetTest.cpp
+
+  cheri/AttrTest.cpp
   )
 
 clang_target_link_libraries(ASTTests

--- a/clang/unittests/AST/cheri/AttrTest.cpp
+++ b/clang/unittests/AST/cheri/AttrTest.cpp
@@ -1,0 +1,77 @@
+//===- unittests/AST/cheri/AttrTests.cpp --- CHERI Attribute tests --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/Attr.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/AttrKinds.h"
+#include "clang/Tooling/Tooling.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+
+namespace {
+
+using clang::ast_matchers::constantExpr;
+using clang::ast_matchers::equals;
+using clang::ast_matchers::functionDecl;
+using clang::ast_matchers::has;
+using clang::ast_matchers::hasDescendant;
+using clang::ast_matchers::hasName;
+using clang::ast_matchers::integerLiteral;
+using clang::ast_matchers::match;
+using clang::ast_matchers::selectFirst;
+using clang::ast_matchers::stringLiteral;
+using clang::ast_matchers::varDecl;
+using clang::tooling::buildASTFromCode;
+using clang::tooling::buildASTFromCodeWithArgs;
+
+template <typename Attr>
+testing::AssertionResult HasAttribute(const FunctionDecl *FD,
+                                      const std::string attrName) {
+  if (FD->hasAttr<Attr>())
+    return testing::AssertionSuccess();
+
+  return testing::AssertionFailure()
+         << *FD << " doesn't have a " << attrName << " attribute";
+}
+
+TEST(Attr, CHERICompartmentName) {
+  // cheri_compartment name is a strange attribute which is both:
+  //
+  // * a function type attribute: affects the calling convention
+  // * a function declaration attribute: marks the function as an compartment
+  // entrypoint
+  //
+  // Thus this attribute is both handled by SemaType and SemaDeclAttr and in
+  // order to not output twice a diagnosis we have to handle it specially. The
+  // following test ensure we don't skip silently the attribute.
+
+  auto AST = buildASTFromCode(R"cpp(
+    #define cheri_compartment(name) __attribute__((cheri_compartment(name)))
+    #define default_compartment cheri_compartment("default_compartment")
+
+    void default_compartment      f_00();
+    default_compartment void      f_01();
+    default_compartment void     *f_03();
+    void default_compartment     *f_04();
+    void * default_compartment    f_05();
+ )cpp");
+
+  {
+    for (auto Node : match(functionDecl().bind("fn"), AST->getASTContext())) {
+      const FunctionDecl *FD = Node.getNodeAs<FunctionDecl>("fn");
+
+      EXPECT_TRUE(
+          HasAttribute<CHERICompartmentNameAttr>(FD, "cheri_compartment"));
+    };
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Reapply https://github.com/CHERIoT-Platform/llvm-project/pull/47

Changes since that version:

* Squashed history.
* ~Removed early return that caused link errors.~ (fix by early returning for Decl instead of DeclChunk)
* Disable. warning by default while CheriotRTOS transitions.

Superseed #79
