### PR TITLE
Enable RVE elf flag for cheriot ABIs

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -109,8 +109,6 @@ void RISCVTargetELFStreamer::finish() {
     break;
   case RISCVABI::ABI_IL32PC64:
   case RISCVABI::ABI_L64PC128:
-  case RISCVABI::ABI_CHERIOT:
-  case RISCVABI::ABI_CHERIOT_BAREMETAL:
     EFlags |= ELF::EF_RISCV_CHERIABI;
     break;
   case RISCVABI::ABI_ILP32F:
@@ -136,6 +134,8 @@ void RISCVTargetELFStreamer::finish() {
     EFlags |= ELF::EF_RISCV_RVE;
     break;
   case RISCVABI::ABI_IL32PC64E:
+  case RISCVABI::ABI_CHERIOT:
+  case RISCVABI::ABI_CHERIOT_BAREMETAL:
     EFlags |= ELF::EF_RISCV_RVE;
     EFlags |= ELF::EF_RISCV_CHERIABI;
     break;

--- a/llvm/test/Object/RISCV/cheriot-elf-flags.ll
+++ b/llvm/test/Object/RISCV/cheriot-elf-flags.ll
@@ -1,0 +1,4 @@
+; RUN: llc --filetype=obj -mtriple=riscv32-unknown-unknown -mcpu=cheriot -target-abi cheriot %s -o - | llvm-readelf --file-header - | FileCheck %s
+
+; Ensure CHERIoT targets have the correct ELF flags.
+; CHECK: Flags: 0x30009, RVC, RVE, cheriabi, capability mode


### PR DESCRIPTION
The `EF_RISCV_RVE` flag in ELF headers must match for all objects when linking. CHERIoT targets use ~~XLEN=16~~ 16 integer registers (E), so I think this should be set.

Tested by linking to objects that did have the `RVE` flag set. Before this patch the linker complained about the mismatch:

```
cannot link object files with different EF_RISCV_RVE
```