### PR TITLE
[CHERIoT] Add missing cases for newly introduced attributes in `printAttributedAfter`

### DIFF
--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2106,6 +2106,12 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case attr::CHERILibCall:
     OS << "cheri_libcall";
     break;
+  case attr::CHERIOTMMIODevice:
+    OS << "cheriot_mmio";
+    break;
+  case attr::CHERIOTSharedObject:
+    OS << "cheriot_shared_object";
+    break;
   case attr::FastCall: OS << "fastcall"; break;
   case attr::StdCall: OS << "stdcall"; break;
   case attr::ThisCall: OS << "thiscall"; break;


### PR DESCRIPTION
As per title, needed due to forgotten `case`s in https://github.com/CHERIoT-Platform/llvm-project/pull/147. 