### PR TITLE
[CHERIoT] Add missing case for newly introduced `cheriot_sealed` attribute in type printer

### DIFF
--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2112,6 +2112,9 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case attr::CHERIOTSharedObject:
     OS << "cheriot_shared_object";
     break;
+  case attr::CHERIoTSealedType:
+    OS << "cheriot_sealed";
+    break;
   case attr::FastCall: OS << "fastcall"; break;
   case attr::StdCall: OS << "stdcall"; break;
   case attr::ThisCall: OS << "thiscall"; break;


### PR DESCRIPTION
...which I forgot once again.