### PR TITLE
[CHERIoT] Add a spelling for interrupt_state in the cheriot namespace.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -874,7 +874,10 @@ def MinimumStack : InheritableAttr, TargetSpecificAttr<TargetRISCV> {
 }
 
 def InterruptState : InheritableAttr, TargetSpecificAttr<TargetRISCV> {
-  let Spellings = [CXX11<"cheri", "interrupt_state">,
+  let Spellings = [CXX11<"cheriot", "interrupt_state">,
+                   C2x<"cheriot", "interrupt_state">,
+                   GNU<"cheriot_interrupt_state">,
+                   CXX11<"cheri", "interrupt_state">,
                    C2x<"cheri", "interrupt_state">,
                    GNU<"cheri_interrupt_state">];
   let Args = [EnumArgument<"State", "InterruptState",

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -241,9 +241,9 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
     // Macros for CHERIoT in the default and bare-metal ABIs.
     if (ABI == "cheriot" || ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT__", "20250108");
+      Builder.defineMacro("__CHERIOT__", "20250113");
     if (ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250108");
+      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250113");
 
     Builder.defineMacro("__riscv_clen", Twine(getCHERICapabilityWidth()));
     // TODO: _MIPS_CAP_ALIGN_MASK equivalent?

--- a/clang/test/CodeGen/cheri/cheri-mcu-interrupts.c
+++ b/clang/test/CodeGen/cheri/cheri-mcu-interrupts.c
@@ -1,21 +1,22 @@
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32cheriot-unknown-cheriotrtos" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" | FileCheck %s
 int foo(void);
+
 // CHECK: define dso_local i32 @disabled() local_unnamed_addr addrspace(200) #[[DIS:[0-9]]]
-__attribute__((cheri_interrupt_state(disabled)))
+__attribute__((cheriot_interrupt_state(disabled)))
 int disabled(void)
 {
 	return foo();
 }
 
 // CHECK: define dso_local i32 @enabled() local_unnamed_addr addrspace(200) #[[EN:[0-9]]]
-__attribute__((cheri_interrupt_state(enabled)))
+__attribute__((cheriot_interrupt_state(enabled)))
 int enabled(void)
 {
 	return foo();
 }
 
 // CHECK: define dso_local i32 @inherit() local_unnamed_addr addrspace(200) #[[INH:[0-9]]]
-__attribute__((cheri_interrupt_state(inherit)))
+__attribute__((cheriot_interrupt_state(inherit)))
 int inherit(void)
 {
 	return foo();
@@ -39,7 +40,7 @@ void default_enable_callback(void)
 // Explicitly setting interrupt status should override the default
 
 // CHECK: define dso_local chericcallcce i32 @_Z23explicit_disable_calleev() local_unnamed_addr addrspace(200) #[[EXPDIS:[0-9]]]
-__attribute__((cheri_interrupt_state(disabled)))
+__attribute__((cheriot_interrupt_state(disabled)))
 __attribute__((cheri_compartment("example")))
 int explicit_disable_callee(void)
 {
@@ -47,12 +48,49 @@ int explicit_disable_callee(void)
 }
 
 // CHECK: define dso_local chericcallcc void @explicit_disable_callback() local_unnamed_addr addrspace(200) #[[EXPDIS]]
-__attribute__((cheri_interrupt_state(disabled)))
+__attribute__((cheriot_interrupt_state(disabled)))
 __attribute__((cheri_ccallback))
 void explicit_disable_callback(void)
 {
 }
 
+// Check deprecated spellings
+
+// CHECK: define dso_local i32 @disabled1() local_unnamed_addr addrspace(200) #[[DIS]]
+__attribute__((cheri_interrupt_state(disabled)))
+int disabled1(void)
+{
+	return foo();
+}
+
+// CHECK: define dso_local i32 @enabled1() local_unnamed_addr addrspace(200) #[[EN]]
+__attribute__((cheri_interrupt_state(enabled)))
+int enabled1(void)
+{
+	return foo();
+}
+
+// CHECK: define dso_local i32 @inherit1() local_unnamed_addr addrspace(200) #[[INH]]
+__attribute__((cheri_interrupt_state(inherit)))
+int inherit1(void)
+{
+	return foo();
+}
+
+// CHECK: define dso_local chericcallcce i32 @_Z24explicit_disable_callee1v() local_unnamed_addr addrspace(200) #[[EXPDIS]]
+__attribute__((cheri_interrupt_state(disabled)))
+__attribute__((cheri_compartment("example")))
+int explicit_disable_callee1(void)
+{
+  return 0;
+}
+
+// CHECK: define dso_local chericcallcc void @explicit_disable_callback1() local_unnamed_addr addrspace(200) #[[EXPDIS]]
+__attribute__((cheri_interrupt_state(disabled)))
+__attribute__((cheri_ccallback))
+void explicit_disable_callback1(void)
+{
+}
 
 // CHECK: attributes #[[DIS]]
 // CHECK-SAME: "interrupt-state"="disabled"

--- a/clang/test/CodeGenCXX/cheri/cheri-mcu-interrupts.cpp
+++ b/clang/test/CodeGenCXX/cheri/cheri-mcu-interrupts.cpp
@@ -1,22 +1,44 @@
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32cheriot-unknown-cheriotrtos" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" "-cheri-compartment=example" | FileCheck %s
 int foo(void);
+
 // CHECK: define dso_local noundef i32 @_Z8disabledv() local_unnamed_addr addrspace(200) #[[DIS:[0-9]]]
-[[cheri::interrupt_state(disabled)]]
+[[cheriot::interrupt_state(disabled)]]
 int disabled(void)
 {
 	return foo();
 }
 
 // CHECK: define dso_local noundef i32 @_Z7enabledv() local_unnamed_addr addrspace(200) #[[EN:[0-9]]]
-[[cheri::interrupt_state(enabled)]]
+[[cheriot::interrupt_state(enabled)]]
 int enabled(void)
 {
 	return foo();
 }
 
 // CHECK: define dso_local noundef i32 @_Z7inheritv() local_unnamed_addr addrspace(200) #[[INH:[0-9]]]
-[[cheri::interrupt_state(inherit)]]
+[[cheriot::interrupt_state(inherit)]]
 int inherit(void)
+{
+	return foo();
+}
+
+// CHECK: define dso_local noundef i32 @_Z9disabled1v() local_unnamed_addr addrspace(200) #[[DIS]]
+[[cheri::interrupt_state(disabled)]]
+int disabled1(void)
+{
+	return foo();
+}
+
+// CHECK: define dso_local noundef i32 @_Z8enabled1v() local_unnamed_addr addrspace(200) #[[EN]]
+[[cheri::interrupt_state(enabled)]]
+int enabled1(void)
+{
+	return foo();
+}
+
+// CHECK: define dso_local noundef i32 @_Z8inherit1v() local_unnamed_addr addrspace(200) #[[INH]]
+[[cheri::interrupt_state(inherit)]]
+int inherit1(void)
 {
 	return foo();
 }

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -320,8 +320,8 @@
 // Check for CHERIoT-specific defines
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" -E -dM < /dev/null | FileCheck -check-prefix CHERIOT %s
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot-baremetal" -E -dM < /dev/null | FileCheck -check-prefixes CHERIOT,CHERIOT-BAREMETAL %s
-// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250108
-// CHERIOT: #define __CHERIOT__ 20250108
+// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250113
+// CHERIOT: #define __CHERIOT__ 20250113
 
 
 // RUN: %cheri128_cc1 -fgnuc-version=4.2.1 -E -dM -ffreestanding < /dev/null | FileCheck -check-prefixes CHERI-COMMON,CHERI-MIPS,CHERI128 %s


### PR DESCRIPTION
Part of https://github.com/CHERIoT-Platform/llvm-project/issues/101
