### PR TITLE
Add a __cheriot_minimum_stack__ predefined expr for reading back the value of minimum stack annotations.

### DIFF
--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -1729,7 +1729,6 @@ BUILTIN(__builtin_cheri_cap_build, "v*mvC*mvC*m", "nct")
 BUILTIN(__builtin_cheri_cap_type_copy, "v*mvC*mvC*m", "nct")
 BUILTIN(__builtin_cheri_conditional_seal, "v*mvC*mvC*m", "nct")
 
-BUILTIN(__builtin_cheriot_get_specified_minimum_stack, "z", "nc")
 
 // Safestack builtins
 BUILTIN(__builtin___get_unsafe_stack_start, "v*", "Fn")

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -135,6 +135,8 @@ def warn_double_const_requires_fp64 : Warning<
   "casting to single precision">;
 def err_half_const_requires_fp16 : Error<
   "half precision constant requires cl_khr_fp16">;
+def err_cheriot_minstack_without_annotation : Error<
+  "__cheriot_minimum_stack__ can only be used in a function with a minimum stack annotation">;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7304,10 +7304,6 @@ def err_typecheck_convert_ptr_to_cap_unrelated_type: Error<"cannot implicitly "
   "or explicitly convert non-capability%select{| reference to}2 type %0 to "
   "unrelated capability type %1">;
 
-def err_stack_minimum_no_attr: Error<"cannot evaluate "
-  "__builtin_get_specificed_minimum_stack in function without specified minimum "
-  "stack size">;
-
 def warn_uintcap_bitwise_and : Warning<
   "using bitwise and on a capability type may give surprising results; "
   "if this is an alignment check use __builtin_{is_aligned,align_up,align_down}(); "

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -338,6 +338,9 @@ KEYWORD(__capability                , KEYALL)
 KEYWORD(__cheri_output              , KEYALL)
 KEYWORD(__cheri_input               , KEYALL)
 
