### PR TITLE
[CHERIoT] Bump `__CHERIOT__` and `__CHERIOT_BAREMETAL__` definitions

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -306,9 +306,9 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
     // Macros for CHERIoT in the default and bare-metal ABIs.
     if (ABI == "cheriot" || ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT__", "20250217");
+      Builder.defineMacro("__CHERIOT__", "20250610");
     if (ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250217");
+      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20250610");
 
     Builder.defineMacro("__riscv_clen", Twine(getCHERICapabilityWidth()));
     // TODO: _MIPS_CAP_ALIGN_MASK equivalent?

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -391,8 +391,8 @@
 // Check for CHERIoT-specific defines
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" -E -dM < /dev/null | FileCheck -check-prefix CHERIOT %s
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot-baremetal" -E -dM < /dev/null | FileCheck -check-prefixes CHERIOT,CHERIOT-BAREMETAL %s
-// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250217
-// CHERIOT: #define __CHERIOT__ 20250217
+// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20250610
+// CHERIOT: #define __CHERIOT__ 20250610
 
 
 // RUN: %cheri128_cc1 -fgnuc-version=4.2.1 -E -dM -ffreestanding < /dev/null | FileCheck -check-prefixes CHERI-COMMON,CHERI-MIPS,CHERI128 %s


### PR DESCRIPTION
As per title. I think we'll want to wait until https://github.com/CHERIoT-Platform/llvm-project/pull/169 is merged before merging this one; I'll let CI run to see if I missed any tests that use those definitions. 