### PR TITLE
[CHERIoT] Enable FeatureUnalignedScalarMem for cheriot.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -210,4 +210,5 @@ def CHERIOT : RISCVProcessorModel<"cheriot",
                                     FeatureCheri,
                                     FeatureCapMode,
                                     FeatureStdExtC,
-                                    FeatureStdExtM]>;
+                                    FeatureStdExtM,
+                                    FeatureUnalignedScalarMem]>;


### PR DESCRIPTION
This is a performance heuristic that signals that scalar unaligned
memory accesses are fast, i.e. not emulated.
