### PR TITLE
[CHERIoT] Minor change to fix warning in older clang versions

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -639,7 +639,8 @@ protected:
     unsigned BasePathSize;
   };
 
-  static_assert(CK_IntToOCLSampler == (CastExprBitfields{.Kind = CK_IntToOCLSampler}).Kind,
+  static_assert(CK_IntToOCLSampler ==
+                    (CastExprBitfields{CK_IntToOCLSampler, 0, 0, 0}).Kind,
                 "Need more cast kind bits");
 
   class BinaryOperatorBitfields {


### PR DESCRIPTION
A small change that should fix [this](https://cirrus-ci.com/task/5404898843426816?logs=build#L28) warning that shows up when old (<20?) versions of clang are used to compile the project. 