+// CHERIoT Predefine Expr
+KEYWORD(__cheriot_minimum_stack__   , KEYALL)
+
 // C++ 2.11p1: Keywords.
 KEYWORD(asm                         , KEYCXX|KEYGNU)
 KEYWORD(bool                        , BOOLSUPPORT|KEYC2X)

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -241,9 +241,9 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
     // Macros for CHERIoT in the default and bare-metal ABIs.
     if (ABI == "cheriot" || ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT__", "20241214");
+      Builder.defineMacro("__CHERIOT__", "20250108");
     if (ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20241214");
+      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250108");
 
     Builder.defineMacro("__riscv_clen", Twine(getCHERICapabilityWidth()));
     // TODO: _MIPS_CAP_ALIGN_MASK equivalent?

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -241,9 +241,9 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
     // Macros for CHERIoT in the default and bare-metal ABIs.
     if (ABI == "cheriot" || ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT__", "20250102");
+      Builder.defineMacro("__CHERIOT__", "20241214");
     if (ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250102");
+      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20241214");
 
     Builder.defineMacro("__riscv_clen", Twine(getCHERICapabilityWidth()));
     // TODO: _MIPS_CAP_ALIGN_MASK equivalent?

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -2743,13 +2743,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
   switch (BuiltinIDIfNoAsmLabel) {
   default: break;
-  case Builtin::BI__builtin_cheriot_get_specified_minimum_stack: {
-    ConstantInt *Size = Builder.getSize(
-        CurFuncDecl->hasAttr<MinimumStackAttr>()
-            ? CurFuncDecl->getAttr<MinimumStackAttr>()->getSize()
-            : 0);
-    return RValue::get(Size);
-  }
   case Builtin::BI__builtin___CFStringMakeConstantString:
   case Builtin::BI__builtin___NSStringMakeConstantString:
     return RValue::get(ConstantEmitter(*this).emitAbstract(E, E->getType()));

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1297,6 +1297,7 @@ ExprResult Parser::ParseCastExpression(CastParseKind ParseKind,
   case tok::kw_L__FUNCTION__:   // primary-expression: L__FUNCTION__ [MS]
   case tok::kw_L__FUNCSIG__:    // primary-expression: L__FUNCSIG__ [MS]
   case tok::kw___PRETTY_FUNCTION__:  // primary-expression: __P..Y_F..N__ [GNU]
+  case tok::kw___cheriot_minimum_stack__:
     Res = Actions.ActOnPredefinedExpr(Tok.getLocation(), SavedKind);
     ConsumeToken();
     break;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2148,15 +2148,6 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   }
 
   switch (BuiltinID) {
-  case Builtin::BI__builtin_cheriot_get_specified_minimum_stack: {
-    NamedDecl *currentDecl = getCurFunctionOrMethodDecl();
-    if (currentDecl && !currentDecl->hasAttr<MinimumStackAttr>()) {
-      Diag(TheCall->getBeginLoc(), diag::err_stack_minimum_no_attr)
-          << TheCall->getDirectCallee();
-      return ExprError();
-    }
-    break;
-  }
   case Builtin::BI__builtin___CFStringMakeConstantString:
     // CFStringMakeConstantString is currently not implemented for GOFF (i.e.,
     // on z/OS) and for XCOFF (i.e., on AIX). Emit unsupported

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -3765,6 +3765,19 @@ ExprResult Sema::ActOnPredefinedExpr(SourceLocation Loc, tok::TokenKind Kind) {
   case tok::kw_L__FUNCTION__: IK = PredefinedExpr::LFunction; break; // [MS]
   case tok::kw_L__FUNCSIG__: IK = PredefinedExpr::LFuncSig; break; // [MS]
   case tok::kw___PRETTY_FUNCTION__: IK = PredefinedExpr::PrettyFunction; break;
+  case tok::kw___cheriot_minimum_stack__: {
+    FunctionDecl *FD = getCurFunctionDecl();
+
+    if (!FD || !FD->hasAttr<MinimumStackAttr>()) {
+      return Diag(Loc, diag::err_cheriot_minstack_without_annotation);
+    }
+
+    uint64_t MinStack = FD->getAttr<MinimumStackAttr>()->getSize();
+    auto Ty = Context.getSizeType();
+    unsigned Width = Context.getTypeSize(Ty);
+    return IntegerLiteral::Create(Context, llvm::APInt(Width, MinStack), Ty,
+                                  Loc);
+  }
   }
 
   return BuildPredefinedExpr(Loc, IK);

--- a/clang/test/CodeGen/cheri/cheriot-min-stack.c
+++ b/clang/test/CodeGen/cheri/cheriot-min-stack.c
@@ -2,7 +2,7 @@
 int foo(void);
 
 [[cheriot::minimum_stack(256)]]
-// CHECK-LABEL: _Z8disabledv()
+// CHECK: _Z8disabledv()
 // CHECK-SAME: #0
 __attribute__((cheri_compartment("example")))
 int disabled(void)
@@ -10,14 +10,5 @@ int disabled(void)
 	return foo();
 }
 
-[[cheriot::minimum_stack(256)]]
-// CHECK-LABEL: @_Z9readback1v()
-// CHECK: ret i32 256
-__attribute__((cheri_compartment("example")))
-int readback1(void)
-{
-	return __builtin_cheriot_get_specified_minimum_stack();
-}
-
-// CHECK-LABEL: attributes #0 =
+// CHECK: attributes #0 =
 // CHECK-SAME: "minimum-stack-size"="256"

--- a/clang/test/CodeGen/cheri/cheriot-min-stack.c
+++ b/clang/test/CodeGen/cheri/cheriot-min-stack.c
@@ -10,5 +10,14 @@ int disabled(void)
 	return foo();
 }
 
-// CHECK: attributes #0 =
+[[cheriot::minimum_stack(256)]]
+// CHECK-LABEL: @_Z9readback1v()
+// CHECK: ret i32 256
+__attribute__((cheri_compartment("example")))
+int readback1(void)
+{
+	return __cheriot_minimum_stack__;
+}
+
+// CHECK-LABEL: attributes #0 =
 // CHECK-SAME: "minimum-stack-size"="256"

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -320,8 +320,8 @@
 // Check for CHERIoT-specific defines
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" -E -dM < /dev/null | FileCheck -check-prefix CHERIOT %s
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot-baremetal" -E -dM < /dev/null | FileCheck -check-prefixes CHERIOT,CHERIOT-BAREMETAL %s
-// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250102
-// CHERIOT: #define __CHERIOT__ 20250102
+// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20241214
+// CHERIOT: #define __CHERIOT__ 20241214
 
 
 // RUN: %cheri128_cc1 -fgnuc-version=4.2.1 -E -dM -ffreestanding < /dev/null | FileCheck -check-prefixes CHERI-COMMON,CHERI-MIPS,CHERI128 %s

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -320,8 +320,8 @@
 // Check for CHERIoT-specific defines
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" -E -dM < /dev/null | FileCheck -check-prefix CHERIOT %s
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot-baremetal" -E -dM < /dev/null | FileCheck -check-prefixes CHERIOT,CHERIOT-BAREMETAL %s
-// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20241214
-// CHERIOT: #define __CHERIOT__ 20241214
+// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250108
+// CHERIOT: #define __CHERIOT__ 20250108
 
 
 // RUN: %cheri128_cc1 -fgnuc-version=4.2.1 -E -dM -ffreestanding < /dev/null | FileCheck -check-prefixes CHERI-COMMON,CHERI-MIPS,CHERI128 %s

--- a/clang/test/Sema/cheri/cheriot-get-minimum-stack.c
+++ b/clang/test/Sema/cheri/cheriot-get-minimum-stack.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 "-triple" "riscv32cheriot-unknown-cheriotrtos" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" -std=c2x -o - %s -fsyntax-only -verify
+
+__attribute__((cheri_compartment("example")))
+int readback(void)
+{
+	return __cheriot_minimum_stack__; // expected-error{{__cheriot_minimum_stack__ can only be used in a function with a minimum stack annotation}}
+}

--- a/clang/test/Sema/cheri/cheriot-get-minimum-stack.c
+++ b/clang/test/Sema/cheri/cheriot-get-minimum-stack.c
@@ -1,7 +1,0 @@
-// RUN: %clang_cc1 "-triple" "riscv32cheriot-unknown-cheriotrtos" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" -std=c2x -o - %s -fsyntax-only -verify
-
-__attribute__((cheri_compartment("example")))
-int readback(void)
-{
-	return __builtin_cheriot_get_specified_minimum_stack(); // expected-error{{cannot evaluate __builtin_get_specificed_minimum_stack in function without specified minimum stack size}}
-}


### PR DESCRIPTION
- **Revert "[CHERIoT] Add a builtin to read back the specific minimum stack size."**
- **[CHERIoT] Add a __cheriot_minimum_stack__ predefined expr for reading back the value of minimum stack annotations.**
