### PR TITLE
[CHERI] Fix CAP_TAG_GET operand counts and orders to work once validation is applied by upstream.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1631,7 +1631,7 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
   case RISCVISD::CAP_TAG_GET: {
     ReplaceNode(Node, CurDAG->getMachineNode(
                           RISCV::CGetTag, DL, Node->getVTList(),
-                          {Node->getOperand(0), Node->getOperand(1)}));
+                          {Node->getOperand(1), Node->getOperand(0)}));
     return;
   }
   case ISD::INTRINSIC_WO_CHAIN: {

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -6033,7 +6033,7 @@ SDValue Cap, EVT XLenVT) {
 // call is optimized poorly, so we expand it manually.
 SDVTList VTList = DAG.getVTList(XLenVT, MVT::Other);
 SDValue IsTagged =
-DAG.getNode(RISCVISD::CAP_TAG_GET, DL, VTList, Cap, DAG.getEntryNode());
+    DAG.getNode(RISCVISD::CAP_TAG_GET, DL, VTList, DAG.getEntryNode(), Cap);
 SDValue Mask = DAG.getNode(ISD::SUB, DL, XLenVT,
 DAG.getConstant(0, DL, XLenVT), IsTagged);
 // Using EXTRACT_SUBREG instead of getaddr is safe here since the result is
@@ -18936,7 +18936,7 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     case Intrinsic::cheri_cap_tag_get: {
       SDVTList VTList = DAG.getVTList(XLenVT, MVT::Other);
       SDValue IntRes = DAG.getNode(RISCVISD::CAP_TAG_GET, DL, VTList,
-                                   N->getOperand(1), DAG.getEntryNode());
+                                   DAG.getEntryNode(), N->getOperand(1));
       SDValue Chain = SDValue(IntRes.getNode(), 1);
       IntRes = DAG.getNode(ISD::AssertZext, DL, XLenVT, IntRes,
                            DAG.getValueType(MVT::i1));
@@ -18947,7 +18947,7 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     case Intrinsic::cheri_cap_tag_get_temporal: {
       SDVTList VTList = DAG.getVTList(XLenVT, MVT::Other);
       SDValue IntRes = DAG.getNode(RISCVISD::CAP_TAG_GET, DL, VTList,
-                                   N->getOperand(2), N->getOperand(0));
+                                   N->getOperand(0), N->getOperand(2));
       SDValue Chain = SDValue(IntRes.getNode(), 1);
       IntRes = DAG.getNode(ISD::AssertZext, DL, XLenVT, IntRes,
                            DAG.getValueType(MVT::i1));

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -17,7 +17,7 @@ def SDT_RISCVCheriBoolUnary : SDTypeProfile<1, 1, [
   SDTCisInt<0>, SDTCisVT<1, CLenVT>
 ]>;
 
-def SDT_RISCVCheriBoolUnaryChain : SDTypeProfile<2, 2, [
+def SDT_RISCVCheriBoolUnaryChain : SDTypeProfile<1, 1, [
   SDTCisInt<0>, SDTCisVT<2, CLenVT>
 ]>;
 


### PR DESCRIPTION
This is a cherry-pick from the cheriot-upstream branch where it was required due to increased validation in upstream. It's not technically required in clang-20, but it's best to keep the two branches in sync.
