### PR TITLE
[CHERI] generate cap for SMUL overflow temporary

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -4822,7 +4822,9 @@ void DAGTypeLegalizer::ExpandIntRes_XMULO(SDNode *N,
 
   Type *RetTy = VT.getTypeForEVT(*DAG.getContext());
   EVT PtrRangeVT = TLI.getPointerRangeTy(DAG.getDataLayout());
-  Type *PtrTy = PtrRangeVT.getTypeForEVT(*DAG.getContext());
+  EVT PtrVT = TLI.getPointerTy(DAG.getDataLayout(),
+                               DAG.getDataLayout().getProgramAddressSpace());
+  Type *PtrTy = PtrVT.getTypeForEVT(*DAG.getContext());
 
   // Replace this with a libcall that will check overflow.
   RTLIB::Libcall LC = RTLIB::UNKNOWN_LIBCALL;
@@ -4875,7 +4877,8 @@ void DAGTypeLegalizer::ExpandIntRes_XMULO(SDNode *N,
 
   // Also pass the address of the overflow check.
   Entry.Node = Temp;
-  Entry.Ty = PointerType::getUnqual(PtrTy->getContext());
+  Entry.Ty =
+      PointerType::get(PtrTy, DAG.getDataLayout().getProgramAddressSpace());
   Entry.IsSExt = true;
   Entry.IsZExt = false;
   Args.push_back(Entry);


### PR DESCRIPTION
This was previously a pointer for AS0 (i32) which trips an assertion later in `getCopyToParts` (called by `LowerCall`) when a capability is copied into that position.

I was hitting this assertion with `smulo.i128` so I think it's the same issue filed here: https://github.com/CTSRD-CHERI/llvm-project/issues/743. Should I have submitted this to the CHERI repo instead? (I will submit it there afterwards anyway if the patch looks sensible here).