### PR TITLE
[CHERIoT] Fixes to `cheriot_cap_import` attribute

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2117,7 +2117,10 @@ static void handleCHERIOTMMIODevice(Sema &S, Decl *D, const ParsedAttr &Attr,
   }
 
   QualType QT = VD->getType();
-  if (!QT.isVolatileQualified()) {
+  auto *PQT = dyn_cast<PointerType>(QT);
+  auto IsVolatile = (PQT && PQT->getPointeeType().isVolatileQualified()) ||
+                    QT.isVolatileQualified();
+  if (!IsVolatile) {
     S.Diag(Attr.getLoc(), diag::warn_cheriot_global_cap_import_non_volatile)
         << VD->getName() << Attr.getAttrName();
   }

--- a/clang/test/CodeGen/cheri/riscv/cheriot-cap-import-attr.c
+++ b/clang/test/CodeGen/cheri/riscv/cheriot-cap-import-attr.c
@@ -176,15 +176,15 @@ void func() {
 
 // CHECK: attributes #0 = { "cheriot_global_cap_import"="mem,uart,RWcm" }
 // CHECK: attributes #1 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,RWcm" }
-// CHECK: attributes #2 = { "cheriot_global_cap_import"="mem,uart,R" }
-// CHECK: attributes #3 = { "cheriot_global_cap_import"="mem,uart,Rc" }
-// CHECK: attributes #4 = { "cheriot_global_cap_import"="mem,uart,Rcm" }
-// CHECK: attributes #5 = { "cheriot_global_cap_import"="mem,uart,W" }
-// CHECK: attributes #6 = { "cheriot_global_cap_import"="mem,uart,Wc" }
-// CHECK: attributes #7 = { "cheriot_global_cap_import"="mem,uart,RWc" }
-// CHECK: attributes #8 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,R" }
-// CHECK: attributes #9 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,Rc" }
-// CHECK: attributes #10 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,Rcm" }
-// CHECK: attributes #11 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,W" }
-// CHECK: attributes #12 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,Wc" }
-// CHECK: attributes #13 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,RWc" }
+// CHECK: attributes #2 = { "cheriot_global_cap_import"="mem,uart,R---" }
+// CHECK: attributes #3 = { "cheriot_global_cap_import"="mem,uart,R-c-" }
+// CHECK: attributes #4 = { "cheriot_global_cap_import"="mem,uart,R-cm" }
+// CHECK: attributes #5 = { "cheriot_global_cap_import"="mem,uart,-W--" }
+// CHECK: attributes #6 = { "cheriot_global_cap_import"="mem,uart,-Wc-" }
+// CHECK: attributes #7 = { "cheriot_global_cap_import"="mem,uart,RWc-" }
+// CHECK: attributes #8 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,R---" }
+// CHECK: attributes #9 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,R-c-" }
+// CHECK: attributes #10 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,R-cm" }
+// CHECK: attributes #11 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,-W--" }
+// CHECK: attributes #12 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,-Wc-" }
+// CHECK: attributes #13 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,RWc-" }

--- a/clang/test/Sema/cheri/cheriot-cap-import-attr-ill-formed.c
+++ b/clang/test/Sema/cheri/cheriot-cap-import-attr-ill-formed.c
@@ -7,8 +7,10 @@ __attribute__((cheriot_mmio("uart", "m"))) extern volatile struct Uart uart2; //
 __attribute__((cheriot_mmio("uart", "R"))) volatile struct Uart uart3; // no warnings or errors, extern is implied 
 __attribute__((cheriot_mmio("uart"))) volatile struct Uart uart4 = {};  // expected-error{{global variable definition 'uart4' with attribute 'cheriot_mmio' cannot have an initializer}}
 __attribute__((cheriot_mmio("uart"))) volatile struct {int k;} uart5 = {10};  // expected-error{{global variable definition 'uart5' with attribute 'cheriot_mmio' cannot have an initializer}}
+__attribute__((cheriot_mmio("uart", "R"))) extern volatile struct Uart *uart6; /* no warnings or errors*/
 __attribute__((cheriot_shared_object("exampleK", "RR"))) extern int exampleK; // expected-warning{{the permissions in 'cheriot_shared_object' contain a duplicate permission symbol: 'R' (value: 'RR')}}
 __attribute__((cheriot_shared_object("exampleK", "m"))) extern int exampleK; // expected-error{{the permissions in 'cheriot_shared_object' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: 'm')}}
 __attribute__((cheriot_shared_object("exampleK", "Wm"))) extern int exampleK; // expected-error{{the permissions in 'cheriot_shared_object' contain ill-formed dependencies: contains mut (m) but does not have both read (R) and cap (c) (value: 'Wm')}}
 __attribute__((cheriot_shared_object("exampleK", "R"))) int exampleK; // no warnings or errors, extern is implied 
 __attribute__((cheriot_shared_object("exampleK", "R"))) int exampleK2 = 10; // expected-error{{global variable definition 'exampleK2' with attribute 'cheriot_shared_object' cannot have an initializer}}
+__attribute__((cheriot_shared_object("exampleK", "R"))) int *exampleK3; /* no warnings or errors */ 

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/CodeGen.h"
@@ -1498,10 +1499,11 @@ public:
       return false;
     }
 
-    Permissions = (HasRead ? std::string(ReadPermissionSymbol) : "") +
-                  (HasWrite ? std::string(WritePermissionSymbol) : "") +
-                  (HasCap ? std::string(CapPermissionSymbol) : "") +
-                  (HasMut ? std::string(MutPermissionSymbol) : "");
+    Permissions = ((HasRead ? Twine(ReadPermissionSymbol) : "-") +
+                   (HasWrite ? Twine(WritePermissionSymbol) : "-") +
+                   (HasCap ? Twine(CapPermissionSymbol) : "-") +
+                   (HasMut ? Twine(MutPermissionSymbol) : "-"))
+                      .str();
     return true;
   }
 


### PR DESCRIPTION
In particular, this PR fixes the mangling scheme of permissions ("" -> "-" when permission not present) and, when checking for volatile qualifiers, checks the pointee if the type is a pointer.