### PR TITLE
Switch to using 16 vCPUs in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ pr_task:
     image_family: ubuntu-2404-lts-arm64
     architecture: arm64
     zone: us-central1-a
-    type: c4a-standard-8
+    type: c4a-standard-16
     disk: 60
     preemptible: true
   env:
@@ -41,7 +41,7 @@ x86_release_task:
     image_family: ubuntu-2404-lts-amd64
     architecture: amd64
     zone: us-central1-a
-    type: t2d-standard-8
+    type: t2d-standard-16
   env:
     NINJA_STATUS: '%p [%f:%s/%t] %o/s, %es: '
     CIRRUS_CLONE_DEPTH: 1


### PR DESCRIPTION
We achieve almost perfectly linear speedup on this, so it's a clear win.
