### PR TITLE
[cheriot] If a R_RISCV_CHERI_CCALL reloc survives relaxation, remap it to CHERIOT compartment relocs.

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -498,6 +498,21 @@ void RISCV::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     int64_t hi = SignExtend64(val + 0x800, bits) >> 12;
     checkInt(loc, hi, 20, rel);
     if (isInt<20>(hi)) {
+      // FIXME: Is there a better way to test for cheriot here?
+      if (rel.type == R_RISCV_CHERI_CCALL && config->isCheriAbi &&
+          config->emachine == EM_RISCV && config->capabilitySize == 8) {
+        // CHERIOT uses an 11-bit shift on AUIPCC, requiring special handling.
+        relocate(loc,
+                 Relocation{rel.expr, R_RISCV_CHERIOT_COMPARTMENT_HI,
+                            rel.offset, rel.addend, rel.sym},
+                 val);
+        relocate(loc + 4,
+                 Relocation{rel.expr, R_RISCV_CHERIOT_COMPARTMENT_LO_I,
+                            rel.offset, rel.addend, rel.sym},
+                 val);
+        return;
+      }
+
       relocateNoSym(loc, R_RISCV_PCREL_HI20, val);
       relocateNoSym(loc + 4, R_RISCV_PCREL_LO12_I, val);
     }


### PR DESCRIPTION
This is needed because Cheriot uses 11-bit shifts on AUIPCC (differing from normal RISC-V CHERI), and requires that the HI and LO relocs offset the target in the same direction. This is meant to be handled for all of Cheriot via R_RISCV_CHERIOT_COMPARTMENT_HI and R_RISCV_CHERIOT_COMPARTMENT_LO_I, but that is complicated by the simultaneous need to relax calls in (almost) all situations, which requires using R_RISCV_CHERI_CCALL.

The solution is to preserve R_RISCV_CHERI_CCALL through relaxation, but then to remap it onto R_RISCV_CHERIOT_COMPARTMENT_HI / R_RISCV_CHERIOT_COMPARTMENT_LO_I during relocation. This gets us relaxation in the common case, and correct offsetting in the scenario where relaxation fails.
