### PR TITLE
[CHERIoT] Relax libcall-export-from-compartment warnings when the export is weak.

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15902,13 +15902,14 @@ Decl *Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Decl *D,
     Diag(FD->getLocation(), diag::warn_function_def_in_objc_container);
 
   if (FD->getType()->getAs<FunctionType>()->getCallConv() == CC_CHERILibCall &&
-      !Context.getLangOpts().CheriCompartmentName.empty())
+      !Context.getLangOpts().CheriCompartmentName.empty() && !FD->isInlined())
     Diag(FD->getLocation(),
          diag::err_cheri_libcall_implemented_wrong_compartment)
         << Context.getLangOpts().CheriCompartmentName;
   else if (FD->hasAttr<CHERICompartmentNameAttr>() &&
            (FD->getAttr<CHERICompartmentNameAttr>()->getCompartmentName() !=
-            Context.getLangOpts().CheriCompartmentName))
+            Context.getLangOpts().CheriCompartmentName) &&
+           !FD->isInlined())
     Diag(FD->getLocation(), diag::err_cheri_implemented_wrong_compartment)
         << FD->getAttr<CHERICompartmentNameAttr>()->getCompartmentName()
         << Context.getLangOpts().CheriCompartmentName;

--- a/clang/test/Sema/cheri/cheri-mcu-compartment-warns.c
+++ b/clang/test/Sema/cheri/cheri-mcu-compartment-warns.c
@@ -12,3 +12,9 @@ int shouldBePrototype(void) // libcall-error{{CHERI compartment entry declared f
 {
 	return 1;
 }
+
+__attribute__((cheriot_libcall))
+inline int inlineDefinition(int a, int b)
+{
+	return a+b;
+}


### PR DESCRIPTION
This is needed to unblock updating to a newer libc++ in CheriotRTOS.
