### PR TITLE
[CHERIoT] Fix two issues that block compiling libc++'s extern string templates.

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -765,7 +765,9 @@ bool ItaniumMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
         .Default(true);
     }
 
-    if (FD->getType()->castAs<FunctionType>()->getCallConv() == CC_CHERILibCall) {
+    if (FD->getType()->castAs<FunctionType>()->getCallConv() ==
+            CC_CHERILibCall &&
+        FD->getDeclName().isIdentifier()) {
       assert(getASTContext().getTargetInfo().getTargetOpts().ABI != "cheriot-baremetal");
       return llvm::StringSwitch<bool>(FD->getName())
         .Case("memcpy", false)

--- a/clang/lib/AST/Mangle.cpp
+++ b/clang/lib/AST/Mangle.cpp
@@ -122,7 +122,9 @@ bool MangleContext::shouldMangleDeclName(const NamedDecl *D) {
   // This is necessary because hasAttrs returns false for calling convention
   // attributes.
   if (auto *FD = dyn_cast<FunctionDecl>(D))
-    if (FD->getType()->castAs<FunctionType>()->getCallConv() == CC_CHERILibCall) {
+    if (FD->getType()->castAs<FunctionType>()->getCallConv() ==
+            CC_CHERILibCall &&
+        FD->getDeclName().isIdentifier()) {
       assert(ASTContext.getTargetInfo().getTargetOpts().ABI != "cheriot-baremetal");
       return llvm::StringSwitch<bool>(FD->getName())
         .Case("memcpy", false)

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -24,6 +24,7 @@
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/IR/CallingConv.h"
+#include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/Support/Compiler.h"
@@ -289,6 +290,13 @@ MachineBasicBlock *RISCVExpandPseudo::insertLoadOfImportTable(
                                  Fn->hasExternalLinkage(), CallImportTarget);
 }
 
+static const GlobalValue *resolveGlobalAlias(const GlobalValue *GV) {
+  auto *GA = dyn_cast<GlobalAlias>(GV);
+  if (GA)
+    return GA->getAliaseeObject();
+  return GV;
+}
+
 MachineBasicBlock *RISCVExpandPseudo::insertLoadOfImportTable(
     MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
     MCSymbol *ImportSymbol, MCSymbol *ExportSymbol, Register DestReg,
@@ -339,7 +347,7 @@ bool RISCVExpandPseudo::expandCompartmentCall(MachineBasicBlock &MBB,
   if (Callee.isGlobal()) {
     // If this is a global, check if it's in the same compartment.  If so, we
     // want to lower as a direct ccall.
-    auto *Fn = cast<Function>(Callee.getGlobal());
+    auto *Fn = cast<Function>(resolveGlobalAlias(Callee.getGlobal()));
     if (MF->getFunction().hasFnAttribute("cheri-compartment") &&
         (Fn->getFnAttribute("cheri-compartment").getValueAsString() ==
          MF->getFunction()
@@ -391,7 +399,7 @@ bool RISCVExpandPseudo::expandCompartmentCall(MachineBasicBlock &MBB,
   computeAndAddLiveIns(LiveRegs, *NewMBB);
 
   if (Callee.isGlobal()) {
-    auto *Fn = cast<Function>(Callee.getGlobal());
+    auto *Fn = dyn_cast<Function>(resolveGlobalAlias(Callee.getGlobal()));
     insertLoadOfImportTable(MBB, MBBI, Fn, RISCV::C6);
   } else {
     assert(Callee.isReg() && "Expected register operand");
@@ -416,7 +424,7 @@ bool RISCVExpandPseudo::expandLibraryCall(
   MachineInstr &MI = *MBBI;
   auto *MF = MBB.getParent();
   if (Callee.isGlobal()) {
-    auto *Fn = cast<Function>(Callee.getGlobal());
+    auto *Fn = cast<Function>(resolveGlobalAlias(Callee.getGlobal()));
     // If this is a global, check if it's defined in the same module and has a
     // compatible interrupt status.  If so, we want to lower as a direct ccall.
     if (!Fn->isDeclaration() && isSafeToDirectCall(MF->getFunction(), *Fn)) {

--- a/llvm/test/CodeGen/RISCV/cheri/cheri-mcu-call-libcall.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheri-mcu-call-libcall.ll
@@ -4,6 +4,7 @@ target datalayout = "e-m:e-pf200:64:64:64:32-p:32:32-i64:64-n32-S128-A200-P200-G
 target triple = "riscv32-unknown-unknown"
 
 ; Function Attrs: minsize nounwind optsize
+; CHECK-LABEL: callFromNotLibcall:
 define dso_local i32 @callFromNotLibcall() local_unnamed_addr addrspace(200) #0 {
 entry:
 ; Check that these are direct calls via the import table, not going via the
@@ -22,11 +23,27 @@ entry:
   ret i32 %add
 }
 
+; CHECK-LABEL: callViaAlias:
+define dso_local i32 @callViaAlias() local_unnamed_addr addrspace(200) #0 {
+entry:
+; CHECK: ccall bar_alias
+  %call1 = tail call cherilibcallcc i32 @bar_alias() #2
+  ret i32 %call1
+}
+
+define cherilibcallcc i32 @bar() local_unnamed_addr addrspace(200) #0 {
+entry:
+  ret i32 0
+}
+
 ; Function Attrs: minsize optsize
 declare cherilibcallcc i32 @add(i32, i32) local_unnamed_addr addrspace(200) #1
 
 ; Function Attrs: minsize optsize
 declare cherilibcallcc i32 @foo() local_unnamed_addr addrspace(200) #1
+
+; CHECK: .set bar_alias, bar
+@bar_alias = weak_odr dso_local unnamed_addr alias void (), ptr addrspace(200) @bar
 
 attributes #0 = { minsize nounwind optsize "cheri-compartment"="foo" "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+xcheri,-64bit,-relax,-save-restore,-no-rvc-hints" }
 attributes #1 = { minsize optsize "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+xcheri,-64bit,-relax,-save-restore,+no-rvc-hints" }


### PR DESCRIPTION
First, clang was crashing in during name mangling when attempting to mangling
Decls with names that are not identifiers. This was only required for checking
for specific fixed names, so we can just bypass it in that case. I have no
idea how to test this, as my manual reductions don't contain an identifier-less
Decl.

Second, add global alias support to RISCVExpandPseudoInsts.
