### PR TITLE
[CHERIoT] Support most operations on __sealed_capabilities in unevaluated contexts.

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5192,7 +5192,8 @@ ExprResult Sema::ActOnArraySubscriptExpr(Scope *S, Expr *base,
   }
 
   // No subscripting allowed on sealed pointers.
-  if (base->getType()->isCHERISealedCapabilityType(Context))
+  if (base->getType()->isCHERISealedCapabilityType(Context) &&
+      !isUnevaluatedContext())
     Diag(lbLoc, diag::err_sealed_bad_operator) << base->getType();
 
   // Handle any non-overload placeholder types in the base and index
@@ -7370,7 +7371,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
     Fn = result.get();
   }
 
-  if (Fn->getType()->isCHERISealedCapabilityType(Context))
+  if (Fn->getType()->isCHERISealedCapabilityType(Context) &&
+      !isUnevaluatedContext())
     return ExprError(Diag(Fn->getBeginLoc(), diag::err_sealed_func_pointer)
                      << Fn->getType());
 
@@ -12113,7 +12115,8 @@ QualType Sema::CheckAdditionOperands(ExprResult &LHS, ExprResult &RHS,
   Expr *PExp = LHS.get(), *IExp = RHS.get();
 
   // Addition is not allowed on sealed pointers.
-  if (PExp->getType()->isCHERISealedCapabilityType(Context))
+  if (PExp->getType()->isCHERISealedCapabilityType(Context) &&
+      !isUnevaluatedContext())
     return InvalidOperands(Loc, LHS, RHS);
 
   bool isObjCPointer;
@@ -12228,10 +12231,12 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
     QualType lpointee = LHS.get()->getType()->getPointeeType();
 
     // Subtraction is not allowed on sealed pointers.
-    if (LHS.get()->getType()->isCHERISealedCapabilityType(Context))
-      return InvalidOperands(Loc, LHS, RHS);
-    if (RHS.get()->getType()->isCHERISealedCapabilityType(Context))
-      return InvalidOperands(Loc, LHS, RHS);
+    if (!isUnevaluatedContext()) {
+      if (LHS.get()->getType()->isCHERISealedCapabilityType(Context))
+        return InvalidOperands(Loc, LHS, RHS);
+      if (RHS.get()->getType()->isCHERISealedCapabilityType(Context))
+        return InvalidOperands(Loc, LHS, RHS);
+    }
 
     // Diagnose bad cases where we step over interface counts.
     if (LHS.get()->getType()->isObjCObjectPointerType() &&
@@ -16608,7 +16613,8 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
   // The only unary operator that can apply to a sealed capability is AddrOf.
   auto *PtrInput = InputExpr->getType()->getAs<PointerType>();
   if (Opc != UO_AddrOf && PtrInput &&
-      InputExpr->getType()->isCHERISealedCapabilityType(Context))
+      InputExpr->getType()->isCHERISealedCapabilityType(Context) &&
+      !isUnevaluatedContext())
     Diag(OpLoc, diag::err_sealed_bad_operator) << InputExpr->getType();
 
   switch (Opc) {

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -792,7 +792,7 @@ Sema::BuildMemberReferenceExpr(Expr *Base, QualType BaseType,
   LookupResult R(*this, NameInfo, LookupMemberName);
 
   // Member accesses are not allowed on sealed capabilities.
-  if (BaseType->isCHERISealedCapabilityType(Context))
+  if (BaseType->isCHERISealedCapabilityType(Context) && !isUnevaluatedContext())
     return ExprError(Diag(OpLoc, diag::err_sealed_member_access) << BaseType);
 
   // Implicit member accesses.

--- a/clang/test/Sema/cheri/attr-cheriot-sealed.c
+++ b/clang/test/Sema/cheri/attr-cheriot-sealed.c
@@ -52,3 +52,6 @@ void test11(int * __sealed_capability x) {
 	opaque(x); // No error (cast to void permitted)
 }
 
+int test12(int * __sealed_capability a) {
+    return sizeof(*a);
+}

--- a/clang/test/SemaCXX/cheri/attr-cheriot-sealed.cpp
+++ b/clang/test/SemaCXX/cheri/attr-cheriot-sealed.cpp
@@ -39,3 +39,10 @@ int test6(int * __sealed_capability b) {
     test_struct3 c{b}; // expected-error{{converting sealed type 'int * __sealed_capability' to non-sealed type 'int *' without an explicit unsealing}}
     return *(c.a);
 }
+
+int test11(int * __sealed_capability a) {
+    int b = 42;
+    decltype(*a) c = b;
+    c = 43;
+    return b;
+}


### PR DESCRIPTION
This is needed in order to support things like sizeof and decltype.
Casts to an from sealed types are still disallowed.
