### PR TITLE
[CHERIoT] ELF/Writer: import entry permissions

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -3196,7 +3196,13 @@ class CompartmentReportWriter {
           imports.push_back(json::Object{
               {"kind", "MMIO"},
               {"start", entry.start},
-              {"length", entry.length & 0xfffffff},
+              /*
+               * Length and permissions are bit-stuffed into the same 32-bit
+               * word, with the top 8 bits reserved for permission flags and
+               * the bottom 24 for length. See CHERIoT-RTOS's
+               * sdk/core/loader/types.h ReservedPermissionsMask
+               */
+              {"length", entry.length & 0x00ffffff},
               {"permits_load", (entry.length & ImportPermitsLoad) != 0},
               {"permits_store", (entry.length & ImportPermitsStore) != 0},
               {"permits_load_store_capabilities",

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -3192,6 +3192,7 @@ class CompartmentReportWriter {
           static constexpr uint32_t ImportPermitsLoadStoreCapabilities =
               (1UL << 29);
           static constexpr uint32_t ImportPermitsLoadMutable = (1UL << 28);
+          static constexpr uint32_t ImportPermitsLoadGlobal = (1UL << 27);
 
           imports.push_back(json::Object{
               {"kind", "MMIO"},
@@ -3208,7 +3209,9 @@ class CompartmentReportWriter {
               {"permits_load_store_capabilities",
                (entry.length & ImportPermitsLoadStoreCapabilities) != 0},
               {"permits_load_mutable",
-               (entry.length & ImportPermitsLoadMutable) != 0}});
+               (entry.length & ImportPermitsLoadMutable) != 0},
+              {"permits_load_global",
+               (entry.length & ImportPermitsLoadGlobal) != 0}});
         }
         continue;
       }


### PR DESCRIPTION
The loader was reserving 8, not 4, bits for permission flags, and I'm stealing one of the heretofore unused ones for PermitLoadGlobal.