### PR TITLE
[CHERIoT] Allow `extern` on `cheriot_sealed` global variables

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14948,24 +14948,6 @@ Sema::DeclGroupPtrTy Sema::FinalizeDeclaratorGroup(Scope *S, const DeclSpec &DS,
     if (!D)
       continue;
 
-    auto *VD = dyn_cast<VarDecl>(D);
-
-    /// CHERIoT-specific check. If a variable is declared with a sealed type, it
-    /// can't have external storage, since its initializer must be available in
-    /// the unit.
-    ///
-    /// For example
-    /// ```
-    /// typedef int MySealedType __attribute__((cheriot_sealed("MyCompartment",
-    /// "MySealingKeyType"))); extern MySealedType mySealedObject;
-    /// ```
-    /// would not really make sense.
-    if (VD && VD->getType().hasCHERIoTSealedAttr() &&
-        VD->hasExternalStorage()) {
-      Diag(D->getLocation(), diag::err_cheriot_invalid_sealed_declaration)
-          << "external";
-    }
-
     // Check if the Decl has been declared in '#pragma omp declare target'
     // directive and has static storage duration.
     if (auto *VD = dyn_cast<VarDecl>(D);

--- a/clang/test/Sema/cheri/cheriot-static-sealed-value-attr.c
+++ b/clang/test/Sema/cheri/cheriot-static-sealed-value-attr.c
@@ -18,7 +18,7 @@ MyObj4 Obj4 = {0, 0, 0, 0};
 
 struct PlainObj plainObj = {10};
 MyObj5 Obj5 = &plainObj;
-extern MyObj5 Obj6; // expected-error{{cannot declare a sealed variable as external}}
+extern MyObj5 Obj6; // No warnings here, it is allowed to declare it `extern`.
 
 void useStruct(struct MyObj x);
 void useStructSealedCap(struct MyObj *__sealed_capability x);

--- a/clang/test/SemaCXX/cheri/cheriot-static-sealed-value-attr.cpp
+++ b/clang/test/SemaCXX/cheri/cheriot-static-sealed-value-attr.cpp
@@ -17,7 +17,7 @@ MyObj4 Obj4 = {0, 0, 0, 0};
 
 struct PlainObj plainObj = {10};
 MyObj5 Obj5 = &plainObj;
-extern MyObj5 Obj6; // expected-error{{cannot declare a sealed variable as external}}
+extern MyObj5 Obj6; // No warnings here, it is allowed to declare it `extern`. 
 					
 void useStruct(struct MyObj x);
 void useStructSealedCap(struct MyObj *__sealed_capability x);


### PR DESCRIPTION
This change is needed to replicate the [same behaviour](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/include/compartment-macros.h#L223) exhibited in the macros. 

This is useful in instances where a sealed value must be provided by an external source: an example of this need is [this](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/include/stdlib.h#L90) definition in cheriot-rtos' stdlib: here,  if `CHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY` is defined, compilation fails (because the `__default_malloc_capability` symbol is undefined) if no `extern <...> __default_malloc_capability` is given. 

This PR also fixes the related semantic checks. 
