### PR TITLE
[CHERIoT] Add a builtin to read back the specific minimum stack size.

### DIFF
--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -1728,6 +1728,7 @@ BUILTIN(__builtin_cheri_cap_build, "v*mvC*mvC*m", "nct")
 BUILTIN(__builtin_cheri_cap_type_copy, "v*mvC*mvC*m", "nct")
 BUILTIN(__builtin_cheri_conditional_seal, "v*mvC*mvC*m", "nct")
 
+BUILTIN(__builtin_cheriot_get_specified_minimum_stack, "z", "nc")
 
 // Safestack builtins
 BUILTIN(__builtin___get_unsafe_stack_start, "v*", "Fn")

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7304,6 +7304,10 @@ def err_typecheck_convert_ptr_to_cap_unrelated_type: Error<"cannot implicitly "
   "or explicitly convert non-capability%select{| reference to}2 type %0 to "
   "unrelated capability type %1">;
 
+def err_stack_minimum_no_attr: Error<"cannot evaluate "
+  "__builtin_get_specificed_minimum_stack in function without specified minimum "
+  "stack size">;
+
 def warn_uintcap_bitwise_and : Warning<
   "using bitwise and on a capability type may give surprising results; "
   "if this is an alignment check use __builtin_{is_aligned,align_up,align_down}(); "

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -241,9 +241,9 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
     // Macros for CHERIoT in the default and bare-metal ABIs.
     if (ABI == "cheriot" || ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT__", "20241214");
+      Builder.defineMacro("__CHERIOT__", "20250102");
     if (ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20241214");
+      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250102");
 
     Builder.defineMacro("__riscv_clen", Twine(getCHERICapabilityWidth()));
     // TODO: _MIPS_CAP_ALIGN_MASK equivalent?

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -2743,6 +2743,13 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
   switch (BuiltinIDIfNoAsmLabel) {
   default: break;
+  case Builtin::BI__builtin_cheriot_get_specified_minimum_stack: {
+    ConstantInt *Size = Builder.getSize(
+        CurFuncDecl->hasAttr<MinimumStackAttr>()
+            ? CurFuncDecl->getAttr<MinimumStackAttr>()->getSize()
+            : 0);
+    return RValue::get(Size);
+  }
   case Builtin::BI__builtin___CFStringMakeConstantString:
   case Builtin::BI__builtin___NSStringMakeConstantString:
     return RValue::get(ConstantEmitter(*this).emitAbstract(E, E->getType()));

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2148,6 +2148,15 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   }
 
   switch (BuiltinID) {
+  case Builtin::BI__builtin_cheriot_get_specified_minimum_stack: {
+    NamedDecl *currentDecl = getCurFunctionOrMethodDecl();
+    if (currentDecl && !currentDecl->hasAttr<MinimumStackAttr>()) {
+      Diag(TheCall->getBeginLoc(), diag::err_stack_minimum_no_attr)
+          << TheCall->getDirectCallee();
+      return ExprError();
+    }
+    break;
+  }
   case Builtin::BI__builtin___CFStringMakeConstantString:
     // CFStringMakeConstantString is currently not implemented for GOFF (i.e.,
     // on z/OS) and for XCOFF (i.e., on AIX). Emit unsupported

--- a/clang/test/CodeGen/cheri/cheriot-min-stack.c
+++ b/clang/test/CodeGen/cheri/cheriot-min-stack.c
@@ -2,7 +2,7 @@
 int foo(void);
 
 [[cheriot::minimum_stack(256)]]
-// CHECK: _Z8disabledv()
+// CHECK-LABEL: _Z8disabledv()
 // CHECK-SAME: #0
 __attribute__((cheri_compartment("example")))
 int disabled(void)
@@ -10,5 +10,14 @@ int disabled(void)
 	return foo();
 }
 
-// CHECK: attributes #0 =
+[[cheriot::minimum_stack(256)]]
+// CHECK-LABEL: @_Z9readback1v()
+// CHECK: ret i32 256
+__attribute__((cheri_compartment("example")))
+int readback1(void)
+{
+	return __builtin_cheriot_get_specified_minimum_stack();
+}
+
+// CHECK-LABEL: attributes #0 =
 // CHECK-SAME: "minimum-stack-size"="256"

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -320,8 +320,8 @@
 // Check for CHERIoT-specific defines
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" -E -dM < /dev/null | FileCheck -check-prefix CHERIOT %s
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot-baremetal" -E -dM < /dev/null | FileCheck -check-prefixes CHERIOT,CHERIOT-BAREMETAL %s
-// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20241214
-// CHERIOT: #define __CHERIOT__ 20241214
+// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250102
+// CHERIOT: #define __CHERIOT__ 20250102
 
 
 // RUN: %cheri128_cc1 -fgnuc-version=4.2.1 -E -dM -ffreestanding < /dev/null | FileCheck -check-prefixes CHERI-COMMON,CHERI-MIPS,CHERI128 %s

--- a/clang/test/Sema/cheri/cheriot-get-minimum-stack.c
+++ b/clang/test/Sema/cheri/cheriot-get-minimum-stack.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 "-triple" "riscv32cheriot-unknown-cheriotrtos" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" -std=c2x -o - %s -fsyntax-only -verify
+
+__attribute__((cheri_compartment("example")))
+int readback(void)
+{
+	return __builtin_cheriot_get_specified_minimum_stack(); // expected-error{{cannot evaluate __builtin_get_specificed_minimum_stack in function without specified minimum stack size}}
+}


### PR DESCRIPTION
Fixes https://github.com/CHERIoT-Platform/llvm-project/issues/58
