### PR TITLE
Make `cheriot_use_of_builtin_sealing_key_type_no_compartment` a warning that defaults to `Error` level

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -172,6 +172,9 @@ def CheriPedantic : DiagGroup<"cheri-pedantic", [CHERICapabilityToIntegerCast, C
 // Warnings/Errors for bugs in the MIPS/CHERI backend
 def MIPSCHERIBugs: DiagGroup<"mips-cheri-bugs">;
 
+// Generally useful CHERI errors
+def CHERIMissingCompartment: DiagGroup<"cheri-missing-compartment">;
+
 def C99Compat : DiagGroup<"c99-compat">;
 def C23Compat : DiagGroup<"c23-compat">;
 def : DiagGroup<"c2x-compat", [C23Compat]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -157,8 +157,8 @@ def err_cheriot_invalid_sealed_declaration
     : Error<"cannot declare a sealed variable as %0">;
 def err_cheriot_invalid_sealing_key_type_name
     : Error<"the sealing key type name '%0' is not a valid identifier">;
-def err_cheriot_use_of_builtin_sealing_key_type_no_compartment
-    : Error<"%0 used, but no compartment name given">;
+def warn_cheriot_use_of_builtin_sealing_key_type_no_compartment
+    : Warning<"%0 used, but no compartment name given">,InGroup<CHERIMissingCompartment>,DefaultError;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2938,7 +2938,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     }
     if (getLangOpts().CheriCompartmentName.empty()) {
       Diag(Arg->getExprLoc(),
-           diag::err_cheriot_use_of_builtin_sealing_key_type_no_compartment)
+           diag::warn_cheriot_use_of_builtin_sealing_key_type_no_compartment)
           << Context.BuiltinInfo.getName(
                  Builtin::BI__builtin_cheriot_sealing_type);
     }


### PR DESCRIPTION
As per title. Useful for cases like [this](https://github.com/CHERIoT-Platform/cheriot-rtos/actions/runs/15630107928/job/44033295597?pr=545#step:5:458), where we want to silence this diagnostic. 