### PR TITLE
Merge CHERI clang static analyzers from rems-project/llvm-project

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1818,7 +1818,7 @@ let ParentPackage = CHERI in {
             "Report tag-stripping copy for char* function parameters. "
             "Suppression of warnings for C-strings is used to reduce "
             "the number of false alarms, but it's not very reliable.",
-            "true", Released>]>,
+            "false", Released>]>,
         Documentation<NotDocumented>;
 
   def PointerSizeAssumptionsChecker

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1794,6 +1794,10 @@ def UncheckedLocalVarsChecker : Checker<"UncheckedLocalVarsChecker">,
 
 let ParentPackage = CHERI in {
 
+  def CheriAPIModelling : Checker<"CheriAPIModelling">,
+                          HelpText<"Model CheriAPI">,
+                          Documentation<NotDocumented>;
+
   def ProvenanceSourceChecker
       : Checker<"ProvenanceSource">,
         HelpText<"Check expressions with ambiguous provenance source.">,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1802,9 +1802,16 @@ let ParentPackage = CHERI in {
                                       "false", InAlpha>]>,
         Documentation<NotDocumented>;
 
-  def CapabilityCopyChecker : Checker<"CapabilityCopy">,
-                              HelpText<"Check tag-stripping memory copy.">,
-                              Documentation<NotDocumented>;
+  def CapabilityCopyChecker
+      : Checker<"CapabilityCopy">,
+        HelpText<"Check tag-stripping memory copy.">,
+        CheckerOptions<[CmdLineOption<
+            Boolean, "ReportForCharPtr",
+            "Report tag-stripping copy for char* function parameters. "
+            "Suppression of warnings for C-strings is used to reduce "
+            "the number of false alarms, but it's not very reliable.",
+            "true", Released>]>,
+        Documentation<NotDocumented>;
 
 } // end cheri
 

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1826,12 +1826,14 @@ let ParentPackage = CHERI in {
         HelpText<"Detect hardcoded expectations on pointer sizes">,
         Documentation<NotDocumented>;
 
+  def SubObjectRepresentabilityChecker
+      : Checker<"SubObjectRepresentability">,
+        HelpText<
+            "Check for record fields with unrepresentable subobject bounds">,
+        Documentation<NotDocumented>;
+
 } // end cheri
 
 let ParentPackage = CHERIAlpha in {
-
-  def SubObjectRepresentabilityChecker : Checker<"SubObjectRepresentability">,
-                                         HelpText<"TODO: help">,
-                                         Documentation<NotDocumented>;
 
 } // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1836,4 +1836,10 @@ let ParentPackage = CHERI in {
 
 let ParentPackage = CHERIAlpha in {
 
+  def AllocationChecker
+      : Checker<"Allocation">,
+        HelpText<
+            "Suggest narrowing bounds for escaping suballocation capabilities">,
+        Documentation<NotDocumented>;
+
 } // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1797,9 +1797,17 @@ let ParentPackage = CHERI in {
   def ProvenanceSourceChecker
       : Checker<"ProvenanceSource">,
         HelpText<"Check expressions with ambiguous provenance source.">,
-        CheckerOptions<[CmdLineOption<Boolean, "ShowFixIts",
-                                      "Enable fix-it hints for this checker",
-                                      "false", InAlpha>]>,
+        CheckerOptions<
+            [CmdLineOption<Boolean, "ShowFixIts",
+                           "Enable fix-it hints for this checker", "false",
+                           InAlpha>,
+             CmdLineOption<
+                 Boolean, "ReportForAmbiguousProvenance",
+                 "Report for binary operations with ambiguous provenance "
+                 "for which the default capability derivation from LHS is "
+                 "fine. "
+                 "Disabled if [-Wcheri-provenance] is disabled.",
+                 "true", Released>]>,
         Documentation<NotDocumented>;
 
   def CapabilityCopyChecker

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1828,4 +1828,10 @@ let ParentPackage = CHERI in {
 
 } // end cheri
 
-let ParentPackage = CHERIAlpha in {} // end alpha.cheri
+let ParentPackage = CHERIAlpha in {
+
+  def SubObjectRepresentabilityChecker : Checker<"SubObjectRepresentability">,
+                                         HelpText<"TODO: help">,
+                                         Documentation<NotDocumented>;
+
+} // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1813,6 +1813,11 @@ let ParentPackage = CHERI in {
             "true", Released>]>,
         Documentation<NotDocumented>;
 
+  def PointerSizeAssumptionsChecker
+      : Checker<"PointerSizeAssumptions">,
+        HelpText<"Detect hardcoded expectations on pointer sizes">,
+        Documentation<NotDocumented>;
+
 } // end cheri
 
 let ParentPackage = CHERIAlpha in {} // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1674,6 +1674,10 @@ def UnixAPIPortabilityChecker : Checker<"UnixAPI">,
   HelpText<"Finds implementation-defined behavior in UNIX/Posix functions">,
   Documentation<NotDocumented>;
 
+def PointerAlignmentChecker : Checker<"PointerAlignment">,
+                              HelpText<"Check underaligned pointers.">,
+                              Documentation<NotDocumented>;
+
 } // end optin.portability
 
 
@@ -1801,10 +1805,6 @@ let ParentPackage = CHERI in {
   def CapabilityCopyChecker : Checker<"CapabilityCopy">,
                               HelpText<"Check tag-stripping memory copy.">,
                               Documentation<NotDocumented>;
-
-  def CapabilityAlignmentChecker : Checker<"CapabilityAlignmentChecker">,
-                                   HelpText<"Check underaligned pointers.">,
-                                   Documentation<NotDocumented>;
 
 } // end cheri
 

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1844,6 +1844,9 @@ let ParentPackage = CHERIAlpha in {
       : Checker<"Allocation">,
         HelpText<
             "Suggest narrowing bounds for escaping suballocation capabilities">,
+        CheckerOptions<[CmdLineOption<
+            Boolean, "ReportForUnknownAllocations",
+            "Report for pointers with untracked origin", "true", Released>]>,
         Documentation<NotDocumented>;
 
 } // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -124,6 +124,9 @@ def FuchsiaAlpha : Package<"fuchsia">, ParentPackage<Alpha>;
 def WebKit : Package<"webkit">;
 def WebKitAlpha : Package<"webkit">, ParentPackage<Alpha>;
 
+def CHERI : Package<"cheri">;
+def CHERIAlpha : Package<"cheri">, ParentPackage<Alpha>;
+
 //===----------------------------------------------------------------------===//
 // Core Checkers.
 //===----------------------------------------------------------------------===//
@@ -1780,3 +1783,18 @@ def UncheckedLocalVarsChecker : Checker<"UncheckedLocalVarsChecker">,
   Documentation<HasDocumentation>;
 
 } // end alpha.webkit
+
+//===----------------------------------------------------------------------===//
+// CHERI checkers.
+//===----------------------------------------------------------------------===//
+
+let ParentPackage = CHERI in {} // end cheri
+
+let ParentPackage = CHERIAlpha in {
+
+  def ProvenanceSourceChecker
+      : Checker<"ProvenanceSourceChecker">,
+        HelpText<"Check expressions with ambiguous provenance source.">,
+        Documentation<NotDocumented>;
+
+} // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1788,16 +1788,14 @@ def UncheckedLocalVarsChecker : Checker<"UncheckedLocalVarsChecker">,
 // CHERI checkers.
 //===----------------------------------------------------------------------===//
 
-let ParentPackage = CHERI in {} // end cheri
-
-let ParentPackage = CHERIAlpha in {
+let ParentPackage = CHERI in {
 
   def ProvenanceSourceChecker
-      : Checker<"ProvenanceSourceChecker">,
+      : Checker<"ProvenanceSource">,
         HelpText<"Check expressions with ambiguous provenance source.">,
         Documentation<NotDocumented>;
 
-  def CapabilityCopyChecker : Checker<"CapabilityCopyChecker">,
+  def CapabilityCopyChecker : Checker<"CapabilityCopy">,
                               HelpText<"Check tag-stripping memory copy.">,
                               Documentation<NotDocumented>;
 
@@ -1805,4 +1803,6 @@ let ParentPackage = CHERIAlpha in {
                                    HelpText<"Check underaligned pointers.">,
                                    Documentation<NotDocumented>;
 
-} // end alpha.cheri
+} // end cheri
+
+let ParentPackage = CHERIAlpha in {} // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1793,6 +1793,9 @@ let ParentPackage = CHERI in {
   def ProvenanceSourceChecker
       : Checker<"ProvenanceSource">,
         HelpText<"Check expressions with ambiguous provenance source.">,
+        CheckerOptions<[CmdLineOption<Boolean, "ShowFixIts",
+                                      "Enable fix-it hints for this checker",
+                                      "false", InAlpha>]>,
         Documentation<NotDocumented>;
 
   def CapabilityCopyChecker : Checker<"CapabilityCopy">,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1801,4 +1801,8 @@ let ParentPackage = CHERIAlpha in {
                               HelpText<"Check tag-stripping memory copy.">,
                               Documentation<NotDocumented>;
 
+  def CapabilityAlignmentChecker : Checker<"CapabilityAlignmentChecker">,
+                                   HelpText<"Check underaligned pointers.">,
+                                   Documentation<NotDocumented>;
+
 } // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1797,4 +1797,8 @@ let ParentPackage = CHERIAlpha in {
         HelpText<"Check expressions with ambiguous provenance source.">,
         Documentation<NotDocumented>;
 
+  def CapabilityCopyChecker : Checker<"CapabilityCopyChecker">,
+                              HelpText<"Check tag-stripping memory copy.">,
+                              Documentation<NotDocumented>;
+
 } // end alpha.cheri

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -776,9 +776,11 @@ inline SVal ProgramState::getLValue(const ObjCIvarDecl *D, SVal Base) const {
   return getStateManager().StoreMgr->getLValueIvar(D, Base);
 }
 
-inline SVal ProgramState::getLValue(QualType ElementType, SVal Idx, SVal Base) const{
+inline SVal ProgramState::getLValue(QualType ElementType, SVal Idx,
+                                    SVal Base) const {
   if (std::optional<NonLoc> N = Idx.getAs<NonLoc>())
-    return getStateManager().StoreMgr->getLValueElement(ElementType, *N, Base);
+    return getStateManager().StoreMgr->getLValueElement(this, ElementType, *N,
+                                                        Base);
   return UnknownVal();
 }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h
@@ -324,7 +324,10 @@ public:
     return nonloc::ConcreteInt(BasicVals.getValue(integer, ptrType));
   }
 
-  NonLoc makeLocAsInteger(Loc loc, unsigned bits) {
+  NonLoc makeLocAsInteger(Loc loc, unsigned bits, bool hasProvenance) {
+    assert((bits & ~255) == 0);
+    if (hasProvenance)
+      bits |= 256;
     return nonloc::LocAsInteger(BasicVals.getPersistentSValWithData(loc, bits));
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SVals.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/SVals.h
@@ -326,7 +326,13 @@ public:
   }
 
   unsigned getNumBits() const {
-    return castDataAs<std::pair<SVal, uintptr_t>>()->second;
+    return castDataAs<std::pair<SVal, uintptr_t>>()->second & 255;
+  }
+
+  bool hasProvenance() const {
+    const std::pair<SVal, uintptr_t> *D =
+        castDataAs<std::pair<SVal, uintptr_t>>();
+    return D->second & 256;
   }
 
   static bool classof(SVal V) { return V.getKind() == LocAsIntegerKind; }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
@@ -147,7 +147,8 @@ public:
     return getLValueFieldOrIvar(D, Base);
   }
 
-  virtual SVal getLValueElement(QualType elementType, NonLoc offset, SVal Base);
+  virtual SVal getLValueElement(ProgramStateRef State, QualType elementType,
+                                NonLoc offset, SVal Base);
 
   /// ArrayToPointer - Used by ExprEngine::VistCast to handle implicit
   ///  conversions between arrays and pointers.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12112,6 +12112,9 @@ unsigned ASTContext::getIntWidth(QualType T) const {
   if (Target->SupportsCapabilities()) {
     if (T->isPointerType() && T->getAs<PointerType>()->isCHERICapability())
       return Target->getPointerRangeForCHERICapability();
+    if (T->isReferenceType() && T->getAs<ReferenceType>()->isCHERICapability()) {
+      return Target->getPointerRangeForCHERICapability();
+    }
     if (T->isIntCapType())
       return Target->getPointerRangeForCHERICapability();
     // This assertion is correct but breaks some static analyser code paths

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3623,6 +3623,7 @@ static void RenderAnalyzerOptions(const ArgList &Args, ArgStringList &CmdArgs,
         (Triple.isRISCV() && tools::riscv::isCheriPurecap(Args, Triple))) {
       CmdArgs.push_back("-analyzer-checker=cheri");
       CmdArgs.push_back("-analyzer-checker=optin.portability.PointerAlignment");
+      CmdArgs.push_back("-analyzer-checker=alpha.core.PointerSub");
     }
 
     // Default nullability checks.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3616,6 +3616,14 @@ static void RenderAnalyzerOptions(const ArgList &Args, ArgStringList &CmdArgs,
       CmdArgs.push_back("-analyzer-checker=security.insecureAPI.vfork");
     }
 
+    if (Triple.getEnvironment() == llvm::Triple::CheriPurecap ||
+        // FIXME: checks below should eventually become unreachable when
+        // Triple is updated to purecap in ToolChain constructor
+        (Triple.isMIPS() && tools::mips::hasMipsAbiArg(Args, "purecap")) ||
+        (Triple.isRISCV() && tools::riscv::isCheriPurecap(Args, Triple))) {
+      CmdArgs.push_back("-analyzer-checker=cheri");
+    }
+
     // Default nullability checks.
     CmdArgs.push_back("-analyzer-checker=nullability.NullPassedToNonnull");
     CmdArgs.push_back("-analyzer-checker=nullability.NullReturnedFromNonnull");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3622,6 +3622,7 @@ static void RenderAnalyzerOptions(const ArgList &Args, ArgStringList &CmdArgs,
         (Triple.isMIPS() && tools::mips::hasMipsAbiArg(Args, "purecap")) ||
         (Triple.isRISCV() && tools::riscv::isCheriPurecap(Args, Triple))) {
       CmdArgs.push_back("-analyzer-checker=cheri");
+      CmdArgs.push_back("-analyzer-checker=optin.portability.PointerAlignment");
     }
 
     // Default nullability checks.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -66,6 +66,7 @@
 #include "llvm/TargetParser/RISCVISAInfo.h"
 #include "llvm/TargetParser/RISCVTargetParser.h"
 #include <cctype>
+#include <clang/Basic/DiagnosticSema.h>
 
 using namespace clang::driver;
 using namespace clang::driver::tools;
@@ -3570,7 +3571,8 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
 
 static void RenderAnalyzerOptions(const ArgList &Args, ArgStringList &CmdArgs,
                                   const llvm::Triple &Triple,
-                                  const InputInfo &Input) {
+                                  const InputInfo &Input,
+                                  DiagnosticsEngine &Diags) {
   // Add default argument set.
   if (!Args.hasArg(options::OPT__analyzer_no_default_checks)) {
     CmdArgs.push_back("-analyzer-checker=core");
@@ -3622,6 +3624,16 @@ static void RenderAnalyzerOptions(const ArgList &Args, ArgStringList &CmdArgs,
         (Triple.isMIPS() && tools::mips::hasMipsAbiArg(Args, "purecap")) ||
         (Triple.isRISCV() && tools::riscv::isCheriPurecap(Args, Triple))) {
       CmdArgs.push_back("-analyzer-checker=cheri");
+
+      // disable AmbiguousProvenance war if [-Wcheri-provenance] is disabled
+      if (Diags.getDiagnosticLevel(
+              diag::warn_ambiguous_provenance_capability_binop,
+              SourceLocation()) < DiagnosticsEngine::Warning) {
+        CmdArgs.push_back("-analyzer-config");
+        CmdArgs.push_back(
+            "cheri.ProvenanceSource:ReportForAmbiguousProvenance=false");
+      }
+
       CmdArgs.push_back("-analyzer-checker=optin.portability.PointerAlignment");
       CmdArgs.push_back("-analyzer-checker=alpha.core.PointerSub");
     }
@@ -5715,7 +5727,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-DUNICODE");
 
   if (isa<AnalyzeJobAction>(JA))
-    RenderAnalyzerOptions(Args, CmdArgs, Triple, Input);
+    RenderAnalyzerOptions(Args, CmdArgs, Triple, Input, D.getDiags());
 
   if (isa<AnalyzeJobAction>(JA) ||
       (isa<PreprocessJobAction>(JA) && Args.hasArg(options::OPT__analyze)))

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -214,6 +214,9 @@ ExplodedNode *AllocationChecker::emitAllocationPartitionWarning(
 
 void AllocationChecker::checkPostStmt(const CastExpr *CE,
                                       CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   if (CE->getCastKind() != CK_BitCast)
     return;
   SVal SrcVal = C.getSVal(CE->getSubExpr());
@@ -284,6 +287,9 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
 
 void AllocationChecker::checkPreCall(const CallEvent &Call,
                                      CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   if (IgnoreFnSet.contains(Call) || CheriBoundsFnSet.contains(Call))
     return;
 
@@ -331,6 +337,9 @@ void AllocationChecker::checkPreCall(const CallEvent &Call,
 
 void AllocationChecker::checkPostCall(const CallEvent &Call,
                                       CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   if (!CheriBoundsFnSet.contains(Call))
     return;
   const MemRegion *MR = C.getSVal(Call.getArgExpr(0)).getAsRegion();
@@ -350,6 +359,9 @@ void AllocationChecker::checkPostCall(const CallEvent &Call,
 
 void AllocationChecker::checkBind(SVal L, SVal V, const Stmt *S,
                                   CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   const MemRegion *Dst = L.getAsRegion();
   if (!Dst || !isa<FieldRegion>(Dst))
     return;
@@ -371,6 +383,9 @@ void AllocationChecker::checkBind(SVal L, SVal V, const Stmt *S,
 
 void AllocationChecker::checkEndFunction(const ReturnStmt *RS,
                                          CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   if (!RS)
     return;
   const Expr *RV = RS->getRetValue();

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -40,8 +40,8 @@ class AllocationChecker
     : public Checker<check::PostStmt<CastExpr>, check::PreCall, check::PostCall,
                      check::Bind, check::EndFunction> {
   BugType BT_Default{this, "Allocation partitioning", "CHERI portability"};
-  BugType BT_KnownReg{this, "Heap or static allocation partitioning",
-                      "CHERI portability"};
+  BugType BT_UnknownReg{this, "Unknown allocation partitioning",
+                        "CHERI portability"};
 
   const CallDescriptionSet IgnoreFnSet = {
       {CDM::SimpleFunc, {"free"}, 1},
@@ -81,6 +81,8 @@ public:
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
   void checkEndFunction(const ReturnStmt *RS, CheckerContext &Ctx) const;
 
+  bool ReportForUnknownAllocations;
+
 private:
   ExplodedNode *emitAllocationPartitionWarning(CheckerContext &C,
                                                const MemRegion *MR,
@@ -111,7 +113,13 @@ std::pair<const MemRegion *, bool> getAllocationStart(const ASTContext &ASTCtx,
   return std::make_pair(R, ZeroShift);
 }
 
-bool isAllocation(const MemRegion *R) {
+bool isAllocation(const MemRegion *R, const AllocationChecker *Chk) {
+  if (!Chk->ReportForUnknownAllocations) {
+    const MemSpaceRegion *MemSpace = R->getMemorySpace();
+    if (!isa<HeapSpaceRegion, GlobalsSpaceRegion, StackSpaceRegion>(MemSpace))
+      return false;
+  }
+
   if (R->getAs<SymbolicRegion>())
     return true;
   if (const TypedValueRegion *TR = R->getAs<TypedValueRegion>()) {
@@ -176,12 +184,19 @@ ExplodedNode *AllocationChecker::emitAllocationPartitionWarning(
     CheckerContext &C, const MemRegion *MR, SourceRange SR,
     StringRef Msg = "") const {
   if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
-    auto R = std::make_unique<PathSensitiveBugReport>(BT_Default, Msg, ErrNode);
-    R->addRange(SR);
-    R->markInteresting(MR);
 
     const MemRegion *PrevAlloc =
         getAllocationStart(C.getASTContext(), MR, C.getState()).first;
+    const MemSpaceRegion *MS =
+        PrevAlloc ? PrevAlloc->getMemorySpace() : MR->getMemorySpace();
+    const BugType &BT =
+        isa<HeapSpaceRegion, GlobalsSpaceRegion, StackSpaceRegion>(MS)
+            ? BT_Default
+            : BT_UnknownReg;
+    auto R = std::make_unique<PathSensitiveBugReport>(BT, Msg, ErrNode);
+    R->addRange(SR);
+    R->markInteresting(MR);
+
     R->addVisitor(std::make_unique<AllocPartitionBugVisitor>(
         PrevAlloc == MR ? nullptr : PrevAlloc, MR));
 
@@ -216,13 +231,9 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
       getAllocationStart(ASTCtx, MR, State);
 
   const MemRegion *SR = StartPair.first;
-  if (!isAllocation(SR))
+  if (!isAllocation(SR, this))
     return;
   bool ZeroShift = StartPair.second;
-
-  const MemSpaceRegion *MemSpace = SR->getMemorySpace();
-  if (!isa<HeapSpaceRegion, GlobalsSpaceRegion, StackSpaceRegion>(MemSpace))
-    return;
 
   SVal DstVal = C.getSVal(CE);
   const MemRegion *DMR = DstVal.getAsRegion();
@@ -252,10 +263,14 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
                             ->getUnqualifiedDesugaredType();
       const Type *Ty2 = DstTy->getPointeeType()->getUnqualifiedDesugaredType();
       if (!relatedTypes(ASTCtx, Ty1, Ty2)) {
-        State = State->add<SuballocationSet>(SR);
-        if (DMR)
+        if (!State->contains<SuballocationSet>(SR)) {
+          State = State->add<SuballocationSet>(SR);
+          Updated = true;
+        }
+        if (DMR && !State->contains<SuballocationSet>(DMR)) {
           State = State->add<SuballocationSet>(DMR);
-        Updated = true;
+          Updated = true;
+        }
       } // else OK
     } // else ??? (ignore for now)
   } else {
@@ -419,7 +434,10 @@ PathDiagnosticPieceRef AllocationChecker::AllocPartitionBugVisitor::VisitNode(
 //===----------------------------------------------------------------------===//
 
 void ento::registerAllocationChecker(CheckerManager &Mgr) {
-  Mgr.registerChecker<AllocationChecker>();
+  auto *Checker = Mgr.registerChecker<AllocationChecker>();
+  Checker->ReportForUnknownAllocations =
+      Mgr.getAnalyzerOptions().getCheckerBooleanOption(
+          Checker, "ReportForUnknownAllocations");
 }
 
 bool ento::shouldRegisterAllocationChecker(const CheckerManager &Mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -1,0 +1,228 @@
+//===-- AllocationChecker.cpp - Allocation Checker -*- C++ -*--------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines checker that detects unrelated objects being allocated as
+// adjacent suballocations of the bigger memory allocation. It reports
+// situations when an address of such object escapes the function and
+// suggests narrowing the bounds of the escaping capability, so it covers only
+// the current suballocation, following the principle of least privilege.
+//
+//===----------------------------------------------------------------------===//
+#include "CHERIUtils.h"
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h"
+
+using namespace clang;
+using namespace ento;
+using namespace cheri;
+
+namespace {
+
+class AllocationChecker : public Checker<check::PostStmt<CastExpr>> {
+  BugType BT_1{this, "Allocation partitioning", "CHERI portability"};
+
+  class AllocPartitionBugVisitor : public BugReporterVisitor {
+  public:
+    AllocPartitionBugVisitor(const MemRegion *R) : Reg(R) {}
+
+    void Profile(llvm::FoldingSetNodeID &ID) const override {
+      static int X = 0;
+      ID.AddPointer(&X);
+      ID.AddPointer(Reg);
+    }
+
+    PathDiagnosticPieceRef VisitNode(const ExplodedNode *N,
+                                     BugReporterContext &BRC,
+                                     PathSensitiveBugReport &BR) override;
+
+  private:
+    const MemRegion *Reg;
+  };
+
+public:
+  void checkPostStmt(const CastExpr *CE, CheckerContext &C) const;
+
+private:
+  ExplodedNode *emitAllocationPartitionWarning(const CastExpr *CE,
+                                               CheckerContext &C,
+                                               const MemRegion *R) const;
+};
+
+} // namespace
+
+REGISTER_MAP_WITH_PROGRAMSTATE(AllocMap, const MemRegion *, QualType)
+REGISTER_MAP_WITH_PROGRAMSTATE(ShiftMap, const MemRegion *, const MemRegion *)
+
+namespace {
+std::pair<const MemRegion *, bool> getAllocationStart(const MemRegion *R,
+                                                      CheckerContext &C,
+                                                      bool ZeroShift = true) {
+  if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
+    const MemRegion *Base = ER->getSuperRegion();
+    return getAllocationStart(Base, C, ER->getIndex().isZeroConstant());
+  }
+  if (auto OrigR = C.getState()->get<ShiftMap>(R)) {
+    return std::make_pair(*OrigR, false);
+  }
+  return std::make_pair(R, ZeroShift);
+}
+
+bool isAllocation(const MemRegion *R) {
+  if (R->getAs<SymbolicRegion>())
+    return true;
+  if (const TypedValueRegion *TR = R->getAs<TypedValueRegion>()) {
+    return TR->getValueType()->isArrayType();
+  }
+  return false;
+}
+
+bool relatedTypes(const Type *Ty1, const Type *Ty2) {
+  if (Ty1 == Ty2)
+    return true;
+  if (Ty1->isArrayType())
+    return relatedTypes(Ty1->getArrayElementTypeNoTypeQual(), Ty2);
+  return false;
+}
+
+bool isGenPtrType(QualType Ty) {
+  return Ty->isVoidPointerType() ||
+         ((Ty->isPointerType() || Ty->isArrayType()) &&
+          Ty->getPointeeOrArrayElementType()->isCharType());
+}
+
+std::optional<QualType> getPrevType(ProgramStateRef State, const MemRegion *R) {
+  if (const QualType *PrevTy = State->get<AllocMap>(R))
+    return *PrevTy;
+  if (const TypedValueRegion *TR = R->getAs<TypedValueRegion>()) {
+    QualType Ty = TR->getValueType();
+    if ((Ty->isPointerType() || Ty->isArrayType()) && !isGenPtrType(Ty))
+      return Ty;
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+ExplodedNode *AllocationChecker::emitAllocationPartitionWarning(
+    const CastExpr *CE, CheckerContext &C, const MemRegion *MR) const {
+  if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
+    SmallString<256> Buf;
+    llvm::raw_svector_ostream OS(Buf);
+    OS << "Allocation partition: ";
+    describeCast(OS, CE, C.getASTContext().getLangOpts());
+    auto R = std::make_unique<PathSensitiveBugReport>(BT_1, OS.str(), ErrNode);
+    R->addVisitor(std::make_unique<AllocPartitionBugVisitor>(MR));
+    C.emitReport(std::move(R));
+    return ErrNode;
+  }
+  return nullptr;
+}
+
+void AllocationChecker::checkPostStmt(const CastExpr *CE,
+                                      CheckerContext &C) const {
+  if (CE->getCastKind() != CK_BitCast)
+    return;
+  SVal SrcVal = C.getSVal(CE->getSubExpr());
+  const MemRegion *MR = SrcVal.getAsRegion();
+  if (!MR)
+    return;
+  if (MR->getMemorySpace()->getKind() == MemSpaceRegion::CodeSpaceRegionKind)
+    return;
+
+  ProgramStateRef State = C.getState();
+  bool Updated = false;
+
+  std::pair<const MemRegion *, bool> StartPair = getAllocationStart(MR, C);
+  const MemRegion *SR = StartPair.first;
+  if (!isAllocation(SR))
+    return;
+  bool ZeroShift = StartPair.second;
+
+  SVal DstVal = C.getSVal(CE);
+  const MemRegion *DMR = DstVal.getAsRegion();
+  if (MR->getAs<ElementRegion>() && (!DMR || !DMR->getAs<ElementRegion>())) {
+    if (DstVal.isUnknown()) {
+      const LocationContext *LCtx = C.getLocationContext();
+      DstVal = C.getSValBuilder().conjureSymbolVal(
+          nullptr, CE, LCtx, CE->getType(), C.blockCount());
+      State = State->BindExpr(CE, LCtx, DstVal);
+      DMR = DstVal.getAsRegion();
+    }
+    if (DMR) {
+      State = State->set<ShiftMap>(DMR, SR);
+      Updated = true;
+    }
+  }
+
+  QualType DstTy = CE->getType().getUnqualifiedType();
+  if (!DstTy->isPointerType())
+    return;
+  if (DstTy->isVoidPointerType() || DstTy->getPointeeType()->isCharType())
+    return;
+
+  std::optional<QualType> PrevTy = getPrevType(State, SR);
+  if (PrevTy) {
+    if (SR != MR && !ZeroShift) {
+      const Type *Ty1 = PrevTy->getTypePtr()
+                            ->getPointeeOrArrayElementType()
+                            ->getUnqualifiedDesugaredType();
+      const Type *Ty2 = DstTy->getPointeeType()->getUnqualifiedDesugaredType();
+      if (!relatedTypes(Ty1, Ty2)) {
+        emitAllocationPartitionWarning(CE, C, SR);
+        return;
+      } // else OK
+    } // else ??? (ignore for now)
+  } else {
+    State = State->set<AllocMap>(SR, DstTy);
+    Updated = true;
+  }
+
+  if (Updated)
+    C.addTransition(State);
+}
+
+PathDiagnosticPieceRef AllocationChecker::AllocPartitionBugVisitor::VisitNode(
+    const ExplodedNode *N, BugReporterContext &BRC,
+    PathSensitiveBugReport &BR) {
+  const Stmt *S = N->getStmtForDiagnostics();
+  if (!S)
+    return nullptr;
+
+  const CastExpr *CE = dyn_cast<CastExpr>(S);
+  if (!CE || CE->getCastKind() != CK_BitCast)
+    return nullptr;
+
+  if (Reg != N->getSVal(CE->getSubExpr()).getAsRegion())
+    return nullptr;
+
+  SmallString<256> Buf;
+  llvm::raw_svector_ostream OS(Buf);
+  OS << "Previous partition: ";
+  describeCast(OS, CE, BRC.getASTContext().getLangOpts());
+
+  // Generate the extra diagnostic.
+  PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
+                                   N->getLocationContext());
+  return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
+}
+
+//===----------------------------------------------------------------------===//
+// Checker registration.
+//===----------------------------------------------------------------------===//
+
+void ento::registerAllocationChecker(CheckerManager &Mgr) {
+  Mgr.registerChecker<AllocationChecker>();
+}
+
+bool ento::shouldRegisterAllocationChecker(const CheckerManager &Mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -21,6 +21,7 @@
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h"
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h>
 
 using namespace clang;
 using namespace ento;
@@ -41,6 +42,10 @@ class AllocationChecker
   BugType BT_Default{this, "Allocation partitioning", "CHERI portability"};
   BugType BT_KnownReg{this, "Heap or static allocation partitioning",
                       "CHERI portability"};
+
+  const CallDescriptionSet IgnoreFnSet = {
+      {{CDM::SimpleFunc, {"free"}, 1}},
+  };
 
   class AllocPartitionBugVisitor : public BugReporterVisitor {
   public:
@@ -253,6 +258,9 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
 
 void AllocationChecker::checkPreCall(const CallEvent &Call,
                                      CheckerContext &C) const {
+  if (IgnoreFnSet.contains(Call))
+    return;
+
   ProgramStateRef State = C.getState();
   ExplodedNode *N = nullptr;
   bool Updated = false;

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -38,7 +38,7 @@ using EscapePair = std::pair<const MemRegion *, EscapeInfo>;
 namespace {
 class AllocationChecker
     : public Checker<check::PostStmt<CastExpr>, check::PreCall, check::PostCall,
-                     check::Bind, check::EndFunction> {
+                     check::Bind, check::EndFunction, check::DeadSymbols> {
   BugType BT_Default{this, "Allocation partitioning", "CHERI portability"};
   BugType BT_UnknownReg{this, "Unknown allocation partitioning",
                         "CHERI portability"};
@@ -80,6 +80,7 @@ public:
   void checkPostCall(const CallEvent &Call, CheckerContext &C) const;
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
   void checkEndFunction(const ReturnStmt *RS, CheckerContext &Ctx) const;
+  void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
   bool ReportForUnknownAllocations;
 
@@ -406,6 +407,22 @@ void AllocationChecker::checkEndFunction(const ReturnStmt *RS,
       return;
     }
   }
+}
+
+void AllocationChecker::checkDeadSymbols(SymbolReaper &SymReaper,
+                                         CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
+  ProgramStateRef State = C.getState();
+  bool Removed = false;
+  State = cleanDead<AllocMap>(State, SymReaper, Removed);
+  State = cleanDead<ShiftMap>(State, SymReaper, Removed);
+  State = cleanDead<SuballocationSet>(State, SymReaper, Removed);
+  State = cleanDead<BoundedSet>(State, SymReaper, Removed);
+
+  if (Removed)
+    C.addTransition(State);
 }
 
 PathDiagnosticPieceRef AllocationChecker::AllocPartitionBugVisitor::VisitNode(

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -28,7 +28,9 @@ using namespace cheri;
 namespace {
 
 class AllocationChecker : public Checker<check::PostStmt<CastExpr>> {
-  BugType BT_1{this, "Allocation partitioning", "CHERI portability"};
+  BugType BT_Default{this, "Allocation partitioning", "CHERI portability"};
+  BugType BT_KnownReg{this, "Heap or static allocation partitioning",
+                      "CHERI portability"};
 
   class AllocPartitionBugVisitor : public BugReporterVisitor {
   public:
@@ -119,7 +121,10 @@ ExplodedNode *AllocationChecker::emitAllocationPartitionWarning(
     llvm::raw_svector_ostream OS(Buf);
     OS << "Allocation partition: ";
     describeCast(OS, CE, C.getASTContext().getLangOpts());
-    auto R = std::make_unique<PathSensitiveBugReport>(BT_1, OS.str(), ErrNode);
+    const MemSpaceRegion *MemSpace = MR->getMemorySpace();
+    bool KnownReg = isa<HeapSpaceRegion, GlobalsSpaceRegion>(MemSpace);
+    auto R = std::make_unique<PathSensitiveBugReport>(
+        KnownReg ? BT_KnownReg : BT_Default, OS.str(), ErrNode);
     R->addVisitor(std::make_unique<AllocPartitionBugVisitor>(MR));
     C.emitReport(std::move(R));
     return ErrNode;

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -92,13 +92,24 @@ bool relatedTypes(const Type *Ty1, const Type *Ty2) {
     return true;
   if (Ty1->isArrayType())
     return relatedTypes(Ty1->getArrayElementTypeNoTypeQual(), Ty2);
+  if (Ty1->isRecordType()) {
+    if (RecordDecl *RD = Ty1->getAs<RecordType>()->getAsRecordDecl()) {
+      const RecordDecl::field_iterator &FirstField = RD->field_begin();
+      if (FirstField != RD->field_end()) {
+        const Type *FFTy = FirstField->getType()->getUnqualifiedDesugaredType();
+        return relatedTypes(FFTy, Ty2);
+      }
+    }
+  }
   return false;
 }
 
-bool isGenPtrType(QualType Ty) {
-  return Ty->isVoidPointerType() ||
-         ((Ty->isPointerType() || Ty->isArrayType()) &&
-          Ty->getPointeeOrArrayElementType()->isCharType());
+bool reportForType(QualType Ty) {
+  if (Ty->isVoidPointerType())
+    return false;
+  if (Ty->isPointerType() || Ty->isArrayType())
+    return !Ty->getPointeeOrArrayElementType()->isCharType();
+  return false;
 }
 
 std::optional<QualType> getPrevType(ProgramStateRef State, const MemRegion *R) {
@@ -106,7 +117,7 @@ std::optional<QualType> getPrevType(ProgramStateRef State, const MemRegion *R) {
     return *PrevTy;
   if (const TypedValueRegion *TR = R->getAs<TypedValueRegion>()) {
     QualType Ty = TR->getValueType();
-    if ((Ty->isPointerType() || Ty->isArrayType()) && !isGenPtrType(Ty))
+    if (reportForType(Ty))
       return Ty;
   }
   return std::nullopt;
@@ -169,9 +180,7 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
   }
 
   QualType DstTy = CE->getType().getUnqualifiedType();
-  if (!DstTy->isPointerType())
-    return;
-  if (DstTy->isVoidPointerType() || DstTy->getPointeeType()->isCharType())
+  if (!reportForType(DstTy))
     return;
 
   std::optional<QualType> PrevTy = getPrevType(State, SR);

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -107,8 +107,14 @@ bool relatedTypes(const Type *Ty1, const Type *Ty2) {
 bool reportForType(QualType Ty) {
   if (Ty->isVoidPointerType())
     return false;
-  if (Ty->isPointerType() || Ty->isArrayType())
-    return !Ty->getPointeeOrArrayElementType()->isCharType();
+  if (Ty->isPointerType() || Ty->isArrayType()) {
+    const Type *PTy = Ty->getPointeeOrArrayElementType();
+    if (PTy->isCharType())
+      return false;
+    if (PTy->isStructureTypeWithFlexibleArrayMember())
+      return false;
+    return true;
+  }
   return false;
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -18,6 +18,7 @@
 #include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
 #include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h"
 
@@ -25,21 +26,32 @@ using namespace clang;
 using namespace ento;
 using namespace cheri;
 
-namespace {
+struct EscapeInfo {
+  PointerEscapeKind Kind;
+  EscapeInfo(PointerEscapeKind K) : Kind(K) {};
+  bool operator==(const EscapeInfo &X) const { return Kind == X.Kind; }
+  void Profile(llvm::FoldingSetNodeID &ID) const { ID.AddInteger(Kind); }
+};
+using EscapePair = std::pair<const MemRegion *, EscapeInfo>;
 
-class AllocationChecker : public Checker<check::PostStmt<CastExpr>> {
+namespace {
+class AllocationChecker
+    : public Checker<check::PostStmt<CastExpr>, check::PreCall, check::Bind,
+                     check::EndFunction> {
   BugType BT_Default{this, "Allocation partitioning", "CHERI portability"};
   BugType BT_KnownReg{this, "Heap or static allocation partitioning",
                       "CHERI portability"};
 
   class AllocPartitionBugVisitor : public BugReporterVisitor {
   public:
-    AllocPartitionBugVisitor(const MemRegion *R) : Reg(R) {}
+    AllocPartitionBugVisitor(const MemRegion *P, const MemRegion *A)
+        : PrevAlloc(P), SubAlloc(A) {}
 
     void Profile(llvm::FoldingSetNodeID &ID) const override {
       static int X = 0;
       ID.AddPointer(&X);
-      ID.AddPointer(Reg);
+      ID.AddPointer(PrevAlloc);
+      ID.AddPointer(SubAlloc);
     }
 
     PathDiagnosticPieceRef VisitNode(const ExplodedNode *N,
@@ -47,32 +59,41 @@ class AllocationChecker : public Checker<check::PostStmt<CastExpr>> {
                                      PathSensitiveBugReport &BR) override;
 
   private:
-    const MemRegion *Reg;
+    const MemRegion *PrevAlloc;
+    const MemRegion *SubAlloc;
+    bool PrevReported = false;
   };
 
 public:
   void checkPostStmt(const CastExpr *CE, CheckerContext &C) const;
+  void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
+  void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
+  void checkEndFunction(const ReturnStmt *RS, CheckerContext &Ctx) const;
 
 private:
-  ExplodedNode *emitAllocationPartitionWarning(const CastExpr *CE,
-                                               CheckerContext &C,
-                                               const MemRegion *R) const;
+  ExplodedNode *emitAllocationPartitionWarning(CheckerContext &C,
+                                               const MemRegion *MR,
+                                               SourceRange SR,
+                                               StringRef Msg) const;
 };
 
 } // namespace
 
 REGISTER_MAP_WITH_PROGRAMSTATE(AllocMap, const MemRegion *, QualType)
 REGISTER_MAP_WITH_PROGRAMSTATE(ShiftMap, const MemRegion *, const MemRegion *)
+REGISTER_SET_WITH_PROGRAMSTATE(SuballocationSet, const MemRegion *)
 
 namespace {
-std::pair<const MemRegion *, bool> getAllocationStart(const MemRegion *R,
-                                                      CheckerContext &C,
+std::pair<const MemRegion *, bool> getAllocationStart(const ASTContext &ASTCtx,
+                                                      const MemRegion *R,
+                                                      ProgramStateRef State,
                                                       bool ZeroShift = true) {
   if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
     const MemRegion *Base = ER->getSuperRegion();
-    return getAllocationStart(Base, C, ER->getIndex().isZeroConstant());
+    return getAllocationStart(ASTCtx, Base, State,
+                              ZeroShift && ER->getIndex().isZeroConstant());
   }
-  if (auto OrigR = C.getState()->get<ShiftMap>(R)) {
+  if (const auto *OrigR = State->get<ShiftMap>(R)) {
     return std::make_pair(*OrigR, false);
   }
   return std::make_pair(R, ZeroShift);
@@ -87,17 +108,22 @@ bool isAllocation(const MemRegion *R) {
   return false;
 }
 
-bool relatedTypes(const Type *Ty1, const Type *Ty2) {
+bool relatedTypes(const ASTContext &ASTCtx, const Type *Ty1, const Type *Ty2) {
   if (Ty1 == Ty2)
     return true;
+  if (Ty1->isIntegerType()) {
+    if (Ty2->isIntegerType())
+      return ASTCtx.getTypeSize(Ty1) == ASTCtx.getTypeSize(Ty2);
+    return false;
+  }
   if (Ty1->isArrayType())
-    return relatedTypes(Ty1->getArrayElementTypeNoTypeQual(), Ty2);
+    return relatedTypes(ASTCtx, Ty1->getArrayElementTypeNoTypeQual(), Ty2);
   if (Ty1->isRecordType()) {
     if (RecordDecl *RD = Ty1->getAs<RecordType>()->getAsRecordDecl()) {
       const RecordDecl::field_iterator &FirstField = RD->field_begin();
       if (FirstField != RD->field_end()) {
         const Type *FFTy = FirstField->getType()->getUnqualifiedDesugaredType();
-        return relatedTypes(FFTy, Ty2);
+        return relatedTypes(ASTCtx, FFTy, Ty2);
       }
     }
   }
@@ -109,7 +135,10 @@ bool reportForType(QualType Ty) {
     return false;
   if (Ty->isPointerType() || Ty->isArrayType()) {
     const Type *PTy = Ty->getPointeeOrArrayElementType();
+    PTy = PTy->getUnqualifiedDesugaredType();
     if (PTy->isCharType())
+      return false;
+    if (PTy->isPointerType())
       return false;
     if (PTy->isStructureTypeWithFlexibleArrayMember())
       return false;
@@ -132,17 +161,24 @@ std::optional<QualType> getPrevType(ProgramStateRef State, const MemRegion *R) {
 } // namespace
 
 ExplodedNode *AllocationChecker::emitAllocationPartitionWarning(
-    const CastExpr *CE, CheckerContext &C, const MemRegion *MR) const {
+    CheckerContext &C, const MemRegion *MR, SourceRange SR,
+    StringRef Msg = "") const {
   if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
-    SmallString<256> Buf;
-    llvm::raw_svector_ostream OS(Buf);
-    OS << "Allocation partition: ";
-    describeCast(OS, CE, C.getASTContext().getLangOpts());
-    const MemSpaceRegion *MemSpace = MR->getMemorySpace();
-    bool KnownReg = isa<HeapSpaceRegion, GlobalsSpaceRegion>(MemSpace);
-    auto R = std::make_unique<PathSensitiveBugReport>(
-        KnownReg ? BT_KnownReg : BT_Default, OS.str(), ErrNode);
-    R->addVisitor(std::make_unique<AllocPartitionBugVisitor>(MR));
+    auto R = std::make_unique<PathSensitiveBugReport>(BT_Default, Msg, ErrNode);
+    R->addRange(SR);
+    R->markInteresting(MR);
+
+    const MemRegion *PrevAlloc =
+        getAllocationStart(C.getASTContext(), MR, C.getState()).first;
+    R->addVisitor(std::make_unique<AllocPartitionBugVisitor>(
+        PrevAlloc == MR ? nullptr : PrevAlloc, MR));
+
+    if (const DeclRegion *PrevDecl = getAllocationDecl(PrevAlloc)) {
+      auto DeclLoc = PathDiagnosticLocation::create(PrevDecl->getDecl(),
+                                                    C.getSourceManager());
+      R->addNote("Original allocation", DeclLoc);
+    }
+
     C.emitReport(std::move(R));
     return ErrNode;
   }
@@ -157,13 +193,16 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
   const MemRegion *MR = SrcVal.getAsRegion();
   if (!MR)
     return;
-  if (MR->getMemorySpace()->getKind() == MemSpaceRegion::CodeSpaceRegionKind)
+  const MemSpaceRegion *MemSpace = MR->getMemorySpace();
+  if (!isa<HeapSpaceRegion, GlobalsSpaceRegion, StackSpaceRegion>(MemSpace))
     return;
 
+  const ASTContext &ASTCtx = C.getASTContext();
   ProgramStateRef State = C.getState();
   bool Updated = false;
 
-  std::pair<const MemRegion *, bool> StartPair = getAllocationStart(MR, C);
+  std::pair<const MemRegion *, bool> StartPair =
+      getAllocationStart(ASTCtx, MR, State);
   const MemRegion *SR = StartPair.first;
   if (!isAllocation(SR))
     return;
@@ -196,9 +235,11 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
                             ->getPointeeOrArrayElementType()
                             ->getUnqualifiedDesugaredType();
       const Type *Ty2 = DstTy->getPointeeType()->getUnqualifiedDesugaredType();
-      if (!relatedTypes(Ty1, Ty2)) {
-        emitAllocationPartitionWarning(CE, C, SR);
-        return;
+      if (!relatedTypes(ASTCtx, Ty1, Ty2)) {
+        State = State->add<SuballocationSet>(SR);
+        if (DMR)
+          State = State->add<SuballocationSet>(DMR);
+        Updated = true;
       } // else OK
     } // else ??? (ignore for now)
   } else {
@@ -210,6 +251,95 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
     C.addTransition(State);
 }
 
+void AllocationChecker::checkPreCall(const CallEvent &Call,
+                                     CheckerContext &C) const {
+  ProgramStateRef State = C.getState();
+  ExplodedNode *N = nullptr;
+  bool Updated = false;
+  for (unsigned Arg = 0; Arg < Call.getNumArgs(); ++Arg) {
+    const Expr *ArgExpr = Call.getArgExpr(Arg);
+    if (const MemRegion *MR = C.getSVal(ArgExpr).getAsRegion()) {
+      if (State->contains<SuballocationSet>(MR)) {
+        SmallString<256> Buf;
+        llvm::raw_svector_ostream OS(Buf);
+        OS << "Pointer to suballocation passed to function as " << (Arg + 1);
+        if (Arg + 1 < 11) {
+          switch (Arg + 1) {
+          case 1:
+            OS << "st";
+            break;
+          case 2:
+            OS << "nd";
+            break;
+          case 3:
+            OS << "rd";
+            break;
+          default:
+            OS << "th";
+            break;
+          }
+        }
+
+        OS << " argument";
+        OS << " (consider narrowing the bounds for suballocation)";
+        N = emitAllocationPartitionWarning(C, MR, ArgExpr->getSourceRange(),
+                                           OS.str());
+        if (N) {
+          State = State->remove<SuballocationSet>(MR);
+          Updated = true;
+        }
+      }
+    }
+  }
+  if (Updated)
+    C.addTransition(State, N ? N : C.getPredecessor());
+}
+
+void AllocationChecker::checkBind(SVal L, SVal V, const Stmt *S,
+                                  CheckerContext &C) const {
+  const MemRegion *Dst = L.getAsRegion();
+  if (!Dst || !isa<FieldRegion>(Dst))
+    return;
+
+  ProgramStateRef State = C.getState();
+  const MemRegion *Val = V.getAsRegion();
+  if (Val && State->contains<SuballocationSet>(Val)) {
+    ExplodedNode *N = emitAllocationPartitionWarning(
+        C, Val, S->getSourceRange(),
+        "Pointer to suballocation escaped on assign"
+        " (consider narrowing the bounds for suballocation)");
+    if (N) {
+      State = State->remove<SuballocationSet>(Val);
+      C.addTransition(State, N);
+    }
+    return;
+  }
+}
+
+void AllocationChecker::checkEndFunction(const ReturnStmt *RS,
+                                         CheckerContext &C) const {
+  if (!RS)
+    return;
+  const Expr *RV = RS->getRetValue();
+  if (!RV)
+    return;
+
+  llvm::SmallVector<EscapePair, 2> Escaped;
+  if (const MemRegion *MR = C.getSVal(RV).getAsRegion()) {
+    if (C.getState()->contains<SuballocationSet>(MR)) {
+      ExplodedNode *N = emitAllocationPartitionWarning(
+          C, MR, RS->getSourceRange(),
+          "Pointer to suballocation returned from function"
+          " (consider narrowing the bounds for suballocation)");
+      if (N) {
+        ProgramStateRef State = N->getState()->remove<SuballocationSet>(MR);
+        C.addTransition(State, N);
+      }
+      return;
+    }
+  }
+}
+
 PathDiagnosticPieceRef AllocationChecker::AllocPartitionBugVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BRC,
     PathSensitiveBugReport &BR) {
@@ -217,22 +347,33 @@ PathDiagnosticPieceRef AllocationChecker::AllocPartitionBugVisitor::VisitNode(
   if (!S)
     return nullptr;
 
-  const CastExpr *CE = dyn_cast<CastExpr>(S);
-  if (!CE || CE->getCastKind() != CK_BitCast)
-    return nullptr;
+  if (const CastExpr *CE = dyn_cast<CastExpr>(S)) {
+    if (CE->getCastKind() != CK_BitCast)
+      return nullptr;
 
-  if (Reg != N->getSVal(CE->getSubExpr()).getAsRegion())
-    return nullptr;
+    SmallString<256> Buf;
+    llvm::raw_svector_ostream OS(Buf);
 
-  SmallString<256> Buf;
-  llvm::raw_svector_ostream OS(Buf);
-  OS << "Previous partition: ";
-  describeCast(OS, CE, BRC.getASTContext().getLangOpts());
+    if (!PrevReported && PrevAlloc &&
+        PrevAlloc == N->getSVal(CE->getSubExpr()).getAsRegion()) {
+      OS << "Previous partition: ";
+      PrevReported = true;
+    } else if (SubAlloc == N->getSVal(CE).getAsRegion() &&
+               N->getState()->contains<SuballocationSet>(SubAlloc) &&
+               !N->getFirstPred()->getState()->contains<SuballocationSet>(
+                   SubAlloc)) {
+      OS << "Allocation partition: ";
+    } else
+      return nullptr;
 
-  // Generate the extra diagnostic.
-  PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
-                                   N->getLocationContext());
-  return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
+    describeCast(OS, CE, BRC.getASTContext().getLangOpts());
+    PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
+                                     N->getLocationContext());
+    auto Ev = std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
+    Ev->setPrunable(false);
+    return Ev;
+  }
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/AllocationChecker.cpp
@@ -37,14 +37,19 @@ using EscapePair = std::pair<const MemRegion *, EscapeInfo>;
 
 namespace {
 class AllocationChecker
-    : public Checker<check::PostStmt<CastExpr>, check::PreCall, check::Bind,
-                     check::EndFunction> {
+    : public Checker<check::PostStmt<CastExpr>, check::PreCall, check::PostCall,
+                     check::Bind, check::EndFunction> {
   BugType BT_Default{this, "Allocation partitioning", "CHERI portability"};
   BugType BT_KnownReg{this, "Heap or static allocation partitioning",
                       "CHERI portability"};
 
   const CallDescriptionSet IgnoreFnSet = {
-      {{CDM::SimpleFunc, {"free"}, 1}},
+      {CDM::SimpleFunc, {"free"}, 1},
+  };
+
+  const CallDescriptionSet CheriBoundsFnSet = {
+      {CDM::SimpleFunc, {"cheri_bounds_set"}, 2},
+      {CDM::SimpleFunc, {"cheri_bounds_set_exact"}, 2},
   };
 
   class AllocPartitionBugVisitor : public BugReporterVisitor {
@@ -72,6 +77,7 @@ class AllocationChecker
 public:
   void checkPostStmt(const CastExpr *CE, CheckerContext &C) const;
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
+  void checkPostCall(const CallEvent &Call, CheckerContext &C) const;
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
   void checkEndFunction(const ReturnStmt *RS, CheckerContext &Ctx) const;
 
@@ -87,6 +93,7 @@ private:
 REGISTER_MAP_WITH_PROGRAMSTATE(AllocMap, const MemRegion *, QualType)
 REGISTER_MAP_WITH_PROGRAMSTATE(ShiftMap, const MemRegion *, const MemRegion *)
 REGISTER_SET_WITH_PROGRAMSTATE(SuballocationSet, const MemRegion *)
+REGISTER_SET_WITH_PROGRAMSTATE(BoundedSet, const MemRegion *)
 
 namespace {
 std::pair<const MemRegion *, bool> getAllocationStart(const ASTContext &ASTCtx,
@@ -198,20 +205,24 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
   const MemRegion *MR = SrcVal.getAsRegion();
   if (!MR)
     return;
-  const MemSpaceRegion *MemSpace = MR->getMemorySpace();
-  if (!isa<HeapSpaceRegion, GlobalsSpaceRegion, StackSpaceRegion>(MemSpace))
+
+  ProgramStateRef State = C.getState();
+  if (State->contains<BoundedSet>(MR))
     return;
 
   const ASTContext &ASTCtx = C.getASTContext();
-  ProgramStateRef State = C.getState();
   bool Updated = false;
-
   std::pair<const MemRegion *, bool> StartPair =
       getAllocationStart(ASTCtx, MR, State);
+
   const MemRegion *SR = StartPair.first;
   if (!isAllocation(SR))
     return;
   bool ZeroShift = StartPair.second;
+
+  const MemSpaceRegion *MemSpace = SR->getMemorySpace();
+  if (!isa<HeapSpaceRegion, GlobalsSpaceRegion, StackSpaceRegion>(MemSpace))
+    return;
 
   SVal DstVal = C.getSVal(CE);
   const MemRegion *DMR = DstVal.getAsRegion();
@@ -258,7 +269,7 @@ void AllocationChecker::checkPostStmt(const CastExpr *CE,
 
 void AllocationChecker::checkPreCall(const CallEvent &Call,
                                      CheckerContext &C) const {
-  if (IgnoreFnSet.contains(Call))
+  if (IgnoreFnSet.contains(Call) || CheriBoundsFnSet.contains(Call))
     return;
 
   ProgramStateRef State = C.getState();
@@ -301,6 +312,25 @@ void AllocationChecker::checkPreCall(const CallEvent &Call,
   }
   if (Updated)
     C.addTransition(State, N ? N : C.getPredecessor());
+}
+
+void AllocationChecker::checkPostCall(const CallEvent &Call,
+                                      CheckerContext &C) const {
+  if (!CheriBoundsFnSet.contains(Call))
+    return;
+  const MemRegion *MR = C.getSVal(Call.getArgExpr(0)).getAsRegion();
+  const MemRegion *ResMR = C.getSVal(Call.getOriginExpr()).getAsRegion();
+  if (!MR || !ResMR)
+    return;
+
+  ProgramStateRef State = C.getState();
+  if (!State->contains<SuballocationSet>(MR) ||
+      !State->contains<SuballocationSet>(ResMR))
+    return;
+
+  State = State->remove<SuballocationSet>(ResMR);
+  State = State->add<BoundedSet>(ResMR);
+  C.addTransition(State);
 }
 
 void AllocationChecker::checkBind(SVal L, SVal V, const Stmt *S,

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -53,17 +53,16 @@ bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {
 }
 
 namespace {
+
 void printType(raw_ostream &OS, const QualType &Ty, const PrintingPolicy &PP) {
-  OS << "'";
-  Ty.print(OS, PP);
-  OS << "'";
-  const QualType &CanTy = Ty.getCanonicalType();
-  if (CanTy != Ty) {
-    OS << " (aka '";
-    CanTy.print(OS, PP);
-    OS << "')";
+  std::string TyStr = Ty.getAsString(PP);
+  OS << "'" << TyStr << "'";
+  std::string CanTyStr = Ty.getCanonicalType().getAsString(PP);
+  if (CanTyStr != TyStr) {
+    OS << " (aka '" << CanTyStr << "')";
   }
 }
+
 } // namespace
 
 void describeCast(raw_ostream &OS, const CastExpr *CE,
@@ -74,6 +73,14 @@ void describeCast(raw_ostream &OS, const CastExpr *CE,
   printType(OS, CE->getSubExpr()->getType(), PP);
   OS << " to ";
   printType(OS, CE->getType(), PP);
+}
+
+const DeclRegion *getAllocationDecl(const MemRegion *MR) {
+  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
+    return DR;
+  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
+    return getAllocationDecl(ER->getSuperRegion());
+  return nullptr;
 }
 
 } // namespace cheri

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "CHERIUtils.h"
+#include <clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h>
+
+#include "clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h"
 
 namespace clang {
 namespace ento {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -35,6 +35,23 @@ bool isGenericPointerType(const QualType T, bool AcceptCharPtr) {
                                     T->getPointeeType()->isCharType());
 }
 
+bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {
+  QualType Ty = OrigTy.getCanonicalType();
+  if (Ty->isCHERICapabilityType(Ctx, true))
+    return true;
+  if (const auto *Record = dyn_cast<RecordType>(Ty)) {
+    for (const auto *Field : Record->getDecl()->fields()) {
+      if (hasCapability(Field->getType(), Ctx))
+        return true;
+    }
+    return false;
+  }
+  if (const auto *Array = dyn_cast<ArrayType>(Ty)) {
+    return hasCapability(Array->getElementType(), Ctx);
+  }
+  return false;
+}
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -52,14 +52,28 @@ bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {
   return false;
 }
 
+namespace {
+void printType(raw_ostream &OS, const QualType &Ty, const PrintingPolicy &PP) {
+  OS << "'";
+  Ty.print(OS, PP);
+  OS << "'";
+  const QualType &CanTy = Ty.getCanonicalType();
+  if (CanTy != Ty) {
+    OS << " (aka '";
+    CanTy.print(OS, PP);
+    OS << "')";
+  }
+}
+} // namespace
+
 void describeCast(raw_ostream &OS, const CastExpr *CE,
                   const LangOptions &LangOpts) {
+  const PrintingPolicy &PP = PrintingPolicy(LangOpts);
   OS << (dyn_cast<ImplicitCastExpr>(CE) ? "implicit" : "explicit");
-  OS << " cast from '";
-  CE->getSubExpr()->getType().print(OS, PrintingPolicy(LangOpts));
-  OS << "' to '";
-  CE->getType().print(OS, PrintingPolicy(LangOpts));
-  OS << "'";
+  OS << " cast from ";
+  printType(OS, CE->getSubExpr()->getType(), PP);
+  OS << " to ";
+  printType(OS, CE->getType(), PP);
 }
 
 } // namespace cheri

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -1,0 +1,27 @@
+//===-- CHERIUtils.h  -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CHERIUtils.h"
+
+namespace clang {
+namespace ento {
+namespace cheri {
+
+bool isPureCapMode(const ASTContext &C) {
+  return C.getTargetInfo().areAllPointersCapabilities();
+}
+
+bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
+  if (!Type->isPointerType())
+    return false;
+  return Type->getPointeeType()->isCHERICapabilityType(Ctx, true);
+}
+
+} // namespace cheri
+} // namespace ento
+} // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -30,9 +30,9 @@ CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
   return ASTCtx.getTypeAlignInChars(ASTCtx.VoidPtrTy);
 }
 
-bool isGenericPointerType(const QualType T) {
-  return T->isVoidPointerType() ||
-         (T->isPointerType() && T->getPointeeType()->isCharType());
+bool isGenericPointerType(const QualType T, bool AcceptCharPtr) {
+  return T->isVoidPointerType() || (AcceptCharPtr && T->isPointerType() &&
+                                    T->getPointeeType()->isCharType());
 }
 
 } // namespace cheri

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -52,6 +52,16 @@ bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {
   return false;
 }
 
+void describeCast(raw_ostream &OS, const CastExpr *CE,
+                  const LangOptions &LangOpts) {
+  OS << (dyn_cast<ImplicitCastExpr>(CE) ? "implicit" : "explicit");
+  OS << " cast from '";
+  CE->getSubExpr()->getType().print(OS, PrintingPolicy(LangOpts));
+  OS << "' to '";
+  CE->getType().print(OS, PrintingPolicy(LangOpts));
+  OS << "'";
+}
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.cpp
@@ -22,6 +22,19 @@ bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
   return Type->getPointeeType()->isCHERICapabilityType(Ctx, true);
 }
 
+CharUnits getCapabilityTypeSize(ASTContext &ASTCtx) {
+  return ASTCtx.getTypeSizeInChars(ASTCtx.VoidPtrTy);
+}
+
+CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
+  return ASTCtx.getTypeAlignInChars(ASTCtx.VoidPtrTy);
+}
+
+bool isGenericPointerType(const QualType T) {
+  return T->isVoidPointerType() ||
+         (T->isPointerType() && T->getPointeeType()->isCharType());
+}
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -25,6 +25,8 @@ CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx);
 
 bool isGenericPointerType(const QualType T, bool AcceptCharPtr = true);
 
+bool hasCapability(const QualType OrigTy, ASTContext &Ctx);
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -23,7 +23,7 @@ CharUnits getCapabilityTypeSize(ASTContext &ASTCtx);
 
 CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx);
 
-bool isGenericPointerType(const QualType T);
+bool isGenericPointerType(const QualType T, bool AcceptCharPtr = true);
 
 } // namespace cheri
 } // namespace ento

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -27,6 +27,9 @@ bool isGenericPointerType(const QualType T, bool AcceptCharPtr = true);
 
 bool hasCapability(const QualType OrigTy, ASTContext &Ctx);
 
+void describeCast(raw_ostream &OS, const CastExpr *CE,
+                  const LangOptions &LangOpts);
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -1,0 +1,26 @@
+//===-- CHERIUtils.h  -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_CHERI_CHERIUTILS_H
+#define LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_CHERI_CHERIUTILS_H
+
+#include "clang/StaticAnalyzer/Core/Checker.h"
+
+namespace clang {
+namespace ento {
+namespace cheri {
+
+bool isPureCapMode(const ASTContext &C);
+
+bool isPointerToCapTy(const QualType Type, ASTContext &Ctx);
+
+} // namespace cheri
+} // namespace ento
+} // namespace clang
+
+#endif // LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_CHERI_CHERIUTILS_H

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -30,6 +30,8 @@ bool hasCapability(const QualType OrigTy, ASTContext &Ctx);
 void describeCast(raw_ostream &OS, const CastExpr *CE,
                   const LangOptions &LangOpts);
 
+const DeclRegion *getAllocationDecl(const MemRegion *MR);
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -10,6 +10,8 @@
 #define LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_CHERI_CHERIUTILS_H
 
 #include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h"
+#include <clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h>
 
 namespace clang {
 namespace ento {
@@ -33,6 +35,42 @@ void describeCast(raw_ostream &OS, const CastExpr *CE,
 const DeclRegion *getAllocationDecl(const MemRegion *MR);
 
 } // namespace cheri
+
+template <typename C>
+inline typename ProgramStateTrait<C>::key_type
+getKey(const std::pair<typename ProgramStateTrait<C>::key_type,
+                       typename ProgramStateTrait<C>::value_type> &P) {
+  return P.first;
+}
+
+template <typename C>
+inline typename ProgramStateTrait<C>::key_type
+getKey(const typename ProgramStateTrait<C>::key_type &K) {
+  return K;
+}
+
+inline bool isLive(SymbolReaper &SymReaper, const MemRegion *MR) {
+  return SymReaper.isLiveRegion(MR);
+}
+
+inline bool isLive(SymbolReaper &SymReaper, SymbolRef Sym) {
+  return SymReaper.isLive(Sym);
+}
+
+template <typename M>
+ProgramStateRef cleanDead(ProgramStateRef State, SymbolReaper &SymReaper,
+                          bool &Removed) {
+  const typename ProgramStateTrait<M>::data_type &Map = State->get<M>();
+  for (const auto &E : Map) {
+    const typename ProgramStateTrait<M>::key_type &K = getKey<M>(E);
+    if (isLive(SymReaper, K))
+      continue;
+    State = State->remove<M>(K);
+    Removed = true;
+  }
+  return State;
+}
+
 } // namespace ento
 } // namespace clang
 

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CHERIUtils.h
@@ -19,6 +19,12 @@ bool isPureCapMode(const ASTContext &C);
 
 bool isPointerToCapTy(const QualType Type, ASTContext &Ctx);
 
+CharUnits getCapabilityTypeSize(ASTContext &ASTCtx);
+
+CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx);
+
+bool isGenericPointerType(const QualType T);
+
 } // namespace cheri
 } // namespace ento
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -1,0 +1,316 @@
+//=== CapabilityAlignmentChecker.cpp - Capability Alignment Checker -*- C++ ==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tracks pointer values alignment and reports pointer casts of underaligned
+// values to types with strict alignment requirements.
+//   * Cast Align Bug
+//       Cast of underaligned pointer value to the pointer type with stricter
+//       alignment requirements.
+//   * CapCastAlignBug
+//       Special case for CHERI: casts to pointer to capability. Storing
+//       capabilities at not capability-aligned addressed will result in
+//       stored capability losing its tag.
+//
+// Currently, this checker (deliberately) does not take into account:
+//    - alignment of static and automatic allocations, enforced by ABI (other
+//    than implied by variable types),
+//    - alignment of fields that is guaranteed implicitly by the alignment of
+//    the whole object and current field offset.
+// Relying on this could make the code less portable and easier to break, but
+// it may be a good idea to introduce a separate warning type that will not
+// be reported for pointer values properly aligned due to the reasons above,
+// so that it will produce just a few reports for critical bugs only.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CHERIUtils.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h>
+
+using namespace clang;
+using namespace ento;
+using namespace cheri;
+
+namespace {
+class CapabilityAlignmentChecker
+    : public Checker<check::PreStmt<CastExpr>, check::PostStmt<CastExpr>,
+                     check::PostStmt<BinaryOperator>> {
+  std::unique_ptr<BugType> CastAlignBug;
+
+public:
+  CapabilityAlignmentChecker();
+
+  void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
+  void checkPostStmt(const CastExpr *BO, CheckerContext &C) const;
+  void checkPreStmt(const CastExpr *BO, CheckerContext &C) const;
+};
+
+} // namespace
+
+REGISTER_MAP_WITH_PROGRAMSTATE(TrailingZerosMap, SymbolRef, int)
+
+CapabilityAlignmentChecker::CapabilityAlignmentChecker() {
+  CastAlignBug.reset(new BugType(this, "Cast increases required alignment",
+                                 "CHERI portability"));
+}
+
+namespace {
+
+int getTrailingZerosCount(const SVal &V, CheckerContext &C);
+
+int getTrailingZerosCount(SymbolRef Sym, CheckerContext &C) {
+  const int *Align = C.getState()->get<TrailingZerosMap>(Sym);
+  if (Align)
+    return *Align;
+  return -1;
+}
+
+int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
+  R = R->StripCasts();
+
+  if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
+    const MemRegion *Base = ER->getBaseRegion();
+    int BaseTZC = -1;
+    if (const SymbolicRegion *SymbBase = Base->getSymbolicBase())
+      BaseTZC = getTrailingZerosCount(SymbBase->getSymbol(), C);
+    else
+      BaseTZC = getTrailingZerosCount(Base, C);
+    int IdxTZC = getTrailingZerosCount(ER->getIndex(), C);
+    if (BaseTZC >= 0 && IdxTZC >= 0)
+      return std::min(BaseTZC, IdxTZC);
+  }
+
+  if (R->getSymbolicBase())
+    return -1;
+
+  const TypedValueRegion *TR = R->getAs<TypedValueRegion>();
+  if (!TR)
+    return -1;
+
+  ASTContext &ASTCtx = C.getASTContext();
+  const QualType &PT = TR->getDesugaredValueType(ASTCtx);
+  unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
+  return llvm::APSInt::getUnsigned(A).countTrailingZeros();
+}
+
+int getTrailingZerosCount(const SVal &V, CheckerContext &C) {
+  if (V.isUnknownOrUndef())
+    return -1;
+
+  if (V.isConstant()) {
+    if (auto LV = V.getAs<loc::ConcreteInt>())
+      return LV->getValue()->countTrailingZeros();
+    if (auto NV = V.getAs<nonloc::ConcreteInt>())
+      return NV->getValue()->countTrailingZeros();
+    return -1;
+  }
+
+  if (SymbolRef Sym = V.getAsSymbol()) {
+    int Res = getTrailingZerosCount(Sym, C);
+    if (Res >= 0)
+      return Res;
+  }
+
+  if (const MemRegion *R = V.getAsRegion()) {
+    return getTrailingZerosCount(R, C);
+  }
+
+  return -1;
+}
+
+int getTrailingZerosCount(const Expr *E, CheckerContext &C) {
+  const SVal &V = C.getSVal(E);
+  return getTrailingZerosCount(V, C);
+}
+
+} // namespace
+
+void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
+                                              CheckerContext &C) const {
+  if (CE->getCastKind() != CastKind::CK_BitCast)
+    return;
+
+  const Expr *Src = CE->getSubExpr();
+  const QualType &DstType = CE->getType();
+  if (!Src->getType()->isPointerType() || !DstType->isPointerType())
+    return;
+
+  ASTContext &ASTCtx = C.getASTContext();
+  int SrcTZC = getTrailingZerosCount(CE->getSubExpr(), C);
+  if (SrcTZC < 0)
+    return;
+  if ((unsigned)SrcTZC >= sizeof(unsigned int) * 8)
+    return; // Too aligned, probably a Zero
+  unsigned SrcAlign = (1U << SrcTZC);
+  const QualType &DstPointeeTy = DstType->getPointeeType();
+  unsigned DstReqAlign = ASTCtx.getTypeAlignInChars(DstPointeeTy).getQuantity();
+  if (SrcAlign < DstReqAlign) {
+    if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
+      SmallString<350> ErrorMessage;
+      llvm::raw_svector_ostream OS(ErrorMessage);
+      OS << "Cast increases required alignment: ";
+      OS << SrcAlign;
+      OS << " -> ";
+      OS << DstReqAlign;
+      OS << ")";
+      auto W = std::make_unique<PathSensitiveBugReport>(*CastAlignBug,
+                                                        ErrorMessage, ErrNode);
+      W->addRange(CE->getSourceRange());
+      C.emitReport(std::move(W));
+    }
+  }
+}
+
+void printAlign(raw_ostream &OS, unsigned TZC) {
+  OS << "aligned(";
+  if (TZC < sizeof(unsigned long) * 8)
+    OS << (1LU << TZC);
+  else
+    OS << "2^(" << TZC << ")";
+  OS << ")";
+}
+
+void CapabilityAlignmentChecker::checkPostStmt(const CastExpr *CE,
+                                               CheckerContext &C) const {
+  CastKind CK = CE->getCastKind();
+  if (CK != CastKind::CK_BitCast && CK != CK_PointerToIntegral &&
+      CK != CK_IntegralToPointer && CK != CK_LValueToRValue)
+    return;
+
+  int DstTZC = getTrailingZerosCount(CE, C);
+  int SrcTZC = getTrailingZerosCount(CE->getSubExpr(), C);
+
+  if (DstTZC < SrcTZC) {
+    SVal DstVal = C.getSVal(CE);
+    ProgramStateRef State = C.getState();
+    if (DstVal.isUnknown()) {
+      const LocationContext *LCtx = C.getLocationContext();
+      DstVal = C.getSValBuilder().conjureSymbolVal(
+          nullptr, CE, LCtx, CE->getType(), C.blockCount());
+      State = State->BindExpr(CE, LCtx, DstVal);
+    }
+    if (SymbolRef Sym = DstVal.getAsSymbol()) {
+      State = State->set<TrailingZerosMap>(Sym, SrcTZC);
+      const NoteTag *Tag =
+          C.getNoteTag([SrcTZC](PathSensitiveBugReport &BR) -> std::string {
+            SmallString<80> Msg;
+            llvm::raw_svector_ostream OS(Msg);
+            OS << "Alignment: ";
+            printAlign(OS, SrcTZC);
+            return std::string(OS.str());
+          });
+      C.addTransition(State, C.getPredecessor(), Tag);
+    }
+  }
+}
+
+void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
+                                               CheckerContext &C) const {
+  int LeftTZ = getTrailingZerosCount(BO->getLHS(), C);
+  if (LeftTZ < 0)
+    return;
+  int RightTZ = getTrailingZerosCount(BO->getRHS(), C);
+  if (RightTZ < 0 && !BO->isShiftOp() && !BO->isShiftAssignOp())
+    return;
+
+  ProgramStateRef State = C.getState();
+  SVal ResVal = C.getSVal(BO);
+  if (ResVal.isUnknown()) {
+    const LocationContext *LCtx = C.getLocationContext();
+    ResVal = C.getSValBuilder().conjureSymbolVal(nullptr, BO, LCtx,
+                                                 BO->getType(), C.blockCount());
+    State = State->BindExpr(BO, LCtx, ResVal);
+  }
+
+  SymbolRef ResSymb = ResVal.getAsSymbol();
+  if (!ResSymb)
+    return;
+
+  const SVal &RHSVal = C.getSVal(BO->getRHS());
+  int BitWidth = C.getASTContext().getTypeSize(BO->getType());
+  int Res = 0;
+  int RHSConst = 0;
+  BinaryOperator::Opcode OpCode = BO->getOpcode();
+  switch (OpCode) {
+  case clang::BO_And:
+  case clang::BO_AndAssign:
+    Res = std::max(LeftTZ, RightTZ);
+    break;
+  case clang::BO_Or:
+  case clang::BO_OrAssign:
+    Res = std::min(LeftTZ, RightTZ);
+    break;
+  case clang::BO_Add:
+  case clang::BO_AddAssign:
+  case clang::BO_Sub:
+  case clang::BO_SubAssign:
+    if (BO->getLHS()->getType()->isPointerType()) {
+      const QualType &PointeeTy = BO->getLHS()->getType()->getPointeeType();
+      const CharUnits A = C.getASTContext().getTypeAlignInChars(PointeeTy);
+      RightTZ +=
+          llvm::APSInt::getUnsigned(A.getQuantity()).countTrailingZeros();
+    }
+    Res = std::min(LeftTZ, RightTZ);
+    break;
+  case clang::BO_Mul:
+  case clang::BO_MulAssign:
+    Res = LeftTZ + RightTZ;
+    break;
+  case clang::BO_Div:
+  case clang::BO_DivAssign:
+    Res = LeftTZ - RightTZ;
+    break;
+  case clang::BO_Shl:
+  case clang::BO_ShlAssign:
+  case clang::BO_Shr:
+  case clang::BO_ShrAssign:
+    if (RHSVal.isConstant()) {
+      if (auto NV = RHSVal.getAs<nonloc::ConcreteInt>())
+        RHSConst = NV->getValue()->getExtValue();
+    }
+    if (BO->getOpcode() == BO_Shl || BO->getOpcode() == BO_ShlAssign)
+      Res = LeftTZ + RHSConst;
+    else
+      Res = RHSVal.isConstant() ? LeftTZ - RHSConst : BitWidth;
+    break;
+  default:
+    return;
+  }
+
+  if (Res <= 0)
+    Res = 0;
+  if (Res > BitWidth)
+    Res = BitWidth;
+
+  State = State->set<TrailingZerosMap>(ResSymb, Res);
+  const NoteTag *Tag =
+      C.getNoteTag([LeftTZ, RightTZ, Res,
+                    OpCode](PathSensitiveBugReport &BR) -> std::string {
+        SmallString<80> Msg;
+        llvm::raw_svector_ostream OS(Msg);
+        OS << "Alignment: ";
+        printAlign(OS, LeftTZ);
+        OS << " " << BinaryOperator::getOpcodeStr(OpCode) << " ";
+        printAlign(OS, RightTZ);
+        OS << " => ";
+        printAlign(OS, Res);
+        return std::string(OS.str());
+      });
+  C.addTransition(State, C.getPredecessor(), Tag);
+}
+
+void ento::registerCapabilityAlignmentChecker(CheckerManager &mgr) {
+  mgr.registerChecker<CapabilityAlignmentChecker>();
+}
+
+bool ento::shouldRegisterCapabilityAlignmentChecker(const CheckerManager &Mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -51,6 +51,25 @@ public:
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkPostStmt(const CastExpr *BO, CheckerContext &C) const;
   void checkPreStmt(const CastExpr *BO, CheckerContext &C) const;
+
+private:
+  class AlignmentBugVisitor : public BugReporterVisitor {
+  public:
+    AlignmentBugVisitor(SymbolRef SR) : Sym(SR) {}
+
+    void Profile(llvm::FoldingSetNodeID &ID) const override {
+      static int X = 0;
+      ID.AddPointer(&X);
+      ID.AddPointer(Sym);
+    }
+
+    PathDiagnosticPieceRef VisitNode(const ExplodedNode *N,
+                                     BugReporterContext &BRC,
+                                     PathSensitiveBugReport &BR) override;
+
+  private:
+    SymbolRef Sym;
+  };
 };
 
 } // namespace
@@ -64,10 +83,12 @@ CapabilityAlignmentChecker::CapabilityAlignmentChecker() {
 
 namespace {
 
-int getTrailingZerosCount(const SVal &V, CheckerContext &C);
+int getTrailingZerosCount(const SVal &V, ProgramStateRef State,
+                          ASTContext &ASTCtx);
 
-int getTrailingZerosCount(SymbolRef Sym, CheckerContext &C) {
-  const int *Align = C.getState()->get<TrailingZerosMap>(Sym);
+int getTrailingZerosCount(SymbolRef Sym, ProgramStateRef State,
+                          ASTContext &ASTCtx) {
+  const int *Align = State->get<TrailingZerosMap>(Sym);
   if (Align)
     return *Align;
 
@@ -79,7 +100,6 @@ int getTrailingZerosCount(SymbolRef Sym, CheckerContext &C) {
     if (HasGlobalsOrParametersStorage) {
       const QualType &SymTy = Sym->getType();
       if (SymTy->isPointerType() && !isGenericPointerType(SymTy)) {
-        ASTContext &ASTCtx = C.getASTContext();
         const QualType &PT = SymTy->getPointeeType();
         if (!PT->isIncompleteType()) {
           unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
@@ -92,18 +112,18 @@ int getTrailingZerosCount(SymbolRef Sym, CheckerContext &C) {
   return -1;
 }
 
-int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
+int getTrailingZerosCount(const MemRegion *R, ProgramStateRef State,
+                          ASTContext &ASTCtx) {
   R = R->StripCasts();
 
-  ASTContext &ASTCtx = C.getASTContext();
   if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
     const MemRegion *Base = ER->getSuperRegion();
     int BaseTZC = -1;
     if (const SymbolicRegion *SymbBase = Base->getSymbolicBase())
-      BaseTZC = getTrailingZerosCount(SymbBase->getSymbol(), C);
+      BaseTZC = getTrailingZerosCount(SymbBase->getSymbol(), State, ASTCtx);
     else
-      BaseTZC = getTrailingZerosCount(Base, C);
-    int IdxTZC = getTrailingZerosCount(ER->getIndex(), C);
+      BaseTZC = getTrailingZerosCount(Base, State, ASTCtx);
+    int IdxTZC = getTrailingZerosCount(ER->getIndex(), State, ASTCtx);
     if (BaseTZC >= 0) {
       const QualType ElemTy = ER->getElementType();
       unsigned ElAlign = ASTCtx.getTypeAlignInChars(ElemTy).getQuantity();
@@ -138,7 +158,8 @@ int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
   return llvm::APSInt::getUnsigned(A).countTrailingZeros();
 }
 
-int getTrailingZerosCount(const SVal &V, CheckerContext &C) {
+int getTrailingZerosCount(const SVal &V, ProgramStateRef State,
+                          ASTContext &ASTCtx) {
   if (V.isUnknownOrUndef())
     return -1;
 
@@ -151,13 +172,13 @@ int getTrailingZerosCount(const SVal &V, CheckerContext &C) {
   }
 
   if (SymbolRef Sym = V.getAsSymbol()) {
-    int Res = getTrailingZerosCount(Sym, C);
+    int Res = getTrailingZerosCount(Sym, State, ASTCtx);
     if (Res >= 0)
       return Res;
   }
 
   if (const MemRegion *R = V.getAsRegion()) {
-    return getTrailingZerosCount(R, C);
+    return getTrailingZerosCount(R, State, ASTCtx);
   }
 
   return -1;
@@ -165,7 +186,7 @@ int getTrailingZerosCount(const SVal &V, CheckerContext &C) {
 
 int getTrailingZerosCount(const Expr *E, CheckerContext &C) {
   const SVal &V = C.getSVal(E);
-  return getTrailingZerosCount(V, C);
+  return getTrailingZerosCount(V, C.getState(), C.getASTContext());
 }
 
 } // namespace
@@ -186,7 +207,7 @@ void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
   const SVal &SrcVal = C.getSVal(CE->getSubExpr());
   if (SrcVal.isConstant())
     return; // special value
-  int SrcTZC = getTrailingZerosCount(SrcVal, C);
+  int SrcTZC = getTrailingZerosCount(SrcVal, C.getState(), C.getASTContext());
   if (SrcTZC < 0)
     return;
   if ((unsigned)SrcTZC >= sizeof(unsigned int) * 8)
@@ -207,6 +228,9 @@ void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
       auto W = std::make_unique<PathSensitiveBugReport>(*CastAlignBug,
                                                         ErrorMessage, ErrNode);
       W->addRange(CE->getSourceRange());
+      if (SymbolRef S = SrcVal.getAsSymbol())
+        W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
+      W->markInteresting(SrcVal);
       C.emitReport(std::move(W));
     }
   }
@@ -242,15 +266,7 @@ void CapabilityAlignmentChecker::checkPostStmt(const CastExpr *CE,
     }
     if (SymbolRef Sym = DstVal.getAsSymbol()) {
       State = State->set<TrailingZerosMap>(Sym, SrcTZC);
-      const NoteTag *Tag =
-          C.getNoteTag([SrcTZC](PathSensitiveBugReport &BR) -> std::string {
-            SmallString<80> Msg;
-            llvm::raw_svector_ostream OS(Msg);
-            OS << "Alignment: ";
-            printAlign(OS, SrcTZC);
-            return std::string(OS.str());
-          });
-      C.addTransition(State, C.getPredecessor(), Tag);
+      C.addTransition(State);
     }
   }
 }
@@ -356,20 +372,66 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
     State = State->BindExpr(BO, LCtx, ResVal);
   }
   State = State->set<TrailingZerosMap>(ResVal.getAsSymbol(), Res);
-  const NoteTag *Tag =
-      C.getNoteTag([LeftTZ, RightTZ, Res,
-                    OpCode](PathSensitiveBugReport &BR) -> std::string {
-        SmallString<80> Msg;
-        llvm::raw_svector_ostream OS(Msg);
-        OS << "Alignment: ";
-        printAlign(OS, LeftTZ);
+  C.addTransition(State);
+}
+
+PathDiagnosticPieceRef
+CapabilityAlignmentChecker::AlignmentBugVisitor::VisitNode(
+    const ExplodedNode *N, BugReporterContext &BRC,
+    PathSensitiveBugReport &BR) {
+
+  const Stmt *S = N->getStmtForDiagnostics();
+  if (!S)
+    return nullptr;
+  const Expr *E = dyn_cast<Expr>(S);
+  if (!E)
+    return nullptr;
+
+  SmallString<256> Buf;
+  llvm::raw_svector_ostream OS(Buf);
+
+  ProgramStateRef State = N->getState();
+
+  SymbolRef ESym = N->getSVal(E).getAsSymbol();
+  if (!ESym)
+    return nullptr;
+
+  const int *NewAlign = State->get<TrailingZerosMap>(ESym);
+  if (!NewAlign)
+    return nullptr;
+
+  if (const CastExpr *CE = dyn_cast<CastExpr>(E)) {
+    if (Sym != N->getSVal(S).getAsSymbol())
+      return nullptr;
+    if (SymbolRef SrcSym = N->getSVal(CE->getSubExpr()).getAsSymbol())
+      if (const int *OldAlign = State->get<TrailingZerosMap>(SrcSym))
+        if (*OldAlign == *NewAlign)
+          return nullptr;
+
+    OS << "Alignment: ";
+    printAlign(OS, *NewAlign);
+  } else if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(E)) {
+    BinaryOperatorKind const OpCode = BO->getOpcode();
+    OS << "Alignment: ";
+    if (!BO->isShiftOp() && !BO->isShiftAssignOp()) {
+      ASTContext &ASTCtx = N->getCodeDecl().getASTContext();
+      int LTZ = getTrailingZerosCount(N->getSVal(BO->getLHS()), State, ASTCtx);
+      int RTZ = getTrailingZerosCount(N->getSVal(BO->getRHS()), State, ASTCtx);
+      if (LTZ >= 0 && RTZ >= 0) {
+        printAlign(OS, LTZ);
         OS << " " << BinaryOperator::getOpcodeStr(OpCode) << " ";
-        printAlign(OS, RightTZ);
+        printAlign(OS, RTZ);
         OS << " => ";
-        printAlign(OS, Res);
-        return std::string(OS.str());
-      });
-  C.addTransition(State, C.getPredecessor(), Tag);
+      }
+    }
+    printAlign(OS, *NewAlign);
+  } else
+    return nullptr;
+
+  // Generate the extra diagnostic.
+  PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
+                                   N->getLocationContext());
+  return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
 }
 
 void ento::registerCapabilityAlignmentChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -70,6 +70,25 @@ int getTrailingZerosCount(SymbolRef Sym, CheckerContext &C) {
   const int *Align = C.getState()->get<TrailingZerosMap>(Sym);
   if (Align)
     return *Align;
+
+  // Is function argument or global?
+  if (const MemRegion *BaseRegOrigin = Sym->getOriginRegion()) {
+    bool HasGlobalsOrParametersStorage =
+        isa<StackArgumentsSpaceRegion, GlobalsSpaceRegion>(
+            BaseRegOrigin->getMemorySpace());
+    if (HasGlobalsOrParametersStorage) {
+      const QualType &SymTy = Sym->getType();
+      if (SymTy->isPointerType() && !isGenericPointerType(SymTy)) {
+        ASTContext &ASTCtx = C.getASTContext();
+        const QualType &PT = SymTy->getPointeeType();
+        if (!PT->isIncompleteType()) {
+          unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
+          return llvm::APSInt::getUnsigned(A).countTrailingZeros();
+        }
+      }
+    }
+  }
+
   return -1;
 }
 
@@ -96,7 +115,9 @@ int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
     return -1;
 
   ASTContext &ASTCtx = C.getASTContext();
-  const QualType &PT = TR->getDesugaredValueType(ASTCtx);
+  const QualType PT = TR->getDesugaredValueType(ASTCtx);
+  if (PT->isIncompleteType())
+    return -1;
   unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
   return llvm::APSInt::getUnsigned(A).countTrailingZeros();
 }
@@ -142,15 +163,21 @@ void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
   const QualType &DstType = CE->getType();
   if (!Src->getType()->isPointerType() || !DstType->isPointerType())
     return;
+  const QualType &DstPointeeTy = DstType->getPointeeType();
+  if (DstPointeeTy->isIncompleteType())
+    return;
 
-  ASTContext &ASTCtx = C.getASTContext();
-  int SrcTZC = getTrailingZerosCount(CE->getSubExpr(), C);
+  const SVal &SrcVal = C.getSVal(CE->getSubExpr());
+  if (SrcVal.isConstant())
+    return; // special value
+  int SrcTZC = getTrailingZerosCount(SrcVal, C);
   if (SrcTZC < 0)
     return;
   if ((unsigned)SrcTZC >= sizeof(unsigned int) * 8)
     return; // Too aligned, probably a Zero
   unsigned SrcAlign = (1U << SrcTZC);
-  const QualType &DstPointeeTy = DstType->getPointeeType();
+
+  ASTContext &ASTCtx = C.getASTContext();
   unsigned DstReqAlign = ASTCtx.getTypeAlignInChars(DstPointeeTy).getQuantity();
   if (SrcAlign < DstReqAlign) {
     if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
@@ -182,7 +209,7 @@ void CapabilityAlignmentChecker::checkPostStmt(const CastExpr *CE,
                                                CheckerContext &C) const {
   CastKind CK = CE->getCastKind();
   if (CK != CastKind::CK_BitCast && CK != CK_PointerToIntegral &&
-      CK != CK_IntegralToPointer && CK != CK_LValueToRValue)
+      CK != CK_IntegralToPointer)
     return;
 
   int DstTZC = getTrailingZerosCount(CE, C);

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -95,16 +95,24 @@ int getTrailingZerosCount(SymbolRef Sym, CheckerContext &C) {
 int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
   R = R->StripCasts();
 
+  ASTContext &ASTCtx = C.getASTContext();
   if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
-    const MemRegion *Base = ER->getBaseRegion();
+    const MemRegion *Base = ER->getSuperRegion();
     int BaseTZC = -1;
     if (const SymbolicRegion *SymbBase = Base->getSymbolicBase())
       BaseTZC = getTrailingZerosCount(SymbBase->getSymbol(), C);
     else
       BaseTZC = getTrailingZerosCount(Base, C);
     int IdxTZC = getTrailingZerosCount(ER->getIndex(), C);
-    if (BaseTZC >= 0 && IdxTZC >= 0)
-      return std::min(BaseTZC, IdxTZC);
+    if (BaseTZC >= 0) {
+      const QualType ElemTy = ER->getElementType();
+      unsigned ElAlign = ASTCtx.getTypeAlignInChars(ElemTy).getQuantity();
+      if (IdxTZC < 0 && ElAlign == 1)
+        return -1;
+      int ElemTyTZC = llvm::APSInt::getUnsigned(ElAlign).countTrailingZeros();
+      return std::min(BaseTZC, std::max(IdxTZC, 0) + ElemTyTZC);
+    }
+    return -1;
   }
 
   if (R->getSymbolicBase())
@@ -114,7 +122,6 @@ int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
   if (!TR)
     return -1;
 
-  ASTContext &ASTCtx = C.getASTContext();
   const QualType PT = TR->getDesugaredValueType(ASTCtx);
   if (PT->isIncompleteType())
     return -1;

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -117,46 +117,41 @@ int getTrailingZerosCount(const MemRegion *R, ProgramStateRef State,
                           ASTContext &ASTCtx) {
   R = R->StripCasts();
 
-  if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
-    const MemRegion *Base = ER->getSuperRegion();
-    int BaseTZC = -1;
-    if (const SymbolicRegion *SymbBase = Base->getSymbolicBase())
-      BaseTZC = getTrailingZerosCount(SymbBase->getSymbol(), State, ASTCtx);
-    else
-      BaseTZC = getTrailingZerosCount(Base, State, ASTCtx);
-    int IdxTZC = getTrailingZerosCount(ER->getIndex(), State, ASTCtx);
-    if (BaseTZC >= 0) {
-      const QualType ElemTy = ER->getElementType();
-      unsigned ElAlign = ASTCtx.getTypeAlignInChars(ElemTy).getQuantity();
-      if (IdxTZC < 0 && ElAlign == 1)
-        return -1;
-      int ElemTyTZC = llvm::APSInt::getUnsigned(ElAlign).countTrailingZeros();
-      return std::min(BaseTZC, std::max(IdxTZC, 0) + ElemTyTZC);
+  if (const SymbolicRegion *SR = R->getAs<SymbolicRegion>())
+    return getTrailingZerosCount(SR->getSymbol(), State, ASTCtx);
+
+  if (const TypedValueRegion *TR = R->getAs<TypedValueRegion>()) {
+    const QualType PT = TR->getDesugaredValueType(ASTCtx);
+    if (PT->isIncompleteType())
+      return -1;
+    unsigned NaturalAlign = ASTCtx.getTypeAlignInChars(PT).getQuantity();
+
+    if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
+      const MemRegion *Base = ER->getSuperRegion();
+      int BaseTZC = getTrailingZerosCount(Base, State, ASTCtx);
+      int IdxTZC = getTrailingZerosCount(ER->getIndex(), State, ASTCtx);
+      if (BaseTZC >= 0) {
+        if (IdxTZC < 0 && NaturalAlign == 1)
+          return -1;
+        int ElemTyTZC =
+            llvm::APSInt::getUnsigned(NaturalAlign).countTrailingZeros();
+        return std::min(BaseTZC, std::max(IdxTZC, 0) + ElemTyTZC);
+      }
+      return -1;
     }
-    return -1;
-  }
 
-  if (R->getSymbolicBase())
-    return -1;
-
-  const TypedValueRegion *TR = R->getAs<TypedValueRegion>();
-  if (!TR)
-    return -1;
-  const QualType PT = TR->getDesugaredValueType(ASTCtx);
-  if (PT->isIncompleteType())
-    return -1;
-  unsigned NaturalAlign = ASTCtx.getTypeAlignInChars(PT).getQuantity();
-
-  unsigned AlignAttrVal = 0;
-  if (auto DR = R->getAs<DeclRegion>()) {
-    if (auto AA = DR->getDecl()->getAttr<AlignedAttr>()) {
-      if (!AA->isAlignmentDependent())
-        AlignAttrVal = AA->getAlignment(ASTCtx) / ASTCtx.getCharWidth();
+    unsigned AlignAttrVal = 0;
+    if (auto DR = R->getAs<DeclRegion>()) {
+      if (auto AA = DR->getDecl()->getAttr<AlignedAttr>()) {
+        if (!AA->isAlignmentDependent())
+          AlignAttrVal = AA->getAlignment(ASTCtx) / ASTCtx.getCharWidth();
+      }
     }
-  }
 
-  unsigned A = std::max(NaturalAlign, AlignAttrVal);
-  return llvm::APSInt::getUnsigned(A).countTrailingZeros();
+    unsigned A = std::max(NaturalAlign, AlignAttrVal);
+    return llvm::APSInt::getUnsigned(A).countTrailingZeros();
+  }
+  return -1;
 }
 
 int getTrailingZerosCount(const SVal &V, ProgramStateRef State,

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -196,6 +196,14 @@ bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
   return !M.empty();
 }
 
+const ValueDecl *getAllocationDecl(const MemRegion *MR) {
+  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
+    return DR->getDecl();
+  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
+    return getAllocationDecl(ER->getSuperRegion());
+  return nullptr;
+}
+
 } // namespace
 
 void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
@@ -240,6 +248,12 @@ void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
       if (SymbolRef S = SrcVal.getAsSymbol())
         W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
       W->markInteresting(SrcVal);
+      if (const MemRegion *MR = SrcVal.getAsRegion()) {
+        if (const ValueDecl *SrcDecl = getAllocationDecl(MR)) {
+          W->addNote("Original allocation", PathDiagnosticLocation::create(
+                                                SrcDecl, C.getSourceManager()));
+        }
+      }
       C.emitReport(std::move(W));
     }
   }

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -239,6 +239,18 @@ void CapabilityAlignmentChecker::checkPostStmt(const CastExpr *CE,
   }
 }
 
+bool valueIsLTPow2(const Expr *E, unsigned P, CheckerContext &C) {
+  if (P >= sizeof(uint64_t) * 8)
+    return true;
+  SValBuilder &SVB = C.getSValBuilder();
+  const NonLoc &B = SVB.makeIntVal((uint64_t)1 << P, true);
+
+  ProgramStateRef State = C.getState();
+  const SVal &V = C.getSVal(E);
+  auto LT = SVB.evalBinOp(State, BO_LT, V, B, E->getType());
+  return !State->assume(LT.castAs<DefinedOrUnknownSVal>(), false);
+}
+
 void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
                                                CheckerContext &C) const {
   int LeftTZ = getTrailingZerosCount(BO->getLHS(), C);
@@ -250,15 +262,7 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
 
   ProgramStateRef State = C.getState();
   SVal ResVal = C.getSVal(BO);
-  if (ResVal.isUnknown()) {
-    const LocationContext *LCtx = C.getLocationContext();
-    ResVal = C.getSValBuilder().conjureSymbolVal(nullptr, BO, LCtx,
-                                                 BO->getType(), C.blockCount());
-    State = State->BindExpr(BO, LCtx, ResVal);
-  }
-
-  SymbolRef ResSymb = ResVal.getAsSymbol();
-  if (!ResSymb)
+  if (!ResVal.isUnknown() && !ResVal.getAsSymbol())
     return;
 
   const SVal &RHSVal = C.getSVal(BO->getRHS());
@@ -269,7 +273,19 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   switch (OpCode) {
   case clang::BO_And:
   case clang::BO_AndAssign:
-    Res = std::max(LeftTZ, RightTZ);
+    if (valueIsLTPow2(BO->getLHS(), RightTZ, C) ||
+        valueIsLTPow2(BO->getRHS(), LeftTZ, C)) {
+      /* Align check: p & (ALIGN - 1)*/
+      if (ResVal.isUnknown()) {
+        ResVal = C.getSValBuilder().makeIntVal(0, true);
+        State = State->BindExpr(BO, C.getLocationContext(), ResVal);
+        C.addTransition(State);
+        return;
+      } else {
+        Res = BitWidth;
+      }
+    } else
+      Res = std::max(LeftTZ, RightTZ);
     break;
   case clang::BO_Or:
   case clang::BO_OrAssign:
@@ -317,7 +333,13 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   if (Res > BitWidth)
     Res = BitWidth;
 
-  State = State->set<TrailingZerosMap>(ResSymb, Res);
+  if (ResVal.isUnknown()) {
+    const LocationContext *LCtx = C.getLocationContext();
+    ResVal = C.getSValBuilder().conjureSymbolVal(nullptr, BO, LCtx,
+                                                 BO->getType(), C.blockCount());
+    State = State->BindExpr(BO, LCtx, ResVal);
+  }
+  State = State->set<TrailingZerosMap>(ResVal.getAsSymbol(), Res);
   const NoteTag *Tag =
       C.getNoteTag([LeftTZ, RightTZ, Res,
                     OpCode](PathSensitiveBugReport &BR) -> std::string {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -121,11 +121,20 @@ int getTrailingZerosCount(const MemRegion *R, CheckerContext &C) {
   const TypedValueRegion *TR = R->getAs<TypedValueRegion>();
   if (!TR)
     return -1;
-
   const QualType PT = TR->getDesugaredValueType(ASTCtx);
   if (PT->isIncompleteType())
     return -1;
-  unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
+  unsigned NaturalAlign = ASTCtx.getTypeAlignInChars(PT).getQuantity();
+
+  unsigned AlignAttrVal = 0;
+  if (auto DR = R->getAs<DeclRegion>()) {
+    if (auto AA = DR->getDecl()->getAttr<AlignedAttr>()) {
+      if (!AA->isAlignmentDependent())
+        AlignAttrVal = AA->getAlignment(ASTCtx) / ASTCtx.getCharWidth();
+    }
+  }
+
+  unsigned A = std::max(NaturalAlign, AlignAttrVal);
   return llvm::APSInt::getUnsigned(A).countTrailingZeros();
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -43,7 +43,7 @@ using namespace cheri;
 namespace {
 class CapabilityAlignmentChecker
     : public Checker<check::PreStmt<CastExpr>, check::PostStmt<CastExpr>,
-                     check::PostStmt<BinaryOperator>> {
+                     check::PostStmt<BinaryOperator>, check::DeadSymbols> {
   std::unique_ptr<BugType> CastAlignBug;
   std::unique_ptr<BugType> CapCastAlignBug;
 
@@ -53,6 +53,7 @@ public:
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkPostStmt(const CastExpr *BO, CheckerContext &C) const;
   void checkPreStmt(const CastExpr *BO, CheckerContext &C) const;
+  void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
 private:
   ExplodedNode *emitCastAlignWarn(CheckerContext &C, unsigned SrcAlign,
@@ -367,6 +368,23 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   State = State->set<TrailingZerosMap>(ResVal.getAsSymbol(), Res);
   C.addTransition(State);
 }
+
+void CapabilityAlignmentChecker::checkDeadSymbols(SymbolReaper &SymReaper,
+                                                  CheckerContext &C) const {
+  ProgramStateRef State = C.getState();
+  TrailingZerosMapTy TZMap = State->get<TrailingZerosMap>();
+  bool Updated = false;
+  for (TrailingZerosMapTy::iterator I = TZMap.begin(), E = TZMap.end(); I != E;
+       ++I) {
+    if (SymReaper.isDead(I->first)) {
+      State = State->remove<TrailingZerosMap>(I->first);
+      Updated = true;
+    }
+  }
+  if (Updated)
+    C.addTransition(State);
+}
+
 namespace {
 
 bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -32,6 +32,7 @@
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h>
 
@@ -189,16 +190,29 @@ int getTrailingZerosCount(const Expr *E, CheckerContext &C) {
   return getTrailingZerosCount(V, C.getState(), C.getASTContext());
 }
 
+/* Introduced by clang, not in C standard */
+bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
+  using namespace clang::ast_matchers;
+  auto CmpM = binaryOperation(isComparisonOperator());
+  auto VoidPtr = expr(hasType(pointerType(pointee(voidType()))));
+  auto CastM = implicitCastExpr(has(VoidPtr), hasType(pointerType()),
+                                hasCastKind(CK_BitCast), hasParent(CmpM));
+  auto M = match(expr(CastM), *S, C.getASTContext());
+  return !M.empty();
+}
+
 } // namespace
 
 void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
                                               CheckerContext &C) const {
-  if (CE->getCastKind() != CastKind::CK_BitCast)
+  CastKind CK = CE->getCastKind();
+  if (CK != CastKind::CK_BitCast && CK != CK_IntegralToPointer)
+    return;
+  if (isImplicitConversionFromVoidPtr(CE, C))
     return;
 
-  const Expr *Src = CE->getSubExpr();
   const QualType &DstType = CE->getType();
-  if (!Src->getType()->isPointerType() || !DstType->isPointerType())
+  if (!DstType->isPointerType())
     return;
   const QualType &DstPointeeTy = DstType->getPointeeType();
   if (DstPointeeTy->isIncompleteType())

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityAlignmentChecker.cpp
@@ -45,6 +45,7 @@ class CapabilityAlignmentChecker
     : public Checker<check::PreStmt<CastExpr>, check::PostStmt<CastExpr>,
                      check::PostStmt<BinaryOperator>> {
   std::unique_ptr<BugType> CastAlignBug;
+  std::unique_ptr<BugType> CapCastAlignBug;
 
 public:
   CapabilityAlignmentChecker();
@@ -54,6 +55,10 @@ public:
   void checkPreStmt(const CastExpr *BO, CheckerContext &C) const;
 
 private:
+  ExplodedNode *emitCastAlignWarn(CheckerContext &C, unsigned SrcAlign,
+                                  unsigned DstReqAlign,
+                                  const CastExpr *CE) const;
+
   class AlignmentBugVisitor : public BugReporterVisitor {
   public:
     AlignmentBugVisitor(SymbolRef SR) : Sym(SR) {}
@@ -78,8 +83,11 @@ private:
 REGISTER_MAP_WITH_PROGRAMSTATE(TrailingZerosMap, SymbolRef, int)
 
 CapabilityAlignmentChecker::CapabilityAlignmentChecker() {
-  CastAlignBug.reset(new BugType(this, "Cast increases required alignment",
-                                 "CHERI portability"));
+  CastAlignBug.reset(
+      new BugType(this, "Cast increases required alignment", "Type Error"));
+  CapCastAlignBug.reset(new BugType(
+      this, "Cast increases required alignment to capability alignment",
+      "CHERI portability"));
 }
 
 namespace {
@@ -196,14 +204,6 @@ bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
   return !M.empty();
 }
 
-const ValueDecl *getAllocationDecl(const MemRegion *MR) {
-  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
-    return DR->getDecl();
-  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
-    return getAllocationDecl(ER->getSuperRegion());
-  return nullptr;
-}
-
 } // namespace
 
 void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
@@ -234,38 +234,8 @@ void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
   ASTContext &ASTCtx = C.getASTContext();
   unsigned DstReqAlign = ASTCtx.getTypeAlignInChars(DstPointeeTy).getQuantity();
   if (SrcAlign < DstReqAlign) {
-    if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
-      SmallString<350> ErrorMessage;
-      llvm::raw_svector_ostream OS(ErrorMessage);
-      OS << "Cast increases required alignment: ";
-      OS << SrcAlign;
-      OS << " -> ";
-      OS << DstReqAlign;
-      OS << ")";
-      auto W = std::make_unique<PathSensitiveBugReport>(*CastAlignBug,
-                                                        ErrorMessage, ErrNode);
-      W->addRange(CE->getSourceRange());
-      if (SymbolRef S = SrcVal.getAsSymbol())
-        W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
-      W->markInteresting(SrcVal);
-      if (const MemRegion *MR = SrcVal.getAsRegion()) {
-        if (const ValueDecl *SrcDecl = getAllocationDecl(MR)) {
-          W->addNote("Original allocation", PathDiagnosticLocation::create(
-                                                SrcDecl, C.getSourceManager()));
-        }
-      }
-      C.emitReport(std::move(W));
-    }
+    emitCastAlignWarn(C, SrcAlign, DstReqAlign, CE);
   }
-}
-
-void printAlign(raw_ostream &OS, unsigned TZC) {
-  OS << "aligned(";
-  if (TZC < sizeof(unsigned long) * 8)
-    OS << (1LU << TZC);
-  else
-    OS << "2^(" << TZC << ")";
-  OS << ")";
 }
 
 void CapabilityAlignmentChecker::checkPostStmt(const CastExpr *CE,
@@ -397,6 +367,89 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   State = State->set<TrailingZerosMap>(ResVal.getAsSymbol(), Res);
   C.addTransition(State);
 }
+namespace {
+
+bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {
+  QualType Ty = OrigTy.getCanonicalType();
+  if (Ty->isCHERICapabilityType(Ctx, true))
+    return true;
+  if (const auto *Record = dyn_cast<RecordType>(Ty)) {
+    for (const auto *Field : Record->getDecl()->fields()) {
+      if (hasCapability(Field->getType(), Ctx))
+        return true;
+    }
+    return false;
+  }
+  if (const auto *Array = dyn_cast<ArrayType>(Ty)) {
+    return hasCapability(Array->getElementType(), Ctx);
+  }
+  return false;
+}
+
+void printAlign(raw_ostream &OS, unsigned TZC) {
+  OS << "aligned(";
+  if (TZC < sizeof(unsigned long) * 8)
+    OS << (1LU << TZC);
+  else
+    OS << "2^(" << TZC << ")";
+  OS << ")";
+}
+
+void describeOriginalAllocation(const MemRegion *MR, PathSensitiveBugReport &W,
+                                const SourceManager &SM, ASTContext &ASTCtx) {
+  if (const DeclRegion *DR = MR->getAs<DeclRegion>()) {
+    const ValueDecl *SrcDecl = DR->getDecl();
+    SmallString<350> Note;
+    llvm::raw_svector_ostream OS2(Note);
+    const QualType &AllocType = SrcDecl->getType().getCanonicalType();
+    OS2 << "Original allocation of type ";
+    OS2 << "'" << AllocType.getAsString() << "'";
+    OS2 << " which has an alignment requirement ";
+    OS2 << ASTCtx.getTypeAlignInChars(AllocType).getQuantity();
+    OS2 << " bytes";
+    W.addNote(Note, PathDiagnosticLocation::create(SrcDecl, SM));
+  } else if (const ElementRegion *ER = MR->getAs<ElementRegion>())
+    describeOriginalAllocation(ER->getSuperRegion(), W, SM, ASTCtx);
+}
+
+} // namespace
+
+ExplodedNode *CapabilityAlignmentChecker::emitCastAlignWarn(
+    CheckerContext &C, unsigned SrcAlign, unsigned DstReqAlign,
+    const CastExpr *CE) const {
+  ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+  if (!ErrNode)
+    return nullptr;
+
+  ASTContext &ASTCtx = C.getASTContext();
+  const QualType &DstTy = CE->getType();
+  bool DstAlignIsCap = hasCapability(DstTy->getPointeeType(), ASTCtx);
+
+  SmallString<350> ErrorMessage;
+  llvm::raw_svector_ostream OS(ErrorMessage);
+  OS << "Pointer value aligned to a " << SrcAlign << " byte boundary";
+  OS << " cast to type '" << DstTy.getAsString() << "'";
+  OS << " with required";
+  if (DstAlignIsCap)
+    OS << " capability";
+  OS << " alignment " << DstReqAlign;
+  OS << " bytes";
+
+  auto W = std::make_unique<PathSensitiveBugReport>(
+      DstAlignIsCap ? *CapCastAlignBug : *CastAlignBug, ErrorMessage, ErrNode);
+  W->addRange(CE->getSourceRange());
+
+  const SVal &SrcVal = C.getSVal(CE->getSubExpr());
+  W->markInteresting(SrcVal);
+  if (SymbolRef S = SrcVal.getAsSymbol())
+    W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
+  else if (const MemRegion *MR = SrcVal.getAsRegion()) {
+    describeOriginalAllocation(MR, *W, C.getSourceManager(), C.getASTContext());
+  }
+
+  C.emitReport(std::move(W));
+  return ErrNode;
+}
 
 PathDiagnosticPieceRef
 CapabilityAlignmentChecker::AlignmentBugVisitor::VisitNode(
@@ -413,29 +466,26 @@ CapabilityAlignmentChecker::AlignmentBugVisitor::VisitNode(
   SmallString<256> Buf;
   llvm::raw_svector_ostream OS(Buf);
 
-  ProgramStateRef State = N->getState();
-
-  SymbolRef ESym = N->getSVal(E).getAsSymbol();
-  if (!ESym)
+  if (Sym != N->getSVal(S).getAsSymbol())
     return nullptr;
 
-  const int *NewAlign = State->get<TrailingZerosMap>(ESym);
-  if (!NewAlign)
+  ProgramStateRef State = N->getState();
+  ProgramStateRef Pred = N->getFirstPred()->getState();
+  const int *NewAlign = State->get<TrailingZerosMap>(Sym);
+  const int *OldAlign = Pred->get<TrailingZerosMap>(Sym);
+  if (!NewAlign || (OldAlign && *NewAlign == *OldAlign))
     return nullptr;
 
   if (const CastExpr *CE = dyn_cast<CastExpr>(E)) {
-    if (Sym != N->getSVal(S).getAsSymbol())
-      return nullptr;
     if (SymbolRef SrcSym = N->getSVal(CE->getSubExpr()).getAsSymbol())
-      if (const int *OldAlign = State->get<TrailingZerosMap>(SrcSym))
-        if (*OldAlign == *NewAlign)
+      if (const int *SrcAlign = State->get<TrailingZerosMap>(SrcSym))
+        if (*SrcAlign == *NewAlign)
           return nullptr;
+  }
 
-    OS << "Alignment: ";
-    printAlign(OS, *NewAlign);
-  } else if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(E)) {
+  OS << "Alignment: ";
+  if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(E)) {
     BinaryOperatorKind const OpCode = BO->getOpcode();
-    OS << "Alignment: ";
     if (!BO->isShiftOp() && !BO->isShiftAssignOp()) {
       ASTContext &ASTCtx = N->getCodeDecl().getASTContext();
       int LTZ = getTrailingZerosCount(N->getSVal(BO->getLHS()), State, ASTCtx);
@@ -447,9 +497,8 @@ CapabilityAlignmentChecker::AlignmentBugVisitor::VisitNode(
         OS << " => ";
       }
     }
-    printAlign(OS, *NewAlign);
-  } else
-    return nullptr;
+  }
+  printAlign(OS, *NewAlign);
 
   // Generate the extra diagnostic.
   PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -77,6 +77,8 @@ public:
   void checkBranchCondition(const Stmt *Cond, CheckerContext &C) const;
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
 
+  bool ReportForCharPtr = false;
+
 private:
   ExplodedNode *checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
 };
@@ -116,7 +118,7 @@ const MemRegion *stripNonCapShift(const MemRegion *R, ASTContext &ASTCtx) {
   return ER->getSuperRegion();
 }
 
-bool isVoidOrCharPtrArgRegion(const MemRegion *Reg) {
+bool isVoidOrCharPtrArgRegion(const MemRegion *Reg, bool AcceptCharPtr) {
   if (!Reg)
     return false;
 
@@ -126,7 +128,7 @@ bool isVoidOrCharPtrArgRegion(const MemRegion *Reg) {
     return false;
 
   SymbolRef Sym = SymReg->getSymbol();
-  if (!isGenericPointerType(Sym->getType()))
+  if (!isGenericPointerType(Sym->getType(), AcceptCharPtr))
     return false;
 
   // 2. void* symbol is function argument
@@ -135,7 +137,7 @@ bool isVoidOrCharPtrArgRegion(const MemRegion *Reg) {
          BaseRegOrigin->getMemorySpace()->hasStackParametersStorage();
 }
 
-CHERITagState getTagState(SVal Val, CheckerContext &C,
+CHERITagState getTagState(SVal Val, CheckerContext &C, bool AcceptCharPtr,
                           bool AcceptUnaligned = true) {
   if (Val.isUnknownOrUndef())
     return CHERITagState::getUnknown();
@@ -152,14 +154,14 @@ CHERITagState getTagState(SVal Val, CheckerContext &C,
       const MemRegion *SuperReg = stripNonCapShift(MR, C.getASTContext());
       if (isa<FieldRegion>(SuperReg))
         return CHERITagState::getUnknown(); // not a part of capability
-      if (isVoidOrCharPtrArgRegion(SuperReg) &&
+      if (isVoidOrCharPtrArgRegion(SuperReg, AcceptCharPtr) &&
           (AcceptUnaligned || !S->contains<UnalignedPtr>(SuperReg)) &&
           !S->contains<CString>(SuperReg))
         return CHERITagState::getMayBeTagged();
       if (MR != SuperReg && isa<TypedValueRegion>(SuperReg)) {
         const SVal &SuperVal = C.getState()->getSVal(SuperReg);
         if (Val != SuperVal)
-          return getTagState(SuperVal, C);
+          return getTagState(SuperVal, C, AcceptCharPtr);
       }
     }
   }
@@ -168,7 +170,7 @@ CHERITagState getTagState(SVal Val, CheckerContext &C,
 }
 
 bool isCapabilityStorage(CheckerContext &C, const MemRegion *R,
-                         bool AcceptUnaligned = true) {
+                         bool AcceptCharPtr, bool AcceptUnaligned = true) {
   const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
   if (!AcceptUnaligned && C.getState()->contains<UnalignedPtr>(BaseReg))
     return false;
@@ -176,7 +178,7 @@ bool isCapabilityStorage(CheckerContext &C, const MemRegion *R,
     return false;
   if (const auto *SymR = dyn_cast<SymbolicRegion>(BaseReg)) {
     QualType const Ty = SymR->getSymbol()->getType();
-    if (isGenericPointerType(Ty))
+    if (isGenericPointerType(Ty, AcceptCharPtr))
       return true;
     return isPointerToCapTy(Ty, C.getASTContext());
   }
@@ -201,7 +203,7 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
   ProgramStateRef State = C.getState();
   QualType const Ty = l.getType(ASTCtx);
   QualType const ArgValTy = Ty->getPointeeType();
-  if (!isGenericPointerType(ArgValTy))
+  if (!isGenericPointerType(ArgValTy, ReportForCharPtr))
     return;
 
   /* Loading VoidPtr function argument */
@@ -341,12 +343,12 @@ const MemRegion *isCapAlignCheck(const BinaryOperator *BO, CheckerContext &C) {
 }
 
 bool handleAlignmentCheck(const BinaryOperator *BO, ProgramStateRef State,
-                          CheckerContext &C) {
+                          CheckerContext &C, bool AcceptCharPtr) {
   auto ExprPtrReg = isCapAlignCheck(BO, C);
   if (!ExprPtrReg)
     return false;
 
-  if (!isVoidOrCharPtrArgRegion(ExprPtrReg))
+  if (!isVoidOrCharPtrArgRegion(ExprPtrReg, AcceptCharPtr))
     return false;
 
   SVal AndVal = C.getSVal(BO);
@@ -392,11 +394,11 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
     return;
   /* Non-capability scalar store */
 
-  const CHERITagState &ValTag = getTagState(V, C);
+  const CHERITagState &ValTag = getTagState(V, C, ReportForCharPtr);
   if (!ValTag.isTagged() && !ValTag.mayBeTagged())
     return;
 
-  if (!isCapabilityStorage(C, MR))
+  if (!isCapabilityStorage(C, MR, ReportForCharPtr))
     return;
 
   if (ValTag.mayBeTagged() && !isPartOfCopyingSequence(PointeeTy, V, S, C))
@@ -420,7 +422,8 @@ using namespace clang::ast_matchers;
 using namespace clang::ast_matchers::internal;
 
 ProgramStateRef markOriginAsCStringForMatch(const Stmt *E, Matcher<Stmt> D,
-                                            CheckerContext &C) {
+                                            CheckerContext &C,
+                                            bool AcceptCharPtr) {
   auto M = match(D, *E, C.getASTContext());
 
   bool Updated = false;
@@ -438,7 +441,7 @@ ProgramStateRef markOriginAsCStringForMatch(const Stmt *E, Matcher<Stmt> D,
 
     const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
 
-    if (isVoidOrCharPtrArgRegion(BaseReg)) {
+    if (isVoidOrCharPtrArgRegion(BaseReg, AcceptCharPtr)) {
       /* It's probably a string, so it's not to be regarded as a potential
        * pointer to capability */
       State = State->add<CString>(BaseReg);
@@ -497,7 +500,8 @@ void CapabilityCopyChecker::checkBranchCondition(const Stmt *Cond,
 
   auto CharMatcher = expr(hasType(isAnyCharacter())).bind("c");
   auto CondMatcher = stmt(expr(ignoringParenCasts(CharMatcher)));
-  const ProgramStateRef N = markOriginAsCStringForMatch(Cond, CondMatcher, C);
+  const ProgramStateRef N =
+      markOriginAsCStringForMatch(Cond, CondMatcher, C, ReportForCharPtr);
   bool updated = checkForWhileBoundVar(Cond, C, N ? N : C.getState());
   if (!updated && N)
     C.addTransition(N);
@@ -512,7 +516,8 @@ void CapabilityCopyChecker::checkPostStmt(const ArraySubscriptExpr *E,
   auto CharMatcher = expr(hasType(isAnyCharacter())).bind("c");
   auto IndexMatcher = stmt(expr(ignoringParenCasts(CharMatcher)));
 
-  const ProgramStateRef N = markOriginAsCStringForMatch(Index, IndexMatcher, C);
+  const ProgramStateRef N =
+      markOriginAsCStringForMatch(Index, IndexMatcher, C, ReportForCharPtr);
   if (N)
     C.addTransition(N);
 }
@@ -586,11 +591,12 @@ void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
   auto Arithm = binaryOperation(BitOps, has(CharMatcher));
 
   auto BOM = anyOf(Cmp, Arithm);
-  const ProgramStateRef NewState = markOriginAsCStringForMatch(BO, BOM, C);
+  const ProgramStateRef NewState =
+      markOriginAsCStringForMatch(BO, BOM, C, ReportForCharPtr);
   if (NewState)
     State = NewState;
 
-  bool updated = handleAlignmentCheck(BO, State, C);
+  bool updated = handleAlignmentCheck(BO, State, C, ReportForCharPtr);
   if (!updated && NewState)
     C.addTransition(NewState);
 }
@@ -618,7 +624,9 @@ void CapabilityCopyChecker::checkPreCall(const CallEvent &Call,
 }
 
 void ento::registerCapabilityCopyChecker(CheckerManager &mgr) {
-  mgr.registerChecker<CapabilityCopyChecker>();
+  auto *Checker = mgr.registerChecker<CapabilityCopyChecker>();
+  Checker->ReportForCharPtr = mgr.getAnalyzerOptions().getCheckerBooleanOption(
+      Checker, "ReportForCharPtr");
 }
 
 bool ento::shouldRegisterCapabilityCopyChecker(const CheckerManager &Mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -115,7 +115,7 @@ const MemRegion *stripNonCapShift(const MemRegion *R, ASTContext &ASTCtx) {
   if (!isNonCapScalarType(ER->getValueType(), ASTCtx))
     return R;
 
-  return ER->getSuperRegion();
+  return stripNonCapShift(ER->getSuperRegion(), ASTCtx);
 }
 
 bool isVoidOrCharPtrArgRegion(const MemRegion *Reg, bool AcceptCharPtr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -56,7 +56,7 @@ public:
   void checkLocation(SVal l, bool isLoad, const Stmt *S,
                      CheckerContext &C) const;
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
-  void checkBranchCondition(const Stmt *Condition, CheckerContext &Ctx) const;
+  void checkBranchCondition(const Stmt *Condition, CheckerContext &C) const;
 
 private:
   ExplodedNode *checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
@@ -73,6 +73,10 @@ CapabilityCopyChecker::CapabilityCopyChecker() {
                   "CHERI portability"));
   StoreCapAsNonCap.reset(new BugType(this, "Tag-stripping copy of capability",
                                      "CHERI portability"));
+}
+
+static bool isPureCapMode(const ASTContext &C) {
+  return C.getTargetInfo().areAllPointersCapabilities();
 }
 
 static bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
@@ -160,6 +164,9 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
                                           CheckerContext &C) const {
   if (!isLoad)
     return;
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return;
 
   const MemRegion *R = l.getAsRegion();
   if (!R || !R->hasStackParametersStorage())
@@ -167,7 +174,7 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
 
   // Get ArgVal
   ProgramStateRef State = C.getState();
-  QualType const Ty = l.getType(C.getASTContext());
+  QualType const Ty = l.getType(ASTCtx);
   QualType const ArgValTy = Ty->getPointeeType();
   if (!ArgValTy->isVoidPointerType())
     return;
@@ -179,7 +186,7 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
     return;
 
   // If argument has value from caller, CharTy will not be used
-  SVal ArgValDeref = State->getSVal(ArgValAsRegion, C.getASTContext().CharTy);
+  SVal ArgValDeref = State->getSVal(ArgValAsRegion, ASTCtx.CharTy);
 
   const NoteTag *Tag;
   if (const auto *ArgValDerefAsRegion = ArgValDeref.getAsRegion()) {
@@ -254,12 +261,16 @@ static bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
 
 void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
                                       CheckerContext &C) const {
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return;
+
   const MemRegion *MR = L.getAsRegion();
   if (!MR)
     return;
 
-  const QualType &PointeeTy = L.getType(C.getASTContext())->getPointeeType();
-  if (!isNonCapScalarType(PointeeTy, C.getASTContext()))
+  const QualType &PointeeTy = L.getType(ASTCtx)->getPointeeType();
+  if (!isNonCapScalarType(PointeeTy, ASTCtx))
     return;
   /* Non-capability scalar store */
 
@@ -271,7 +282,7 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
     return;
 
   // Skip if loop bound is not big enough to copy capability
-  unsigned BlockSize = C.getASTContext().getTypeSize(PointeeTy);
+  unsigned BlockSize = ASTCtx.getTypeSize(PointeeTy);
   if (isInsideSmallConstantBoundLoop(S, C, BlockSize))
     return;
 
@@ -287,6 +298,8 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
 ExplodedNode *CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
                                                       const Expr *E) const {
   ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return nullptr;
   if (!isNonCapScalarType(E->getType(), ASTCtx))
     return nullptr;
 
@@ -340,6 +353,10 @@ static const MemRegion *isCapAlignCheck(const BinaryOperator *BO,
 
 void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
                                           CheckerContext &C) const {
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return;
+
   ExplodedNode *N = nullptr;
 
   /* Check for capability repr bytes used in arithmetic */
@@ -384,30 +401,34 @@ void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
 }
 
 void CapabilityCopyChecker::checkBranchCondition(const Stmt *Condition,
-                                                 CheckerContext &Ctx) const {
+                                                 CheckerContext &C) const {
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return;
+
   using namespace clang::ast_matchers;
   // TODO: do-while, merge with second matcher
   auto childOfWhile = stmt(hasParent(stmt(anyOf(whileStmt(), doStmt()))));
-  auto L = match(childOfWhile, *Condition, Ctx.getASTContext());
+  auto L = match(childOfWhile, *Condition, ASTCtx);
   if (L.empty())
     return;
 
   auto whileCond = whileConditionMatcher();
 
-  auto M = match(whileCond, *Condition, Ctx.getASTContext());
+  auto M = match(whileCond, *Condition, ASTCtx);
   if (M.size() != 1)
     return;
 
-  const SVal &CondVal = Ctx.getSVal(Condition);
-  if (Ctx.getSVal(Condition).isUnknownOrUndef())
+  const SVal &CondVal = C.getSVal(Condition);
+  if (C.getSVal(Condition).isUnknownOrUndef())
     return;
 
   ProgramStateRef ThenSt, ElseSt;
   std::tie(ThenSt, ElseSt) =
-      Ctx.getState()->assume(CondVal.castAs<DefinedOrUnknownSVal>());
+      C.getState()->assume(CondVal.castAs<DefinedOrUnknownSVal>());
   for (auto I : M) {
     auto L = I.getNodeAs<Expr>("len");
-    if (SymbolRef ISym = Ctx.getSVal(L).getAsSymbol()) {
+    if (SymbolRef ISym = C.getSVal(L).getAsSymbol()) {
       if (ThenSt)
         ThenSt = ThenSt->add<WhileBoundVar>(ISym);
       if (ElseSt)
@@ -416,9 +437,9 @@ void CapabilityCopyChecker::checkBranchCondition(const Stmt *Condition,
       return;
   }
   if (ThenSt)
-    Ctx.addTransition(ThenSt);
+    C.addTransition(ThenSt);
   if (ElseSt)
-    Ctx.addTransition(ElseSt);
+    C.addTransition(ElseSt);
 }
 
 void ento::registerCapabilityCopyChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -54,8 +54,11 @@ class CapabilityCopyChecker
                      check::PostStmt<ArraySubscriptExpr>,
                      check::BranchCondition, check::PreCall> {
 
-  std::unique_ptr<BugType> UseCapAsNonCap;
-  std::unique_ptr<BugType> StoreCapAsNonCap;
+  BugType UseCapAsNonCap{this,
+                         "Part of capability value used in binary operator",
+                         "CHERI portability"};
+  BugType StoreCapAsNonCap{this, "Tag-stripping copy of capability",
+                           "CHERI portability"};
 
   using CheckFn = std::function<void(const CapabilityCopyChecker *,
                                      const CallEvent &Call, CheckerContext &C)>;
@@ -66,12 +69,9 @@ class CapabilityCopyChecker
       {{CDM::SimpleFunc, {"strcat"}, 2}, 3}};
 
 public:
-  CapabilityCopyChecker();
-
   void checkLocation(SVal l, bool isLoad, const Stmt *S,
                      CheckerContext &C) const;
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
-
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkPostStmt(const ArraySubscriptExpr *E, CheckerContext &C) const;
   void checkBranchCondition(const Stmt *Cond, CheckerContext &C) const;
@@ -88,14 +88,6 @@ REGISTER_SET_WITH_PROGRAMSTATE(VoidPtrArgDeref, const MemRegion *)
 REGISTER_SET_WITH_PROGRAMSTATE(UnalignedPtr, const MemRegion *)
 REGISTER_SET_WITH_PROGRAMSTATE(CString, const MemRegion *)
 REGISTER_LIST_WITH_PROGRAMSTATE(WhileBoundVar, SymbolRef)
-
-CapabilityCopyChecker::CapabilityCopyChecker() {
-  UseCapAsNonCap.reset(
-      new BugType(this, "Part of capability value used in binary operator",
-                  "CHERI portability"));
-  StoreCapAsNonCap.reset(new BugType(this, "Tag-stripping copy of capability",
-                                     "CHERI portability"));
-}
 
 namespace {
 
@@ -411,7 +403,7 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
   /* Storing capability to capability storage as non-cap*/
   if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
     auto W = std::make_unique<PathSensitiveBugReport>(
-        *StoreCapAsNonCap, "Tag-stripping store of a capability", ErrNode);
+        StoreCapAsNonCap, "Tag-stripping store of a capability", ErrNode);
     W->addRange(S->getSourceRange());
     C.emitReport(std::move(W));
   }
@@ -551,7 +543,7 @@ ExplodedNode *CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
     /* Pointer to capability passed as void* argument */
     if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
       auto W = std::make_unique<PathSensitiveBugReport>(
-          *UseCapAsNonCap,
+          UseCapAsNonCap,
           "Part of capability representation used as argument in binary "
           "operator",
           ErrNode);

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -49,10 +49,10 @@ public:
 };
 
 class CapabilityCopyChecker
-    : public Checker<check::Location, check::Bind,
-                     check::PostStmt<BinaryOperator>,
-                     check::PostStmt<ArraySubscriptExpr>,
-                     check::BranchCondition, check::PreCall> {
+    : public Checker<
+          check::Location, check::Bind, check::PostStmt<BinaryOperator>,
+          check::PostStmt<ArraySubscriptExpr>, check::BranchCondition,
+          check::PreCall, check::DeadSymbols> {
 
   BugType UseCapAsNonCap{this,
                          "Part of capability value used in binary operator",
@@ -76,6 +76,7 @@ public:
   void checkPostStmt(const ArraySubscriptExpr *E, CheckerContext &C) const;
   void checkBranchCondition(const Stmt *Cond, CheckerContext &C) const;
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
+  void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
   bool ReportForCharPtr = false;
 
@@ -87,7 +88,7 @@ private:
 REGISTER_SET_WITH_PROGRAMSTATE(VoidPtrArgDeref, const MemRegion *)
 REGISTER_SET_WITH_PROGRAMSTATE(UnalignedPtr, const MemRegion *)
 REGISTER_SET_WITH_PROGRAMSTATE(CString, const MemRegion *)
-REGISTER_LIST_WITH_PROGRAMSTATE(WhileBoundVar, SymbolRef)
+REGISTER_SET_WITH_PROGRAMSTATE(WhileBoundVar, SymbolRef)
 
 namespace {
 
@@ -250,8 +251,8 @@ bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C, long N) {
   SValBuilder &SVB = C.getSValBuilder();
   const NonLoc &ItVal = SVB.makeIntVal(N, true);
 
-  auto BoundVarList = C.getState()->get<WhileBoundVar>();
-  for (auto &&V : BoundVarList) {
+  auto BoundVarSet = C.getState()->get<WhileBoundVar>();
+  for (auto &&V : BoundVarSet) {
     auto SmallLoop =
         SVB.evalBinOpNN(C.getState(), clang::BO_GE, nonloc::SymbolVal(V), ItVal,
                         SVB.getConditionType());
@@ -472,8 +473,6 @@ bool checkForWhileBoundVar(const Stmt *Condition, CheckerContext &C,
     if (SymbolRef ISym = C.getSVal(L).getAsSymbol()) {
       if (ThenSt)
         ThenSt = ThenSt->add<WhileBoundVar>(ISym);
-      if (ElseSt)
-        ElseSt = ElseSt->set<WhileBoundVar>(llvm::ImmutableList<SymbolRef>());
     } else
       return false;
   }
@@ -613,6 +612,23 @@ void CapabilityCopyChecker::checkPreCall(const CallEvent &Call,
   }
 
   C.addTransition(State);
+}
+
+void CapabilityCopyChecker::checkDeadSymbols(SymbolReaper &SymReaper,
+                                             CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
+  ProgramStateRef State = C.getState();
+  bool Removed = false;
+
+  State = cleanDead<VoidPtrArgDeref>(State, SymReaper, Removed);
+  State = cleanDead<UnalignedPtr>(State, SymReaper, Removed);
+  State = cleanDead<CString>(State, SymReaper, Removed);
+  State = cleanDead<WhileBoundVar>(State, SymReaper, Removed);
+
+  if (Removed)
+    C.addTransition(State);
 }
 
 void ento::registerCapabilityCopyChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
@@ -41,8 +43,9 @@ public:
   void Profile(llvm::FoldingSetNodeID &ID) const { ID.AddInteger(K); }
 };
 
-class CapabilityCopyChecker : public Checker<check::PostStmt<BinaryOperator>,
-                                             check::Location, check::Bind> {
+class CapabilityCopyChecker
+    : public Checker<check::PostStmt<BinaryOperator>, check::Location,
+                     check::Bind, check::BranchCondition> {
   std::unique_ptr<BugType> UseCapAsNonCap;
   std::unique_ptr<BugType> StoreCapAsNonCap;
 
@@ -53,6 +56,7 @@ public:
   void checkLocation(SVal l, bool isLoad, const Stmt *S,
                      CheckerContext &C) const;
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
+  void checkBranchCondition(const Stmt *Condition, CheckerContext &Ctx) const;
 
 private:
   bool checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
@@ -60,6 +64,7 @@ private:
 } // namespace
 
 REGISTER_SET_WITH_PROGRAMSTATE(VoidPtrArgDeref, const MemRegion *)
+REGISTER_LIST_WITH_PROGRAMSTATE(WhileBoundVar, SymbolRef)
 
 CapabilityCopyChecker::CapabilityCopyChecker() {
   UseCapAsNonCap.reset(
@@ -193,6 +198,51 @@ static bool isCapabilityStorage(CheckerContext &C, const MemRegion *R) {
   return false;
 }
 
+static auto whileConditionMatcher() {
+  using namespace clang::ast_matchers;
+
+  // (--len)
+  // FIXME: PreDec for do-while; PostDec for while
+  auto U =
+      unaryOperator(hasOperatorName("--"), hasUnaryOperand(expr().bind("len")));
+  // (--len > 0)
+  auto BO =
+      binaryOperation(hasAnyOperatorName("!=", ">"), hasLHS(U),
+                      hasRHS(ignoringImplicit(integerLiteral(equals(0)))));
+  return stmt(anyOf(U, BO));
+}
+
+static bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
+                                           unsigned BlockSize) {
+  ASTContext &ASTCtx = C.getASTContext();
+  SValBuilder &SVB = C.getSValBuilder();
+  unsigned CapSize = ASTCtx.getTypeSize(ASTCtx.VoidPtrTy);
+  unsigned IterNum4CapCopy = CapSize / BlockSize;
+  const NonLoc &ItVal = SVB.makeIntVal(IterNum4CapCopy, true);
+
+  auto BoundVarList = C.getState()->get<WhileBoundVar>();
+  for (auto &&V : BoundVarList) {
+    auto SmallLoop =
+        SVB.evalBinOpNN(C.getState(), clang::BO_GE, nonloc::SymbolVal(V), ItVal,
+                        SVB.getConditionType());
+    if (auto LC = SmallLoop.getAs<DefinedOrUnknownSVal>())
+      if (!C.getState()->assume(*LC, true))
+        return true;
+    return false;
+  }
+
+  using namespace clang::ast_matchers;
+  if (C.blockCount() == 1) {
+    // first iter
+    auto doWhileStmtMatcher = doStmt(hasCondition(whileConditionMatcher()));
+    auto M = match(stmt(hasParent(doWhileStmtMatcher)), *S, C.getASTContext());
+    if (!M.empty())
+      return true; // decide on second iteration
+  }
+
+  return false;
+}
+
 void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
                                       CheckerContext &C) const {
   const MemRegion *MR = L.getAsRegion();
@@ -202,19 +252,26 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
   const QualType &PointeeTy = L.getType(C.getASTContext())->getPointeeType();
   if (!isNonCapScalarType(PointeeTy, C.getASTContext()))
     return;
-
   /* Non-capability scalar store */
+
   const CHERITagState &ValTag = getTagState(V, C);
-  if ((ValTag.isTagged() || ValTag.mayBeTagged()) &&
-      isCapabilityStorage(C, MR)) {
-    /* Storing capability to capability storage as non-cap*/
-    if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
-      auto W = std::make_unique<PathSensitiveBugReport>(
-          *StoreCapAsNonCap, "Tag-stripping store of a capability", ErrNode);
-      W->addRange(S->getSourceRange());
-      C.emitReport(std::move(W));
-      return;
-    }
+  if (!ValTag.isTagged() && !ValTag.mayBeTagged())
+    return;
+
+  if (!isCapabilityStorage(C, MR))
+    return;
+
+  // Skip if loop bound is not big enough to copy capability
+  unsigned BlockSize = C.getASTContext().getTypeSize(PointeeTy);
+  if (isInsideSmallConstantBoundLoop(S, C, BlockSize))
+    return;
+
+  /* Storing capability to capability storage as non-cap*/
+  if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
+    auto W = std::make_unique<PathSensitiveBugReport>(
+        *StoreCapAsNonCap, "Tag-stripping store of a capability", ErrNode);
+    W->addRange(S->getSourceRange());
+    C.emitReport(std::move(W));
   }
 }
 
@@ -263,6 +320,44 @@ void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
     return;
 
   checkBinaryOpArg(C, BO->getLHS()) || checkBinaryOpArg(C, BO->getRHS());
+}
+
+void CapabilityCopyChecker::checkBranchCondition(const Stmt *Condition,
+                                                 CheckerContext &Ctx) const {
+  using namespace clang::ast_matchers;
+  // TODO: do-while, merge with second matcher
+  auto childOfWhile = stmt(hasParent(stmt(anyOf(whileStmt(), doStmt()))));
+  auto L = match(childOfWhile, *Condition, Ctx.getASTContext());
+  if (L.empty())
+    return;
+
+  auto whileCond = whileConditionMatcher();
+
+  auto M = match(whileCond, *Condition, Ctx.getASTContext());
+  if (M.size() != 1)
+    return;
+
+  const SVal &CondVal = Ctx.getSVal(Condition);
+  if (Ctx.getSVal(Condition).isUnknownOrUndef())
+    return;
+
+  ProgramStateRef ThenSt, ElseSt;
+  std::tie(ThenSt, ElseSt) =
+      Ctx.getState()->assume(CondVal.castAs<DefinedOrUnknownSVal>());
+  for (auto I : M) {
+    auto L = I.getNodeAs<Expr>("len");
+    if (SymbolRef ISym = Ctx.getSVal(L).getAsSymbol()) {
+      if (ThenSt)
+        ThenSt = ThenSt->add<WhileBoundVar>(ISym);
+      if (ElseSt)
+        ElseSt = ElseSt->set<WhileBoundVar>(llvm::ImmutableList<SymbolRef>());
+    } else
+      return;
+  }
+  if (ThenSt)
+    Ctx.addTransition(ThenSt);
+  if (ElseSt)
+    Ctx.addTransition(ElseSt);
 }
 
 void ento::registerCapabilityCopyChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -116,11 +116,6 @@ const MemRegion *stripNonCapShift(const MemRegion *R, ASTContext &ASTCtx) {
   return ER->getSuperRegion();
 }
 
-bool isGenericPointerType(const QualType T) {
-  return T->isVoidPointerType() ||
-         (T->isPointerType() && T->getPointeeType()->isCharType());
-}
-
 bool isVoidOrCharPtrArgRegion(const MemRegion *Reg) {
   if (!Reg)
     return false;
@@ -170,14 +165,6 @@ CHERITagState getTagState(SVal Val, CheckerContext &C,
   }
 
   return CHERITagState::getUnknown();
-}
-
-CharUnits getCapabilityTypeSize(ASTContext &ASTCtx) {
-  return ASTCtx.getTypeSizeInChars(ASTCtx.VoidPtrTy);
-}
-
-CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
-  return ASTCtx.getTypeAlignInChars(ASTCtx.VoidPtrTy);
 }
 
 bool isCapabilityStorage(CheckerContext &C, const MemRegion *R,

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -16,7 +16,10 @@
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include <clang/ASTMatchers/ASTMatchersInternal.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h>
 
 using namespace clang;
 using namespace ento;
@@ -44,19 +47,33 @@ public:
 };
 
 class CapabilityCopyChecker
-    : public Checker<check::PostStmt<BinaryOperator>, check::Location,
-                     check::Bind, check::BranchCondition> {
+    : public Checker<check::Location, check::Bind,
+                     check::PostStmt<BinaryOperator>,
+                     check::PostStmt<ArraySubscriptExpr>,
+                     check::BranchCondition, check::PreCall> {
+
   std::unique_ptr<BugType> UseCapAsNonCap;
   std::unique_ptr<BugType> StoreCapAsNonCap;
+
+  using CheckFn = std::function<void(const CapabilityCopyChecker *,
+                                     const CallEvent &Call, CheckerContext &C)>;
+  const CallDescriptionMap<int> CStringFn = {
+      {{CDM::SimpleFunc, {"strlen"}, 1}, 1},
+      {{CDM::SimpleFunc, {"strdup"}, 1}, 1},
+      {{CDM::SimpleFunc, {"strcpy"}, 2}, 3},
+      {{CDM::SimpleFunc, {"strcat"}, 2}, 3}};
 
 public:
   CapabilityCopyChecker();
 
-  void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkLocation(SVal l, bool isLoad, const Stmt *S,
                      CheckerContext &C) const;
   void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
-  void checkBranchCondition(const Stmt *Condition, CheckerContext &C) const;
+
+  void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
+  void checkPostStmt(const ArraySubscriptExpr *E, CheckerContext &C) const;
+  void checkBranchCondition(const Stmt *Cond, CheckerContext &C) const;
+  void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
 
 private:
   ExplodedNode *checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
@@ -65,6 +82,7 @@ private:
 
 REGISTER_SET_WITH_PROGRAMSTATE(VoidPtrArgDeref, const MemRegion *)
 REGISTER_SET_WITH_PROGRAMSTATE(UnalignedPtr, const MemRegion *)
+REGISTER_SET_WITH_PROGRAMSTATE(CString, const MemRegion *)
 REGISTER_LIST_WITH_PROGRAMSTATE(WhileBoundVar, SymbolRef)
 
 CapabilityCopyChecker::CapabilityCopyChecker() {
@@ -75,17 +93,18 @@ CapabilityCopyChecker::CapabilityCopyChecker() {
                                      "CHERI portability"));
 }
 
-static bool isPureCapMode(const ASTContext &C) {
+namespace {
+bool isPureCapMode(const ASTContext &C) {
   return C.getTargetInfo().areAllPointersCapabilities();
 }
 
-static bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
+bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
   if (!Type->isPointerType())
     return false;
   return Type->getPointeeType()->isCHERICapabilityType(Ctx, true);
 }
 
-static bool isNonCapScalarType(QualType T, ASTContext &C) {
+bool isNonCapScalarType(QualType T, ASTContext &C) {
   if (!T->isScalarType())
     return false;
   if (T->isCHERICapabilityType(C, true))
@@ -93,8 +112,7 @@ static bool isNonCapScalarType(QualType T, ASTContext &C) {
   return true;
 }
 
-static const MemRegion *stripNonCapShift(const MemRegion *R,
-                                         ASTContext &ASTCtx) {
+const MemRegion *stripNonCapShift(const MemRegion *R, ASTContext &ASTCtx) {
   const auto *ER = dyn_cast<ElementRegion>(R);
   if (!ER)
     return R;
@@ -105,7 +123,12 @@ static const MemRegion *stripNonCapShift(const MemRegion *R,
   return ER->getSuperRegion();
 }
 
-static bool isVoidPtrArgRegion(const MemRegion *Reg) {
+bool isGenericPointerType(const QualType T) {
+  return T->isVoidPointerType() ||
+         (T->isPointerType() && T->getPointeeType()->isCharType());
+}
+
+bool isVoidOrCharPtrArgRegion(const MemRegion *Reg) {
   if (!Reg)
     return false;
 
@@ -115,7 +138,7 @@ static bool isVoidPtrArgRegion(const MemRegion *Reg) {
     return false;
 
   SymbolRef Sym = SymReg->getSymbol();
-  if (!Sym->getType()->isVoidPointerType())
+  if (!isGenericPointerType(Sym->getType()))
     return false;
 
   // 2. void* symbol is function argument
@@ -124,8 +147,8 @@ static bool isVoidPtrArgRegion(const MemRegion *Reg) {
          BaseRegOrigin->getMemorySpace()->hasStackParametersStorage();
 }
 
-static CHERITagState getTagState(SVal Val, CheckerContext &C,
-                                 bool AcceptUnaligned = true) {
+CHERITagState getTagState(SVal Val, CheckerContext &C,
+                          bool AcceptUnaligned = true) {
   if (Val.isUnknownOrUndef())
     return CHERITagState::getUnknown();
 
@@ -137,9 +160,13 @@ static CHERITagState getTagState(SVal Val, CheckerContext &C,
 
   if (SymbolRef Sym = Val.getAsSymbol()) {
     if (const MemRegion *MR = Sym->getOriginRegion()) {
+      const ProgramStateRef S = C.getState();
       const MemRegion *SuperReg = stripNonCapShift(MR, C.getASTContext());
-      if (isVoidPtrArgRegion(SuperReg) &&
-          (AcceptUnaligned || !C.getState()->contains<UnalignedPtr>(SuperReg)))
+      if (isa<FieldRegion>(SuperReg))
+        return CHERITagState::getUnknown(); // not a part of capability
+      if (isVoidOrCharPtrArgRegion(SuperReg) &&
+          (AcceptUnaligned || !S->contains<UnalignedPtr>(SuperReg)) &&
+          !S->contains<CString>(SuperReg))
         return CHERITagState::getMayBeTagged();
       if (MR != SuperReg && isa<TypedValueRegion>(SuperReg)) {
         const SVal &SuperVal = C.getState()->getSVal(SuperReg);
@@ -152,19 +179,37 @@ static CHERITagState getTagState(SVal Val, CheckerContext &C,
   return CHERITagState::getUnknown();
 }
 
-static unsigned getCapabilityTypeSize(ASTContext &ASTCtx) {
+unsigned getCapabilityTypeSize(ASTContext &ASTCtx) {
   return ASTCtx.getTypeSize(ASTCtx.VoidPtrTy);
 }
 
-static CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
+CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
   return ASTCtx.getTypeAlignInChars(ASTCtx.VoidPtrTy);
 }
+
+bool isCapabilityStorage(CheckerContext &C, const MemRegion *R,
+                         bool AcceptUnaligned = true) {
+  const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
+  if (!AcceptUnaligned && C.getState()->contains<UnalignedPtr>(BaseReg))
+    return false;
+  if (C.getState()->contains<CString>(BaseReg))
+    return false;
+  if (const auto *SymR = dyn_cast<SymbolicRegion>(BaseReg)) {
+    QualType const Ty = SymR->getSymbol()->getType();
+    if (isGenericPointerType(Ty))
+      return true;
+    return isPointerToCapTy(Ty, C.getASTContext());
+  }
+  return false;
+}
+
+} // namespace
 
 void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
                                           CheckerContext &C) const {
   if (!isLoad)
     return;
-  ASTContext &ASTCtx = C.getASTContext();
+  const ASTContext &ASTCtx = C.getASTContext();
   if (!isPureCapMode(ASTCtx))
     return;
 
@@ -176,17 +221,17 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
   ProgramStateRef State = C.getState();
   QualType const Ty = l.getType(ASTCtx);
   QualType const ArgValTy = Ty->getPointeeType();
-  if (!ArgValTy->isVoidPointerType())
+  if (!isGenericPointerType(ArgValTy))
     return;
 
   /* Loading VoidPtr function argument */
-  SVal ArgVal = State->getSVal(R, ArgValTy);
+  const SVal ArgVal = State->getSVal(R, ArgValTy);
   const MemRegion *ArgValAsRegion = ArgVal.getAsRegion();
   if (!ArgValAsRegion)
     return;
 
   // If argument has value from caller, CharTy will not be used
-  SVal ArgValDeref = State->getSVal(ArgValAsRegion, ASTCtx.CharTy);
+  const SVal ArgValDeref = State->getSVal(ArgValAsRegion, ASTCtx.CharTy);
 
   const NoteTag *Tag;
   if (const auto *ArgValDerefAsRegion = ArgValDeref.getAsRegion()) {
@@ -200,21 +245,9 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
   C.addTransition(State, C.getPredecessor(), Tag);
 }
 
-static bool isCapabilityStorage(CheckerContext &C, const MemRegion *R,
-                                bool AcceptUnaligned = true) {
-  const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
-  if (!AcceptUnaligned && C.getState()->contains<UnalignedPtr>(BaseReg))
-    return false;
-  if (const auto *SymR = dyn_cast<SymbolicRegion>(BaseReg)) {
-    QualType const Ty = SymR->getSymbol()->getType();
-    if (Ty->isVoidPointerType())
-      return true;
-    return isPointerToCapTy(Ty, C.getASTContext());
-  }
-  return false;
-}
+namespace {
 
-static auto whileConditionMatcher() {
+auto whileConditionMatcher() {
   using namespace clang::ast_matchers;
 
   // (--len)
@@ -228,12 +261,12 @@ static auto whileConditionMatcher() {
   return stmt(anyOf(U, BO));
 }
 
-static bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
-                                           unsigned BlockSize) {
+bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
+                                    unsigned BlockSize) {
   ASTContext &ASTCtx = C.getASTContext();
   SValBuilder &SVB = C.getSValBuilder();
-  unsigned CapSize = getCapabilityTypeSize(ASTCtx);
-  unsigned IterNum4CapCopy = CapSize / BlockSize;
+  const unsigned CapSize = getCapabilityTypeSize(ASTCtx);
+  const unsigned IterNum4CapCopy = CapSize / BlockSize;
   const NonLoc &ItVal = SVB.makeIntVal(IterNum4CapCopy, true);
 
   auto BoundVarList = C.getState()->get<WhileBoundVar>();
@@ -259,6 +292,69 @@ static bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
   return false;
 }
 
+bool isAssignmentInCondition(const Stmt *S, CheckerContext &C) {
+  using namespace clang::ast_matchers;
+  auto A = binaryOperation(hasOperatorName("=")).bind("T");
+  auto L = anyOf(forStmt(hasCondition(expr(hasDescendant(A)))),
+                 whileStmt(hasCondition(expr(hasDescendant(A)))),
+                 doStmt(hasCondition(expr(hasDescendant(A)))));
+
+  auto LB = expr(hasAncestor(stmt(L)), equalsBoundNode("T"));
+  auto M = match(LB, *S, C.getASTContext());
+  return !M.empty();
+}
+
+const MemRegion *isCapAlignCheck(const BinaryOperator *BO, CheckerContext &C) {
+  if (BO->getOpcode() != clang::BO_And)
+    return nullptr;
+
+  const long CapAlignMask =
+      getCapabilityTypeAlign(C.getASTContext()).getQuantity() - 1;
+
+  const SVal &RHSVal = C.getSVal(BO->getRHS());
+  if (!RHSVal.isConstant(CapAlignMask))
+    return nullptr;
+
+  return C.getSVal(BO->getLHS()).getAsRegion();
+}
+
+bool handleAlignmentCheck(const BinaryOperator *BO, ProgramStateRef State,
+                          CheckerContext &C) {
+  auto ExprPtrReg = isCapAlignCheck(BO, C);
+  if (!ExprPtrReg)
+    return false;
+
+  if (!isVoidOrCharPtrArgRegion(ExprPtrReg))
+    return false;
+
+  SVal AndVal = C.getSVal(BO);
+  if (AndVal.isUnknown()) {
+    const LocationContext *LCtx = C.getLocationContext();
+    AndVal = C.getSValBuilder().conjureSymbolVal(nullptr, BO, LCtx,
+                                                 BO->getType(), C.blockCount());
+    State = State->BindExpr(BO, LCtx, AndVal);
+  }
+
+  SValBuilder &SVB = C.getSValBuilder();
+  auto PtrIsCapAligned = SVB.evalEQ(State, AndVal, SVB.makeIntVal(0, true));
+  ProgramStateRef Aligned, NotAligned;
+  std::tie(Aligned, NotAligned) =
+      State->assume(PtrIsCapAligned.castAs<DefinedOrUnknownSVal>());
+
+  if (NotAligned) {
+    // If void* argument value is not capability aligned, then it cannot
+    // be a pointer to capability
+    NotAligned = NotAligned->add<UnalignedPtr>(ExprPtrReg->StripCasts());
+    C.addTransition(NotAligned);
+  }
+
+  if (Aligned)
+    C.addTransition(Aligned);
+
+  return NotAligned || Aligned;
+}
+} // namespace
+
 void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
                                       CheckerContext &C) const {
   ASTContext &ASTCtx = C.getASTContext();
@@ -282,8 +378,12 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
     return;
 
   // Skip if loop bound is not big enough to copy capability
-  unsigned BlockSize = ASTCtx.getTypeSize(PointeeTy);
+  const unsigned BlockSize = ASTCtx.getTypeSize(PointeeTy);
   if (isInsideSmallConstantBoundLoop(S, C, BlockSize))
+    return;
+
+  // Suppress for `while ((*dst++=src++));`
+  if (isAssignmentInCondition(S, C))
     return;
 
   /* Storing capability to capability storage as non-cap*/
@@ -293,6 +393,108 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
     W->addRange(S->getSourceRange());
     C.emitReport(std::move(W));
   }
+}
+
+namespace {
+using namespace clang::ast_matchers;
+using namespace clang::ast_matchers::internal;
+
+ProgramStateRef markOriginAsCStringForMatch(const Stmt *E, Matcher<Stmt> D,
+                                            CheckerContext &C) {
+  auto M = match(D, *E, C.getASTContext());
+
+  bool Updated = false;
+  ProgramStateRef State = C.getState();
+  for (auto I : M) {
+    auto CExpr = I.getNodeAs<Expr>("c");
+    const SVal &CVal = C.getSVal(CExpr);
+
+    const MemRegion *R = CVal.getAsRegion();
+    if (!R)
+      if (SymbolRef Sym = CVal.getAsSymbol())
+        R = Sym->getOriginRegion();
+    if (!R)
+      continue;
+
+    const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
+
+    if (isVoidOrCharPtrArgRegion(BaseReg)) {
+      /* It's probably a string, so it's not to be regarded as a potential
+       * pointer to capability */
+      State = State->add<CString>(BaseReg);
+      Updated = true;
+    }
+  }
+  return Updated ? State : nullptr;
+}
+
+bool checkForWhileBoundVar(const Stmt *Condition, CheckerContext &C,
+                           ProgramStateRef PrevSt) {
+  ASTContext &ASTCtx = C.getASTContext();
+
+  using namespace clang::ast_matchers;
+  // TODO: do-while, merge with second matcher
+  auto childOfWhile = stmt(hasParent(stmt(anyOf(whileStmt(), doStmt()))));
+  auto L = match(childOfWhile, *Condition, ASTCtx);
+  if (L.empty())
+    return false;
+
+  auto whileCond = whileConditionMatcher();
+
+  auto M = match(whileCond, *Condition, ASTCtx);
+  if (M.size() != 1)
+    return false;
+
+  const SVal &CondVal = C.getSVal(Condition);
+  if (C.getSVal(Condition).isUnknownOrUndef())
+    return false;
+
+  ProgramStateRef ThenSt, ElseSt;
+  std::tie(ThenSt, ElseSt) =
+      PrevSt->assume(CondVal.castAs<DefinedOrUnknownSVal>());
+  for (auto I : M) {
+    auto L = I.getNodeAs<Expr>("len");
+    if (SymbolRef ISym = C.getSVal(L).getAsSymbol()) {
+      if (ThenSt)
+        ThenSt = ThenSt->add<WhileBoundVar>(ISym);
+      if (ElseSt)
+        ElseSt = ElseSt->set<WhileBoundVar>(llvm::ImmutableList<SymbolRef>());
+    } else
+      return false;
+  }
+  if (ThenSt)
+    C.addTransition(ThenSt);
+  if (ElseSt)
+    C.addTransition(ElseSt);
+  return true;
+}
+} // namespace
+
+void CapabilityCopyChecker::checkBranchCondition(const Stmt *Cond,
+                                                 CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
+  auto CharMatcher = expr(hasType(isAnyCharacter())).bind("c");
+  auto CondMatcher = stmt(expr(ignoringParenCasts(CharMatcher)));
+  const ProgramStateRef N = markOriginAsCStringForMatch(Cond, CondMatcher, C);
+  bool updated = checkForWhileBoundVar(Cond, C, N ? N : C.getState());
+  if (!updated && N)
+    C.addTransition(N);
+}
+
+void CapabilityCopyChecker::checkPostStmt(const ArraySubscriptExpr *E,
+                                          CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
+  const Expr *Index = E->getIdx();
+  auto CharMatcher = expr(hasType(isAnyCharacter())).bind("c");
+  auto IndexMatcher = stmt(expr(ignoringParenCasts(CharMatcher)));
+
+  const ProgramStateRef N = markOriginAsCStringForMatch(Index, IndexMatcher, C);
+  if (N)
+    C.addTransition(N);
 }
 
 ExplodedNode *CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
@@ -336,110 +538,63 @@ ExplodedNode *CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
   return nullptr;
 }
 
-static const MemRegion *isCapAlignCheck(const BinaryOperator *BO,
-                                        CheckerContext &C) {
-  if (BO->getOpcode() != clang::BO_And)
-    return nullptr;
-
-  long CapAlignMask =
-      getCapabilityTypeAlign(C.getASTContext()).getQuantity() - 1;
-
-  const SVal &RHSVal = C.getSVal(BO->getRHS());
-  if (!RHSVal.isConstant(CapAlignMask))
-    return nullptr;
-
-  return C.getSVal(BO->getLHS()).getAsRegion();
-}
-
 void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
                                           CheckerContext &C) const {
-  ASTContext &ASTCtx = C.getASTContext();
+  const ASTContext &ASTCtx = C.getASTContext();
   if (!isPureCapMode(ASTCtx))
     return;
 
-  ExplodedNode *N = nullptr;
-
   /* Check for capability repr bytes used in arithmetic */
+  ExplodedNode *N = nullptr;
   if (!BO->isAssignmentOp() || BO->isCompoundAssignmentOp()) {
-    N = checkBinaryOpArg(C, BO->getLHS());
-    if (!N)
+    if (!(N = checkBinaryOpArg(C, BO->getLHS())))
       N = checkBinaryOpArg(C, BO->getRHS());
   }
   if (!N)
     N = C.getPredecessor();
+  ProgramStateRef State = N->getState();
 
-  /* Handle alignment check */
-  if (auto ExprPtrReg = isCapAlignCheck(BO, C)) {
-    if (!isVoidPtrArgRegion(ExprPtrReg))
-      return;
-    ProgramStateRef State = N->getState();
+  /* CString character check */
+  using namespace clang::ast_matchers;
+  auto CharMatcher =
+      ignoringParenCasts(expr(hasType(isAnyCharacter())).bind("c"));
+  auto Cmp = binaryOperation(isComparisonOperator(), has(CharMatcher));
 
-    SVal AndVal = C.getSVal(BO);
-    if (AndVal.isUnknown()) {
-      const LocationContext *LCtx = C.getLocationContext();
-      AndVal = C.getSValBuilder().conjureSymbolVal(
-          nullptr, BO, LCtx, BO->getType(), C.blockCount());
-      State = State->BindExpr(BO, LCtx, AndVal);
-    }
+  /* Not a c-string, but rather an array of individual bytes.
+   * We shall handle it the same way as c-string */
+  auto BitOps = hasAnyOperatorName("&", "&=", "^", "^=", "|", "|=");
+  auto Arithm = binaryOperation(BitOps, has(CharMatcher));
 
-    SValBuilder &SVB = C.getSValBuilder();
-    auto PtrIsCapAligned = SVB.evalEQ(State, AndVal, SVB.makeIntVal(0, true));
-    ProgramStateRef Aligned, NotAligned;
-    std::tie(Aligned, NotAligned) =
-        State->assume(PtrIsCapAligned.castAs<DefinedOrUnknownSVal>());
+  auto BOM = anyOf(Cmp, Arithm);
+  const ProgramStateRef NewState = markOriginAsCStringForMatch(BO, BOM, C);
+  if (NewState)
+    State = NewState;
 
-    if (NotAligned) {
-      // If void* argument value is not capability aligned, then it cannot
-      // be a pointer to capability
-      NotAligned = NotAligned->add<UnalignedPtr>(ExprPtrReg->StripCasts());
-      C.addTransition(NotAligned);
-    }
-
-    if (Aligned)
-      C.addTransition(Aligned);
-  }
+  bool updated = handleAlignmentCheck(BO, State, C);
+  if (!updated && NewState)
+    C.addTransition(NewState);
 }
 
-void CapabilityCopyChecker::checkBranchCondition(const Stmt *Condition,
-                                                 CheckerContext &C) const {
-  ASTContext &ASTCtx = C.getASTContext();
-  if (!isPureCapMode(ASTCtx))
+void CapabilityCopyChecker::checkPreCall(const CallEvent &Call,
+                                         CheckerContext &C) const {
+  if (!Call.isGlobalCFunction())
     return;
 
-  using namespace clang::ast_matchers;
-  // TODO: do-while, merge with second matcher
-  auto childOfWhile = stmt(hasParent(stmt(anyOf(whileStmt(), doStmt()))));
-  auto L = match(childOfWhile, *Condition, ASTCtx);
-  if (L.empty())
+  const int *StrParams = CStringFn.lookup(Call);
+  if (!StrParams)
     return;
 
-  auto whileCond = whileConditionMatcher();
-
-  auto M = match(whileCond, *Condition, ASTCtx);
-  if (M.size() != 1)
-    return;
-
-  const SVal &CondVal = C.getSVal(Condition);
-  if (C.getSVal(Condition).isUnknownOrUndef())
-    return;
-
-  ProgramStateRef ThenSt, ElseSt;
-  std::tie(ThenSt, ElseSt) =
-      C.getState()->assume(CondVal.castAs<DefinedOrUnknownSVal>());
-  for (auto I : M) {
-    auto L = I.getNodeAs<Expr>("len");
-    if (SymbolRef ISym = C.getSVal(L).getAsSymbol()) {
-      if (ThenSt)
-        ThenSt = ThenSt->add<WhileBoundVar>(ISym);
-      if (ElseSt)
-        ElseSt = ElseSt->set<WhileBoundVar>(llvm::ImmutableList<SymbolRef>());
-    } else
-      return;
+  ProgramStateRef State = C.getState();
+  int i = 0, P = *StrParams;
+  while (P) {
+    if (P & 1)
+      if (const MemRegion *Str = Call.getArgSVal(i).getAsRegion())
+        State = State->add<CString>(Str);
+    i++;
+    P >>= 1;
   }
-  if (ThenSt)
-    C.addTransition(ThenSt);
-  if (ElseSt)
-    C.addTransition(ElseSt);
+
+  C.addTransition(State);
 }
 
 void ento::registerCapabilityCopyChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -233,15 +233,26 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
   // If argument has value from caller, CharTy will not be used
   const SVal ArgValDeref = State->getSVal(ArgValAsRegion, ASTCtx.CharTy);
 
-  const NoteTag *Tag;
+  bool T;
   if (const auto *ArgValDerefAsRegion = ArgValDeref.getAsRegion()) {
-    Tag = C.getNoteTag("void* argument points to capability");
     State = State->add<VoidPtrArgDeref>(ArgValDerefAsRegion);
+    T = true;
   } else if (ArgValDeref.getAsSymbol()) {
-    Tag = C.getNoteTag("void* argument may be a pointer to capability");
+    T = false;
   } else
     return;
 
+  const NoteTag *Tag =
+      C.getNoteTag([T, ArgValTy](PathSensitiveBugReport &BR) -> std::string {
+        SmallString<80> Msg;
+        llvm::raw_svector_ostream OS(Msg);
+        OS << ArgValTy.getAsString();
+        if (T)
+          OS << " argument points to capability";
+        else
+          OS << " argument may be a pointer to capability";
+        return std::string(OS.str());
+      });
   C.addTransition(State, C.getPredecessor(), Tag);
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CHERIUtils.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
@@ -23,6 +24,7 @@
 
 using namespace clang;
 using namespace ento;
+using namespace cheri;
 
 namespace {
 
@@ -94,15 +96,6 @@ CapabilityCopyChecker::CapabilityCopyChecker() {
 }
 
 namespace {
-bool isPureCapMode(const ASTContext &C) {
-  return C.getTargetInfo().areAllPointersCapabilities();
-}
-
-bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
-  if (!Type->isPointerType())
-    return false;
-  return Type->getPointeeType()->isCHERICapabilityType(Ctx, true);
-}
 
 bool isNonCapScalarType(QualType T, ASTContext &C) {
   if (!T->isScalarType())

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -59,11 +59,12 @@ public:
   void checkBranchCondition(const Stmt *Condition, CheckerContext &Ctx) const;
 
 private:
-  bool checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
+  ExplodedNode *checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
 };
 } // namespace
 
 REGISTER_SET_WITH_PROGRAMSTATE(VoidPtrArgDeref, const MemRegion *)
+REGISTER_SET_WITH_PROGRAMSTATE(UnalignedPtr, const MemRegion *)
 REGISTER_LIST_WITH_PROGRAMSTATE(WhileBoundVar, SymbolRef)
 
 CapabilityCopyChecker::CapabilityCopyChecker() {
@@ -101,6 +102,9 @@ static const MemRegion *stripNonCapShift(const MemRegion *R,
 }
 
 static bool isVoidPtrArgRegion(const MemRegion *Reg) {
+  if (!Reg)
+    return false;
+
   // 1. Reg is pointed by void* symbol
   const SymbolicRegion *SymReg = Reg->getSymbolicBase();
   if (!SymReg)
@@ -116,7 +120,8 @@ static bool isVoidPtrArgRegion(const MemRegion *Reg) {
          BaseRegOrigin->getMemorySpace()->hasStackParametersStorage();
 }
 
-static CHERITagState getTagState(SVal Val, CheckerContext &C) {
+static CHERITagState getTagState(SVal Val, CheckerContext &C,
+                                 bool AcceptUnaligned = true) {
   if (Val.isUnknownOrUndef())
     return CHERITagState::getUnknown();
 
@@ -129,7 +134,8 @@ static CHERITagState getTagState(SVal Val, CheckerContext &C) {
   if (SymbolRef Sym = Val.getAsSymbol()) {
     if (const MemRegion *MR = Sym->getOriginRegion()) {
       const MemRegion *SuperReg = stripNonCapShift(MR, C.getASTContext());
-      if (isVoidPtrArgRegion(SuperReg))
+      if (isVoidPtrArgRegion(SuperReg) &&
+          (AcceptUnaligned || !C.getState()->contains<UnalignedPtr>(SuperReg)))
         return CHERITagState::getMayBeTagged();
       if (MR != SuperReg && isa<TypedValueRegion>(SuperReg)) {
         const SVal &SuperVal = C.getState()->getSVal(SuperReg);
@@ -187,8 +193,11 @@ void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
   C.addTransition(State, C.getPredecessor(), Tag);
 }
 
-static bool isCapabilityStorage(CheckerContext &C, const MemRegion *R) {
+static bool isCapabilityStorage(CheckerContext &C, const MemRegion *R,
+                                bool AcceptUnaligned = true) {
   const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
+  if (!AcceptUnaligned && C.getState()->contains<UnalignedPtr>(BaseReg))
+    return false;
   if (const auto *SymR = dyn_cast<SymbolicRegion>(BaseReg)) {
     QualType const Ty = SymR->getSymbol()->getType();
     if (Ty->isVoidPointerType())
@@ -216,7 +225,7 @@ static bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
                                            unsigned BlockSize) {
   ASTContext &ASTCtx = C.getASTContext();
   SValBuilder &SVB = C.getSValBuilder();
-  unsigned CapSize = ASTCtx.getTypeSize(ASTCtx.VoidPtrTy);
+  unsigned CapSize = getCapabilityTypeSize(ASTCtx);
   unsigned IterNum4CapCopy = CapSize / BlockSize;
   const NonLoc &ItVal = SVB.makeIntVal(IterNum4CapCopy, true);
 
@@ -275,11 +284,11 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
   }
 }
 
-bool CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
-                                             const Expr *E) const {
+ExplodedNode *CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
+                                                      const Expr *E) const {
   ASTContext &ASTCtx = C.getASTContext();
   if (!isNonCapScalarType(E->getType(), ASTCtx))
-    return false;
+    return nullptr;
 
   const SVal &Val = C.getSVal(E);
   const MemRegion *MR = Val.getAsRegion();
@@ -287,15 +296,15 @@ bool CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
     // Check if Val is a part of capability
     SymbolRef Sym = Val.getAsSymbol();
     if (!Sym)
-      return false;
+      return nullptr;
     const MemRegion *OrigRegion = Sym->getOriginRegion();
     if (!OrigRegion)
-      return false;
+      return nullptr;
     const MemRegion *SReg = stripNonCapShift(OrigRegion, C.getASTContext());
     const SVal &WiderVal = C.getState()->getSVal(SReg, ASTCtx.CharTy);
     MR = WiderVal.getAsRegion();
     if (!MR)
-      return false;
+      return nullptr;
   }
 
   if (C.getState()->contains<VoidPtrArgDeref>(MR)) {
@@ -308,18 +317,70 @@ bool CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
           ErrNode);
       W->addRange(E->getSourceRange());
       C.emitReport(std::move(W));
-      return true;
+      return ErrNode;
     }
   }
-  return false;
+  return nullptr;
+}
+
+static const MemRegion *isCapAlignCheck(const BinaryOperator *BO,
+                                        CheckerContext &C) {
+  if (BO->getOpcode() != clang::BO_And)
+    return nullptr;
+
+  long CapAlignMask =
+      getCapabilityTypeAlign(C.getASTContext()).getQuantity() - 1;
+
+  const SVal &RHSVal = C.getSVal(BO->getRHS());
+  if (!RHSVal.isConstant(CapAlignMask))
+    return nullptr;
+
+  return C.getSVal(BO->getLHS()).getAsRegion();
 }
 
 void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
                                           CheckerContext &C) const {
-  if (BO->isAssignmentOp())
-    return;
+  ExplodedNode *N = nullptr;
 
-  checkBinaryOpArg(C, BO->getLHS()) || checkBinaryOpArg(C, BO->getRHS());
+  /* Check for capability repr bytes used in arithmetic */
+  if (!BO->isAssignmentOp() || BO->isCompoundAssignmentOp()) {
+    N = checkBinaryOpArg(C, BO->getLHS());
+    if (!N)
+      N = checkBinaryOpArg(C, BO->getRHS());
+  }
+  if (!N)
+    N = C.getPredecessor();
+
+  /* Handle alignment check */
+  if (auto ExprPtrReg = isCapAlignCheck(BO, C)) {
+    if (!isVoidPtrArgRegion(ExprPtrReg))
+      return;
+    ProgramStateRef State = N->getState();
+
+    SVal AndVal = C.getSVal(BO);
+    if (AndVal.isUnknown()) {
+      const LocationContext *LCtx = C.getLocationContext();
+      AndVal = C.getSValBuilder().conjureSymbolVal(
+          nullptr, BO, LCtx, BO->getType(), C.blockCount());
+      State = State->BindExpr(BO, LCtx, AndVal);
+    }
+
+    SValBuilder &SVB = C.getSValBuilder();
+    auto PtrIsCapAligned = SVB.evalEQ(State, AndVal, SVB.makeIntVal(0, true));
+    ProgramStateRef Aligned, NotAligned;
+    std::tie(Aligned, NotAligned) =
+        State->assume(PtrIsCapAligned.castAs<DefinedOrUnknownSVal>());
+
+    if (NotAligned) {
+      // If void* argument value is not capability aligned, then it cannot
+      // be a pointer to capability
+      NotAligned = NotAligned->add<UnalignedPtr>(ExprPtrReg->StripCasts());
+      C.addTransition(NotAligned);
+    }
+
+    if (Aligned)
+      C.addTransition(Aligned);
+  }
 }
 
 void CapabilityCopyChecker::checkBranchCondition(const Stmt *Condition,

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -1,0 +1,274 @@
+//===-- CapabilityCopyChecker.cpp - Capability Copy Checker -*- C++ -*-----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines checker that detects tag-stripping loads and stores that
+// may be used to copy or swap capabilities
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+
+using namespace clang;
+using namespace ento;
+
+namespace {
+
+struct CHERITagState {
+private:
+  enum Kind { Unknown, Tagged, MayBeTagged, Untagged } K;
+  CHERITagState(Kind InK) : K(InK) {}
+
+public:
+  bool isTagged() const { return K == Tagged; }
+  bool mayBeTagged() const { return K == MayBeTagged; }
+  bool isUntagged() const { return K == Untagged; }
+  bool isKnown() const { return K != Unknown; }
+
+  static CHERITagState getTagged() { return CHERITagState(Tagged); }
+  static CHERITagState getMayBeTagged() { return CHERITagState(MayBeTagged); }
+  static CHERITagState getUntagged() { return CHERITagState(Untagged); }
+  static CHERITagState getUnknown() { return CHERITagState(Unknown); }
+
+  bool operator==(const CHERITagState &X) const { return K == X.K; }
+  void Profile(llvm::FoldingSetNodeID &ID) const { ID.AddInteger(K); }
+};
+
+class CapabilityCopyChecker : public Checker<check::PostStmt<BinaryOperator>,
+                                             check::Location, check::Bind> {
+  std::unique_ptr<BugType> UseCapAsNonCap;
+  std::unique_ptr<BugType> StoreCapAsNonCap;
+
+public:
+  CapabilityCopyChecker();
+
+  void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
+  void checkLocation(SVal l, bool isLoad, const Stmt *S,
+                     CheckerContext &C) const;
+  void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
+
+private:
+  bool checkBinaryOpArg(CheckerContext &C, const Expr *E) const;
+};
+} // namespace
+
+REGISTER_SET_WITH_PROGRAMSTATE(VoidPtrArgDeref, const MemRegion *)
+
+CapabilityCopyChecker::CapabilityCopyChecker() {
+  UseCapAsNonCap.reset(
+      new BugType(this, "Part of capability value used in binary operator",
+                  "CHERI portability"));
+  StoreCapAsNonCap.reset(new BugType(this, "Tag-stripping copy of capability",
+                                     "CHERI portability"));
+}
+
+static bool isPointerToCapTy(const QualType Type, ASTContext &Ctx) {
+  if (!Type->isPointerType())
+    return false;
+  return Type->getPointeeType()->isCHERICapabilityType(Ctx, true);
+}
+
+static bool isNonCapScalarType(QualType T, ASTContext &C) {
+  if (!T->isScalarType())
+    return false;
+  if (T->isCHERICapabilityType(C, true))
+    return false;
+  return true;
+}
+
+static const MemRegion *stripNonCapShift(const MemRegion *R,
+                                         ASTContext &ASTCtx) {
+  const auto *ER = dyn_cast<ElementRegion>(R);
+  if (!ER)
+    return R;
+
+  if (!isNonCapScalarType(ER->getValueType(), ASTCtx))
+    return R;
+
+  return ER->getSuperRegion();
+}
+
+static bool isVoidPtrArgRegion(const MemRegion *Reg) {
+  // 1. Reg is pointed by void* symbol
+  const SymbolicRegion *SymReg = Reg->getSymbolicBase();
+  if (!SymReg)
+    return false;
+
+  SymbolRef Sym = SymReg->getSymbol();
+  if (!Sym->getType()->isVoidPointerType())
+    return false;
+
+  // 2. void* symbol is function argument
+  const MemRegion *BaseRegOrigin = Sym->getOriginRegion();
+  return BaseRegOrigin &&
+         BaseRegOrigin->getMemorySpace()->hasStackParametersStorage();
+}
+
+static CHERITagState getTagState(SVal Val, CheckerContext &C) {
+  if (Val.isUnknownOrUndef())
+    return CHERITagState::getUnknown();
+
+  if (Val.isConstant())
+    return CHERITagState::getUntagged();
+
+  if (Val.getAsRegion())
+    return CHERITagState::getTagged();
+
+  if (SymbolRef Sym = Val.getAsSymbol()) {
+    if (const MemRegion *MR = Sym->getOriginRegion()) {
+      const MemRegion *SuperReg = stripNonCapShift(MR, C.getASTContext());
+      if (isVoidPtrArgRegion(SuperReg))
+        return CHERITagState::getMayBeTagged();
+      if (MR != SuperReg && isa<TypedValueRegion>(SuperReg)) {
+        const SVal &SuperVal = C.getState()->getSVal(SuperReg);
+        if (Val != SuperVal)
+          return getTagState(SuperVal, C);
+      }
+    }
+  }
+
+  return CHERITagState::getUnknown();
+}
+
+static unsigned getCapabilityTypeSize(ASTContext &ASTCtx) {
+  return ASTCtx.getTypeSize(ASTCtx.VoidPtrTy);
+}
+
+static CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
+  return ASTCtx.getTypeAlignInChars(ASTCtx.VoidPtrTy);
+}
+
+void CapabilityCopyChecker::checkLocation(SVal l, bool isLoad, const Stmt *S,
+                                          CheckerContext &C) const {
+  if (!isLoad)
+    return;
+
+  const MemRegion *R = l.getAsRegion();
+  if (!R || !R->hasStackParametersStorage())
+    return;
+
+  // Get ArgVal
+  ProgramStateRef State = C.getState();
+  QualType const Ty = l.getType(C.getASTContext());
+  QualType const ArgValTy = Ty->getPointeeType();
+  if (!ArgValTy->isVoidPointerType())
+    return;
+
+  /* Loading VoidPtr function argument */
+  SVal ArgVal = State->getSVal(R, ArgValTy);
+  const MemRegion *ArgValAsRegion = ArgVal.getAsRegion();
+  if (!ArgValAsRegion)
+    return;
+
+  // If argument has value from caller, CharTy will not be used
+  SVal ArgValDeref = State->getSVal(ArgValAsRegion, C.getASTContext().CharTy);
+
+  const NoteTag *Tag;
+  if (const auto *ArgValDerefAsRegion = ArgValDeref.getAsRegion()) {
+    Tag = C.getNoteTag("void* argument points to capability");
+    State = State->add<VoidPtrArgDeref>(ArgValDerefAsRegion);
+  } else if (ArgValDeref.getAsSymbol()) {
+    Tag = C.getNoteTag("void* argument may be a pointer to capability");
+  } else
+    return;
+
+  C.addTransition(State, C.getPredecessor(), Tag);
+}
+
+static bool isCapabilityStorage(CheckerContext &C, const MemRegion *R) {
+  const MemRegion *BaseReg = stripNonCapShift(R, C.getASTContext());
+  if (const auto *SymR = dyn_cast<SymbolicRegion>(BaseReg)) {
+    QualType const Ty = SymR->getSymbol()->getType();
+    if (Ty->isVoidPointerType())
+      return true;
+    return isPointerToCapTy(Ty, C.getASTContext());
+  }
+  return false;
+}
+
+void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
+                                      CheckerContext &C) const {
+  const MemRegion *MR = L.getAsRegion();
+  if (!MR)
+    return;
+
+  const QualType &PointeeTy = L.getType(C.getASTContext())->getPointeeType();
+  if (!isNonCapScalarType(PointeeTy, C.getASTContext()))
+    return;
+
+  /* Non-capability scalar store */
+  const CHERITagState &ValTag = getTagState(V, C);
+  if ((ValTag.isTagged() || ValTag.mayBeTagged()) &&
+      isCapabilityStorage(C, MR)) {
+    /* Storing capability to capability storage as non-cap*/
+    if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
+      auto W = std::make_unique<PathSensitiveBugReport>(
+          *StoreCapAsNonCap, "Tag-stripping store of a capability", ErrNode);
+      W->addRange(S->getSourceRange());
+      C.emitReport(std::move(W));
+      return;
+    }
+  }
+}
+
+bool CapabilityCopyChecker::checkBinaryOpArg(CheckerContext &C,
+                                             const Expr *E) const {
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isNonCapScalarType(E->getType(), ASTCtx))
+    return false;
+
+  const SVal &Val = C.getSVal(E);
+  const MemRegion *MR = Val.getAsRegion();
+  if (!MR) {
+    // Check if Val is a part of capability
+    SymbolRef Sym = Val.getAsSymbol();
+    if (!Sym)
+      return false;
+    const MemRegion *OrigRegion = Sym->getOriginRegion();
+    if (!OrigRegion)
+      return false;
+    const MemRegion *SReg = stripNonCapShift(OrigRegion, C.getASTContext());
+    const SVal &WiderVal = C.getState()->getSVal(SReg, ASTCtx.CharTy);
+    MR = WiderVal.getAsRegion();
+    if (!MR)
+      return false;
+  }
+
+  if (C.getState()->contains<VoidPtrArgDeref>(MR)) {
+    /* Pointer to capability passed as void* argument */
+    if (ExplodedNode *ErrNode = C.generateNonFatalErrorNode()) {
+      auto W = std::make_unique<PathSensitiveBugReport>(
+          *UseCapAsNonCap,
+          "Part of capability representation used as argument in binary "
+          "operator",
+          ErrNode);
+      W->addRange(E->getSourceRange());
+      C.emitReport(std::move(W));
+      return true;
+    }
+  }
+  return false;
+}
+
+void CapabilityCopyChecker::checkPostStmt(const BinaryOperator *BO,
+                                          CheckerContext &C) const {
+  if (BO->isAssignmentOp())
+    return;
+
+  checkBinaryOpArg(C, BO->getLHS()) || checkBinaryOpArg(C, BO->getRHS());
+}
+
+void ento::registerCapabilityCopyChecker(CheckerManager &mgr) {
+  mgr.registerChecker<CapabilityCopyChecker>();
+}
+
+bool ento::shouldRegisterCapabilityCopyChecker(const CheckerManager &Mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CapabilityCopyChecker.cpp
@@ -179,8 +179,8 @@ CHERITagState getTagState(SVal Val, CheckerContext &C,
   return CHERITagState::getUnknown();
 }
 
-unsigned getCapabilityTypeSize(ASTContext &ASTCtx) {
-  return ASTCtx.getTypeSize(ASTCtx.VoidPtrTy);
+CharUnits getCapabilityTypeSize(ASTContext &ASTCtx) {
+  return ASTCtx.getTypeSizeInChars(ASTCtx.VoidPtrTy);
 }
 
 CharUnits getCapabilityTypeAlign(ASTContext &ASTCtx) {
@@ -261,13 +261,9 @@ auto whileConditionMatcher() {
   return stmt(anyOf(U, BO));
 }
 
-bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
-                                    unsigned BlockSize) {
-  ASTContext &ASTCtx = C.getASTContext();
+bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C, long N) {
   SValBuilder &SVB = C.getSValBuilder();
-  const unsigned CapSize = getCapabilityTypeSize(ASTCtx);
-  const unsigned IterNum4CapCopy = CapSize / BlockSize;
-  const NonLoc &ItVal = SVB.makeIntVal(IterNum4CapCopy, true);
+  const NonLoc &ItVal = SVB.makeIntVal(N, true);
 
   auto BoundVarList = C.getState()->get<WhileBoundVar>();
   for (auto &&V : BoundVarList) {
@@ -290,6 +286,41 @@ bool isInsideSmallConstantBoundLoop(const Stmt *S, CheckerContext &C,
   }
 
   return false;
+}
+
+CharUnits getNonCapShift(SVal V) {
+  if (SymbolRef Sym = V.getAsSymbol())
+    if (const MemRegion *MR = Sym->getOriginRegion())
+      if (const auto *ER = dyn_cast<ElementRegion>(MR)) {
+        const RegionRawOffset &Offset = ER->getAsArrayOffset();
+        if (Offset.getRegion())
+          return Offset.getOffset();
+      }
+
+  return CharUnits::Zero();
+}
+
+bool isPartOfCopyingSequence(const QualType &CopyTy, SVal V, const Stmt *S,
+                             CheckerContext &C) {
+  ASTContext &ASTCtx = C.getASTContext();
+  const CharUnits CopySize = ASTCtx.getTypeSizeInChars(CopyTy);
+  const CharUnits CapSize = getCapabilityTypeSize(ASTCtx);
+
+  /* False if loop bound is not big enough to copy capability */
+  const long N = CapSize.alignTo(CopySize) / CopySize;
+  if (isInsideSmallConstantBoundLoop(S, C, N))
+    return false;
+
+  /* True if copy is in loop */
+  using namespace clang::ast_matchers;
+  auto L = anyOf(forStmt(), whileStmt(), doStmt());
+  auto LB = expr(hasAncestor(stmt(L)));
+  if (!match(LB, *S, C.getASTContext()).empty())
+    return true;
+
+  /* Sequence of individual assignments */
+  CharUnits Shift = getNonCapShift(V);
+  return (Shift + CopySize) >= CapSize;
 }
 
 bool isAssignmentInCondition(const Stmt *S, CheckerContext &C) {
@@ -377,9 +408,7 @@ void CapabilityCopyChecker::checkBind(SVal L, SVal V, const Stmt *S,
   if (!isCapabilityStorage(C, MR))
     return;
 
-  // Skip if loop bound is not big enough to copy capability
-  const unsigned BlockSize = ASTCtx.getTypeSize(PointeeTy);
-  if (isInsideSmallConstantBoundLoop(S, C, BlockSize))
+  if (ValTag.mayBeTagged() && !isPartOfCopyingSequence(PointeeTy, V, S, C))
     return;
 
   // Suppress for `while ((*dst++=src++));`

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriAPIModelling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriAPIModelling.cpp
@@ -1,0 +1,93 @@
+//===-- AllocationChecker.cpp - Allocation Checker -*- C++ -*--------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Model CHERI API
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h"
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h>
+
+using namespace clang;
+using namespace ento;
+
+// namespace {
+
+class CheriAPIModelling : public Checker<eval::Call> {
+public:
+  bool evalCall(const CallEvent &Call, CheckerContext &C) const;
+
+  typedef void (CheriAPIModelling::*FnCheck)(CheckerContext &,
+                                             const CallExpr *) const;
+  CallDescriptionMap<FnCheck> Callbacks = {
+      {{CDM::SimpleFunc, {"cheri_address_set"}, 2},
+       &CheriAPIModelling::evalAddrSet},
+      {{CDM::SimpleFunc, {"cheri_bounds_set"}, 2},
+       &CheriAPIModelling::evalBoundsSet},
+      {{CDM::SimpleFunc, {"cheri_bounds_set_exact"}, 2},
+       &CheriAPIModelling::evalBoundsSet},
+      {{CDM::SimpleFunc, {"cheri_perms_and"}, 2},
+       &CheriAPIModelling::evalBoundsSet},
+      {{CDM::SimpleFunc, {"cheri_tag_clear"}, 1},
+       &CheriAPIModelling::evalBoundsSet}
+
+  };
+
+  void evalBoundsSet(CheckerContext &C, const CallExpr *CE) const;
+  void evalAddrSet(CheckerContext &C, const CallExpr *CE) const;
+};
+
+//} // namespace
+
+void CheriAPIModelling::evalBoundsSet(CheckerContext &C,
+                                      const CallExpr *CE) const {
+  auto State = C.getState();
+  SVal Cap = C.getSVal(CE->getArg(0));
+  State = State->BindExpr(CE, C.getLocationContext(), Cap);
+  C.addTransition(State);
+}
+
+void CheriAPIModelling::evalAddrSet(CheckerContext &C,
+                                    const CallExpr *CE) const {
+  auto State = C.getState();
+  SVal Addr = C.getSVal(CE->getArg(1));
+  State = State->BindExpr(CE, C.getLocationContext(), Addr);
+  C.addTransition(State);
+}
+
+bool CheriAPIModelling::evalCall(const CallEvent &Call,
+                                 CheckerContext &C) const {
+  const auto *CE = dyn_cast_or_null<CallExpr>(Call.getOriginExpr());
+  if (!CE)
+    return false;
+
+  const FnCheck *Handler = Callbacks.lookup(Call);
+  if (!Handler)
+    return false;
+
+  (this->**Handler)(C, CE);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Checker registration.
+//===----------------------------------------------------------------------===//
+
+void clang::ento::registerCheriAPIModelling(CheckerManager &Mgr) {
+  Mgr.registerChecker<CheriAPIModelling>();
+}
+
+bool clang::ento::shouldRegisterCheriAPIModelling(const CheckerManager &Mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/PointerSizeAssumptionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/PointerSizeAssumptionsChecker.cpp
@@ -1,0 +1,124 @@
+// ==-- PointerSizeAssumptionsChecker.cpp -------------------------*- C++ -*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This checker detects code where the pointer size was checked against
+// a constant, but the case of capabilities was not addressed explicitly.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/StmtVisitor.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/AnalysisManager.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "CHERIUtils.h"
+
+using namespace clang;
+using namespace ento;
+using namespace cheri;
+using namespace ast_matchers;
+
+namespace {
+
+// ID of a node at which the diagnostic would be emitted.
+constexpr llvm::StringLiteral WarnAtNode = "if_stmt";
+constexpr llvm::StringLiteral ConstNode = "size_const";
+constexpr llvm::StringLiteral TypeNode = "sizeof_type";
+
+class PointerSizeAssumptionsChecker : public Checker<check::ASTCodeBody> {
+public:
+  void checkASTCodeBody(const Decl *D, AnalysisManager &mgr,
+                        BugReporter &BR) const;
+};
+
+auto matchCheckPtrSize() -> decltype(decl()) {
+  // sizeof(void*) ...
+  auto PtrSize = sizeOfExpr(has(expr(hasType(pointerType())).bind("ptr")));
+
+  // ... == 8
+  auto SizeConst = ignoringImplicit(integerLiteral().bind(ConstNode));
+
+  // ... == sizeof long_var
+  auto SizeofFTy =
+      sizeOfExpr(unless(has(expr(hasType(pointerType()))))).bind(TypeNode);
+
+  auto Size = expr(anyOf(SizeConst, SizeofFTy));
+
+  auto Check = binaryOperation(isComparisonOperator(), has(PtrSize), has(Size));
+  auto PointerSizeCheck =
+      traverse(TK_AsIs, stmt(ifStmt(hasCondition(Check))).bind(WarnAtNode));
+
+  return decl(forEachDescendant(PointerSizeCheck));
+}
+
+static void emitDiagnostics(const Expr *WarnStmt, const Decl *D,
+                            BugReporter &BR, AnalysisManager &AM,
+                            const PointerSizeAssumptionsChecker *Checker) {
+  auto *ADC = AM.getAnalysisDeclContext(D);
+
+  auto Range = WarnStmt->getSourceRange();
+  auto Location =
+      PathDiagnosticLocation::createBegin(WarnStmt, BR.getSourceManager(), ADC);
+  std::string Diagnostics;
+  llvm::raw_string_ostream OS(Diagnostics);
+
+  ASTContext &ASTCtx = AM.getASTContext();
+  OS << "This code may fail to consider the case of "
+     << ASTCtx.toBits(getCapabilityTypeSize(ASTCtx)) << "-bit "
+     << "pointers";
+
+  BR.EmitBasicReport(ADC->getDecl(), Checker,
+                     "Only a limited number of pointer sizes checked",
+                     "CHERI portability", OS.str(), Location, Range);
+}
+
+void PointerSizeAssumptionsChecker::checkASTCodeBody(const Decl *D,
+                                                     AnalysisManager &AM,
+                                                     BugReporter &BR) const {
+  auto MatcherM = matchCheckPtrSize();
+
+  ASTContext &ASTCtx = AM.getASTContext();
+  const unsigned CAP_SIZEOF = getCapabilityTypeSize(ASTCtx).getQuantity();
+  auto Matches = match(MatcherM, *D, ASTCtx);
+  const IfStmt *WarnStmt = nullptr;
+  for (const auto &Match : Matches) {
+    unsigned s;
+    if (const IntegerLiteral *IL = Match.getNodeAs<IntegerLiteral>(ConstNode)) {
+      s = IL->getValue().getZExtValue();
+    } else {
+      const UnaryExprOrTypeTraitExpr *SizeOfExpr =
+          Match.getNodeAs<UnaryExprOrTypeTraitExpr>(TypeNode);
+      assert(SizeOfExpr);
+      s = AM.getASTContext()
+              .getTypeSizeInChars(SizeOfExpr->getTypeOfArgument())
+              .getQuantity();
+    }
+    if (s == CAP_SIZEOF)
+      return;
+    if (!WarnStmt)
+      WarnStmt = Match.getNodeAs<IfStmt>(WarnAtNode);
+  }
+  if (WarnStmt)
+    emitDiagnostics(WarnStmt->getCond(), D, BR, AM, this);
+}
+
+} // namespace
+
+void ento::registerPointerSizeAssumptionsChecker(CheckerManager &mgr) {
+  mgr.registerChecker<PointerSizeAssumptionsChecker>();
+}
+
+bool ento::shouldRegisterPointerSizeAssumptionsChecker(
+    const CheckerManager &mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -27,8 +27,11 @@ class ProvenanceSourceChecker
     : public Checker<check::PostStmt<CastExpr>, check::PreStmt<CastExpr>,
                      check::PostStmt<BinaryOperator>,
                      check::PostStmt<UnaryOperator>, check::DeadSymbols> {
-  std::unique_ptr<BugType> AmbiguousProvenanceBinOpBugType;
-  std::unique_ptr<BugType> AmbiguousProvenancePtrBugType;
+  std::unique_ptr<BugType> AmbigProvAddrArithBugType;
+  std::unique_ptr<BugType> AmbigProvWrongOrderBugType;
+  std::unique_ptr<BugType> AmbigProvBinOpBugType;
+
+  std::unique_ptr<BugType> AmbigProvAsPtrBugType;
   std::unique_ptr<BugType> InvalidCapPtrBugType;
   std::unique_ptr<BugType> PtrdiffAsIntCapBugType;
 
@@ -82,6 +85,11 @@ public:
 
 private:
   // Utility
+  const BugType &explainWarning(const BinaryOperator *BO, CheckerContext &C,
+                                bool LHSIsAddr, bool LHSIsNullDerived,
+                                bool RHSIsAddr, bool RHSIsNullDerived,
+                                raw_ostream &OS) const;
+
   ExplodedNode *emitAmbiguousProvenanceWarn(const BinaryOperator *BO,
                                             CheckerContext &C, bool LHSIsAddr,
                                             bool LHSIsNullDerived,
@@ -103,11 +111,20 @@ REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceReg, const MemRegion *)
 REGISTER_TRAIT_WITH_PROGRAMSTATE(Ptr2IntCapId, unsigned)
 
 ProvenanceSourceChecker::ProvenanceSourceChecker() {
-  AmbiguousProvenanceBinOpBugType.reset(new BugType(
+  AmbigProvBinOpBugType.reset(new BugType(
       this, "Binary operation with ambiguous provenance", "CHERI portability"));
-  AmbiguousProvenancePtrBugType.reset(
+  AmbigProvAddrArithBugType.reset(new BugType(
+      this, "CHERI-incompatible pointer arithmetic", "CHERI portability"));
+  AmbigProvWrongOrderBugType.reset(new BugType(
+      this, "Capability derived from wrong argument", "CHERI portability"));
+
+  AmbigProvAsPtrBugType.reset(
       new BugType(this, "Capability with ambiguous provenance used as pointer",
                   "CHERI portability"));
+  InvalidCapPtrBugType.reset(new BugType(
+      this, "Invalid capability used as pointer", "CHERI portability"));
+  PtrdiffAsIntCapBugType.reset(new BugType(
+      this, "Pointer difference as capability", "CHERI portability"));
   InvalidCapPtrBugType.reset(new BugType(
       this, "Invalid capability used as pointer", "CHERI portability"));
   PtrdiffAsIntCapBugType.reset(new BugType(
@@ -225,7 +242,7 @@ void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
     if (!ErrNode)
       return;
     R = std::make_unique<PathSensitiveBugReport>(
-        *AmbiguousProvenancePtrBugType,
+        *AmbigProvAsPtrBugType,
         "Capability with ambiguous provenance is used as pointer", ErrNode);
   } else if (hasNoProvenance(State, SrcVal) && !SrcVal.isConstant() &&
              !isIntToVoidPtrCast(CE)) {
@@ -298,46 +315,77 @@ FixItHint addFixIt(const Expr *NDOp, CheckerContext &C, bool IsUnsigned) {
 
 } // namespace
 
-ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
+const BugType &ProvenanceSourceChecker::explainWarning(
     const BinaryOperator *BO, CheckerContext &C, bool LHSIsAddr,
-    bool LHSIsNullDerived, bool RHSIsAddr, bool RHSIsNullDerived) const {
-  SmallString<350> ErrorMessage;
-  llvm::raw_svector_ostream OS(ErrorMessage);
-
-  const QualType &T = BO->getType();
-  bool const IsUnsigned = T->isUnsignedIntegerType();
-
+    bool LHSIsNullDerived, bool RHSIsAddr, bool RHSIsNullDerived,
+    raw_ostream &OS) const {
   OS << "Result of '" << BO->getOpcodeStr() << "' on capability type '";
-  T.print(OS, PrintingPolicy(C.getASTContext().getLangOpts()));
-  OS << "'; it is unclear which side should be used as the source "
-        "of provenance; consider indicating the provenance-carrying argument "
-        "explicitly by casting the other argument to '"
-     << (IsUnsigned ? "size_t" : "ptrdiff_t") << "'. ";
+  BO->getType().print(OS, PrintingPolicy(C.getASTContext().getLangOpts()));
+  OS << "'; it is unclear which side should be used as the source of "
+        "provenance";
 
-  OS << "Note: along this path, ";
-  if (LHSIsAddr && RHSIsAddr)
-    OS << "LHS and RHS were derived from pointers";
-  else if (LHSIsNullDerived && RHSIsNullDerived) {
+  if (RHSIsAddr) {
+    OS << ". Note: along this path, ";
+    if (LHSIsAddr) {
+      OS << "LHS and RHS were derived from pointers."
+            " Result capability will be derived from LHS by default."
+            " This code may need to be rewritten for CHERI.";
+      return *AmbigProvAddrArithBugType;
+    }
+
+    if (LHSIsNullDerived) {
+      OS << "LHS was derived from NULL, RHS was derived from pointer."
+            " Currently, provenance is inherited from LHS,"
+            " therefore result capability will be invalid.";
+    } else { // unknown LHS provenance
+      OS << "RHS was derived from pointer."
+            " Currently, provenance is inherited from LHS."
+            " Consider indicating the provenance-carrying argument "
+            " explicitly by casting the other argument to '"
+         << (BO->getType()->isUnsignedIntegerType() ? "size_t" : "ptrdiff_t")
+         << "'. ";
+    }
+    return *AmbigProvWrongOrderBugType;
+  }
+
+  OS << "; consider indicating the provenance-carrying argument "
+        "explicitly by casting the other argument to '"
+     << (BO->getType()->isUnsignedIntegerType() ? "size_t" : "ptrdiff_t")
+     << "'. Note: along this path, ";
+
+  if (LHSIsNullDerived && RHSIsNullDerived) {
     OS << "LHS and RHS were derived from NULL";
   } else {
     if (LHSIsAddr)
       OS << "LHS was derived from pointer";
     if (LHSIsNullDerived)
       OS << "LHS was derived from NULL";
-    if ((LHSIsAddr || LHSIsNullDerived) && (RHSIsAddr || RHSIsNullDerived))
-      OS << ", ";
-    if (RHSIsAddr)
-      OS << "RHS was derived from pointer";
-    if (RHSIsNullDerived)
+    if (RHSIsNullDerived) {
+      if (LHSIsAddr || LHSIsNullDerived)
+        OS << ", ";
       OS << "RHS was derived from NULL";
+    }
   }
+
+  return *AmbigProvBinOpBugType;
+}
+
+ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
+    const BinaryOperator *BO, CheckerContext &C, bool LHSIsAddr,
+    bool LHSIsNullDerived, bool RHSIsAddr, bool RHSIsNullDerived) const {
+  bool const IsUnsigned = BO->getType()->isUnsignedIntegerType();
+
+  SmallString<350> ErrorMessage;
+  llvm::raw_svector_ostream OS(ErrorMessage);
+
+  const BugType &BT = explainWarning(BO, C, LHSIsAddr, LHSIsNullDerived,
+                                     RHSIsAddr, RHSIsNullDerived, OS);
 
   // Generate the report.
   ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
   if (!ErrNode)
     return nullptr;
-  auto R = std::make_unique<PathSensitiveBugReport>(
-      *AmbiguousProvenanceBinOpBugType, ErrorMessage, ErrNode);
+  auto R = std::make_unique<PathSensitiveBugReport>(BT, ErrorMessage, ErrNode);
   R->addRange(BO->getSourceRange());
 
   if (ShowFixIts) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -28,13 +28,23 @@ class ProvenanceSourceChecker
     : public Checker<check::PostStmt<CastExpr>, check::PreStmt<CastExpr>,
                      check::PostStmt<BinaryOperator>,
                      check::PostStmt<UnaryOperator>, check::DeadSymbols> {
-  std::unique_ptr<BugType> AmbigProvAddrArithBugType;
-  std::unique_ptr<BugType> AmbigProvWrongOrderBugType;
-  std::unique_ptr<BugType> AmbigProvBinOpBugType;
+  BugType AmbigProvBinOpBugType{
+      this, "Binary operation with ambiguous provenance", "CHERI portability"};
+  BugType AmbigProvAddrArithBugType{
+      this, "CHERI-incompatible pointer arithmetic", "CHERI portability"};
+  BugType AmbigProvWrongOrderBugType{
+      this, "Capability derived from wrong argument", "CHERI portability"};
 
-  std::unique_ptr<BugType> AmbigProvAsPtrBugType;
-  std::unique_ptr<BugType> InvalidCapPtrBugType;
-  std::unique_ptr<BugType> PtrdiffAsIntCapBugType;
+  BugType AmbigProvAsPtrBugType{
+      this, "Capability with ambiguous provenance used as pointer",
+      "CHERI portability"};
+  BugType InvalidCapPtrBugType{this, "NULL-derived capability used as pointer",
+                               "CHERI portability"};
+  BugType NoProvPtrBugType{this,
+                           "cheri_no_provenance capability used as pointer",
+                           "CHERI portability"};
+  BugType PtrdiffAsIntCapBugType{this, "Pointer difference as capability",
+                                 "CHERI portability"};
 
 private:
   class InvalidCapBugVisitor : public BugReporterVisitor {
@@ -74,8 +84,6 @@ private:
   };
 
 public:
-  ProvenanceSourceChecker();
-
   void checkPostStmt(const CastExpr *CE, CheckerContext &C) const;
   void checkPreStmt(const CastExpr *CE, CheckerContext &C) const;
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
@@ -111,29 +119,6 @@ REGISTER_SET_WITH_PROGRAMSTATE(InvalidCap, SymbolRef)
 REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceSym, SymbolRef)
 REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceReg, const MemRegion *)
 REGISTER_TRAIT_WITH_PROGRAMSTATE(Ptr2IntCapId, unsigned)
-
-ProvenanceSourceChecker::ProvenanceSourceChecker() {
-  AmbigProvBinOpBugType.reset(new BugType(
-      this, "Binary operation with ambiguous provenance", "CHERI portability"));
-  AmbigProvAddrArithBugType.reset(new BugType(
-      this, "CHERI-incompatible pointer arithmetic", "CHERI portability"));
-  AmbigProvWrongOrderBugType.reset(new BugType(
-      this, "Capability derived from wrong argument", "CHERI portability"));
-
-  AmbigProvAsPtrBugType.reset(
-      new BugType(this, "Capability with ambiguous provenance used as pointer",
-                  "CHERI portability"));
-  InvalidCapPtrBugType.reset(new BugType(
-      this, "Invalid capability used as pointer", "CHERI portability"));
-  PtrdiffAsIntCapBugType.reset(new BugType(
-      this, "Pointer difference as capability", "CHERI portability"));
-  InvalidCapPtrBugType.reset(new BugType(
-      this, "Invalid capability used as pointer", "CHERI portability"));
-  PtrdiffAsIntCapBugType.reset(new BugType(
-      this, "Pointer difference as capability", "CHERI portability"));
-  NullDerivedCapPtrBugType.reset(new BugType(
-      this, "NULL-derived capability used as pointer", "CHERI portability"));
-}
 
 static bool isIntegerToIntCapCast(const CastExpr *CE) {
   if (CE->getCastKind() != CK_IntegralCast)
@@ -226,6 +211,14 @@ static bool isIntToVoidPtrCast(const CastExpr *CE) {
   return false;
 }
 
+static bool isNoProvToPtrCast(const CastExpr *CE) {
+  if (!CE->getType()->isPointerType())
+    return false;
+
+  const Expr *Src = CE->getSubExpr();
+  return Src->getType()->hasAttr(attr::CHERINoProvenance);
+}
+
 // Report intcap with ambiguous or NULL-derived provenance cast to pointer
 void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
                                            CheckerContext &C) const {
@@ -244,16 +237,20 @@ void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
     if (!ErrNode)
       return;
     R = std::make_unique<PathSensitiveBugReport>(
-        *AmbigProvAsPtrBugType,
+        AmbigProvAsPtrBugType,
         "Capability with ambiguous provenance is used as pointer", ErrNode);
-  } else if (hasNoProvenance(State, SrcVal) && !SrcVal.isConstant() &&
-             !isIntToVoidPtrCast(CE)) {
+  } else if (hasNoProvenance(State, SrcVal) && !SrcVal.isConstant()) {
     ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
     if (!ErrNode)
       return;
-    R = std::make_unique<PathSensitiveBugReport>(
-        *InvalidCapPtrBugType, "Invalid capability is used as pointer",
-        ErrNode);
+    if (isNoProvToPtrCast(CE))
+      R = std::make_unique<PathSensitiveBugReport>(
+          NoProvPtrBugType, "cheri_no_provenance capability used as pointer",
+          ErrNode);
+    else
+      R = std::make_unique<PathSensitiveBugReport>(
+          InvalidCapPtrBugType, "NULL-derived capability used as pointer",
+          ErrNode);
     if (SymbolRef S = SrcVal.getAsSymbol())
       R->addVisitor(std::make_unique<InvalidCapBugVisitor>(S));
   } else
@@ -282,7 +279,7 @@ ProvenanceSourceChecker::emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
   if (!ErrNode)
     return nullptr;
   auto R = std::make_unique<PathSensitiveBugReport>(
-      *PtrdiffAsIntCapBugType, "Pointer difference as capability", ErrNode);
+      PtrdiffAsIntCapBugType, "Pointer difference as capability", ErrNode);
   R->addRange(BO->getSourceRange());
 
   const SVal &LHSVal = C.getSVal(BO->getLHS());
@@ -332,7 +329,7 @@ const BugType &ProvenanceSourceChecker::explainWarning(
       OS << "LHS and RHS were derived from pointers."
             " Result capability will be derived from LHS by default."
             " This code may need to be rewritten for CHERI.";
-      return *AmbigProvAddrArithBugType;
+      return AmbigProvAddrArithBugType;
     }
 
     if (LHSIsNullDerived) {
@@ -347,7 +344,7 @@ const BugType &ProvenanceSourceChecker::explainWarning(
          << (BO->getType()->isUnsignedIntegerType() ? "size_t" : "ptrdiff_t")
          << "'. ";
     }
-    return *AmbigProvWrongOrderBugType;
+    return AmbigProvWrongOrderBugType;
   }
 
   OS << "; consider indicating the provenance-carrying argument "
@@ -369,7 +366,7 @@ const BugType &ProvenanceSourceChecker::explainWarning(
     }
   }
 
-  return *AmbigProvBinOpBugType;
+  return AmbigProvBinOpBugType;
 }
 
 ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -273,6 +273,14 @@ FixItHint addFixIt(const Expr *NDOp, CheckerContext &C, bool IsUnsigned) {
   return {};
 }
 
+bool isArith(BinaryOperatorKind OpCode) {
+  if (BinaryOperator::isCompoundAssignmentOp(OpCode))
+    return isArith(BinaryOperator::getOpForCompoundAssignment(OpCode));
+  return BinaryOperator::isAdditiveOp(OpCode) ||
+         BinaryOperator::isMultiplicativeOp(OpCode) ||
+         BinaryOperator::isBitwiseOp(OpCode);
+}
+
 } // namespace
 
 const BugType &ProvenanceSourceChecker::explainWarning(
@@ -409,9 +417,7 @@ void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
     return;
 
   BinaryOperatorKind const OpCode = BO->getOpcode();
-  if (!(BinaryOperator::isAdditiveOp(OpCode) ||
-        BinaryOperator::isMultiplicativeOp(OpCode) ||
-        BinaryOperator::isBitwiseOp(OpCode)))
+  if (!isArith(OpCode))
     return;
   bool const IsSub = OpCode == clang::BO_Sub || OpCode == clang::BO_SubAssign;
 

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CHERIUtils.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
@@ -19,6 +20,7 @@
 
 using namespace clang;
 using namespace ento;
+using namespace cheri;
 
 namespace {
 class ProvenanceSourceChecker
@@ -130,6 +132,9 @@ static bool isPointerToIntCapCast(const CastExpr *CE) {
 
 void ProvenanceSourceChecker::checkPostStmt(const CastExpr *CE,
                                             CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   if (isIntegerToIntCapCast(CE)) {
     SymbolRef IntCapSym = C.getSVal(CE).getAsSymbol();
     if (!IntCapSym)
@@ -202,6 +207,9 @@ static bool isIntToVoidPtrCast(const CastExpr *CE) {
 // Report intcap with ambiguous or NULL-derived provenance cast to pointer
 void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
                                            CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   if (CE->getCastKind() != clang::CK_IntegralToPointer)
     return;
 
@@ -361,6 +369,9 @@ void ProvenanceSourceChecker::propagateProvenanceInfoForBinOp(
 // store them to report again if used as pointer
 void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
                                             CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   BinaryOperatorKind const OpCode = BO->getOpcode();
   if (!(BinaryOperator::isAdditiveOp(OpCode) ||
         BinaryOperator::isMultiplicativeOp(OpCode) ||
@@ -416,6 +427,9 @@ void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
 
 void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
                                                CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
   ProgramStateRef State = C.getState();
 
   bool Removed = false;

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -532,20 +532,6 @@ void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
     C.addTransition(State);
 }
 
-namespace {
-
-static void describeCast(raw_ostream &OS, const CastExpr *CE,
-                         const LangOptions &LangOpts) {
-  OS << (dyn_cast<ImplicitCastExpr>(CE) ? "implicit" : "explicit");
-  OS << " cast from '";
-  CE->getSubExpr()->getType().print(OS, PrintingPolicy(LangOpts));
-  OS << "' to '";
-  CE->getType().print(OS, PrintingPolicy(LangOpts));
-  OS << "'";
-}
-
-} // namespace
-
 PathDiagnosticPieceRef ProvenanceSourceChecker::InvalidCapBugVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BRC,
     PathSensitiveBugReport &BR) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -43,8 +43,6 @@ class ProvenanceSourceChecker
   BugType NoProvPtrBugType{this,
                            "cheri_no_provenance capability used as pointer",
                            "CHERI portability"};
-  BugType PtrdiffAsIntCapBugType{this, "Pointer difference as capability",
-                                 "CHERI portability"};
 
 private:
   class InvalidCapBugVisitor : public BugReporterVisitor {
@@ -106,9 +104,6 @@ private:
                                             bool RHSIsAddr,
                                             bool RHSIsNullDerived) const;
 
-  ExplodedNode *emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
-                                        CheckerContext &C) const;
-
   static void propagateProvenanceInfo(ExplodedNode *N, const Expr *E,
                                       CheckerContext &C, bool IsInvalidCap,
                                       const NoteTag *Tag);
@@ -120,7 +115,8 @@ REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceSym, SymbolRef)
 REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceReg, const MemRegion *)
 REGISTER_TRAIT_WITH_PROGRAMSTATE(Ptr2IntCapId, unsigned)
 
-static bool isIntegerToIntCapCast(const CastExpr *CE) {
+namespace {
+bool isIntegerToIntCapCast(const CastExpr *CE) {
   if (CE->getCastKind() != CK_IntegralCast)
     return false;
   if (!CE->getType()->isIntCapType() ||
@@ -129,13 +125,15 @@ static bool isIntegerToIntCapCast(const CastExpr *CE) {
   return true;
 }
 
-static bool isPointerToIntCapCast(const CastExpr *CE) {
+bool isPointerToIntCapCast(const CastExpr *CE) {
   if (CE->getCastKind() != clang::CK_PointerToIntegral)
     return false;
   if (!CE->getType()->isIntCapType())
     return false;
   return true;
 }
+
+} // namespace
 
 void ProvenanceSourceChecker::checkPostStmt(const CastExpr *CE,
                                             CheckerContext &C) const {
@@ -162,7 +160,9 @@ void ProvenanceSourceChecker::checkPostStmt(const CastExpr *CE,
   }
 }
 
-static bool hasAmbiguousProvenance(ProgramStateRef State, const SVal &Val) {
+namespace {
+
+bool hasAmbiguousProvenance(ProgramStateRef State, const SVal &Val) {
   if (SymbolRef Sym = Val.getAsSymbol())
     return State->contains<AmbiguousProvenanceSym>(Sym);
 
@@ -172,7 +172,7 @@ static bool hasAmbiguousProvenance(ProgramStateRef State, const SVal &Val) {
   return false;
 }
 
-static bool hasNoProvenance(ProgramStateRef State, const SVal &Val) {
+bool hasNoProvenance(ProgramStateRef State, const SVal &Val) {
   if (Val.isConstant())
     return true;
 
@@ -185,7 +185,7 @@ static bool hasNoProvenance(ProgramStateRef State, const SVal &Val) {
   return false;
 }
 
-static bool isAddress(const SVal &Val) {
+bool isAddress(const SVal &Val) {
   if (!Val.getAsLocSymbol(true))
     return false;
 
@@ -195,29 +195,15 @@ static bool isAddress(const SVal &Val) {
   return true;
 }
 
-static bool isIntToVoidPtrCast(const CastExpr *CE) {
-  if (!CE->getType()->isVoidPointerType())
-    return false;
-
-  const Expr *Src = CE->getSubExpr();
-  if (!Src->getType()->isIntCapType())
-    return false;
-
-  if (auto *CE2 = dyn_cast<CastExpr>(Src)) {
-    const QualType &T = CE2->getSubExpr()->getType();
-    return T->isIntegerType() && !T->isIntCapType();
-  }
-
-  return false;
-}
-
-static bool isNoProvToPtrCast(const CastExpr *CE) {
+bool isNoProvToPtrCast(const CastExpr *CE) {
   if (!CE->getType()->isPointerType())
     return false;
 
   const Expr *Src = CE->getSubExpr();
   return Src->getType()->hasAttr(attr::CHERINoProvenance);
 }
+
+} // namespace
 
 // Report intcap with ambiguous or NULL-derived provenance cast to pointer
 void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
@@ -261,7 +247,9 @@ void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
   C.emitReport(std::move(R));
 }
 
-static bool justConverted2IntCap(Expr *E, const ASTContext &Ctx) {
+namespace {
+
+bool justConverted2IntCap(Expr *E, const ASTContext &Ctx) {
   assert(E->getType()->isCHERICapabilityType(Ctx, true));
   if (auto *CE = dyn_cast<CastExpr>(E)) {
     const QualType OrigType = CE->getSubExpr()->getType();
@@ -270,33 +258,6 @@ static bool justConverted2IntCap(Expr *E, const ASTContext &Ctx) {
   }
   return false;
 }
-
-ExplodedNode *
-ProvenanceSourceChecker::emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
-                                                 CheckerContext &C) const {
-  // Generate the report.
-  ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
-  if (!ErrNode)
-    return nullptr;
-  auto R = std::make_unique<PathSensitiveBugReport>(
-      PtrdiffAsIntCapBugType, "Pointer difference as capability", ErrNode);
-  R->addRange(BO->getSourceRange());
-
-  const SVal &LHSVal = C.getSVal(BO->getLHS());
-  R->markInteresting(LHSVal);
-  if (const MemRegion *Reg = LHSVal.getAsRegion())
-    R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
-
-  const SVal &RHSVal = C.getSVal(BO->getRHS());
-  R->markInteresting(RHSVal);
-  if (const MemRegion *Reg = RHSVal.getAsRegion())
-    R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
-
-  C.emitReport(std::move(R));
-  return ErrNode;
-}
-
-namespace {
 
 FixItHint addFixIt(const Expr *NDOp, CheckerContext &C, bool IsUnsigned) {
   const SourceRange &SrcRange = NDOp->getSourceRange();
@@ -494,9 +455,7 @@ void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
       N = C.getPredecessor();
     InvalidCap = false;
   } else if (IsSub && LHSIsAddr && RHSIsAddr) {
-    N = emitPtrdiffAsIntCapWarn(BO, C);
-    if (!N)
-      N = C.getPredecessor();
+    N = C.getPredecessor();
     InvalidCap = true;
   } else if (LHSIsNullDerived && (RHSIsNullDerived || IsSub)) {
     N = C.getPredecessor();
@@ -558,6 +517,8 @@ void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
     C.addTransition(State);
 }
 
+namespace {
+
 static void describeCast(raw_ostream &OS, const CastExpr *CE,
                          const LangOptions &LangOpts) {
   OS << (dyn_cast<ImplicitCastExpr>(CE) ? "implicit" : "explicit");
@@ -567,6 +528,8 @@ static void describeCast(raw_ostream &OS, const CastExpr *CE,
   CE->getType().print(OS, PrintingPolicy(LangOpts));
   OS << "'";
 }
+
+} // namespace
 
 PathDiagnosticPieceRef ProvenanceSourceChecker::InvalidCapBugVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BRC,

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -25,7 +25,8 @@ using namespace cheri;
 namespace {
 class ProvenanceSourceChecker
     : public Checker<check::PostStmt<CastExpr>, check::PreStmt<CastExpr>,
-                     check::PostStmt<BinaryOperator>, check::DeadSymbols> {
+                     check::PostStmt<BinaryOperator>,
+                     check::PostStmt<UnaryOperator>, check::DeadSymbols> {
   std::unique_ptr<BugType> AmbiguousProvenanceBinOpBugType;
   std::unique_ptr<BugType> AmbiguousProvenancePtrBugType;
   std::unique_ptr<BugType> InvalidCapPtrBugType;
@@ -74,6 +75,7 @@ public:
   void checkPostStmt(const CastExpr *CE, CheckerContext &C) const;
   void checkPreStmt(const CastExpr *CE, CheckerContext &C) const;
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
+  void checkPostStmt(const UnaryOperator *BO, CheckerContext &C) const;
   void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
 private:
@@ -87,10 +89,9 @@ private:
   ExplodedNode *emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
                                         CheckerContext &C) const;
 
-  static void propagateProvenanceInfoForBinOp(ExplodedNode *N,
-                                              const BinaryOperator *BO,
-                                              CheckerContext &C,
-                                              bool IsInvalidCap);
+  static void propagateProvenanceInfo(ExplodedNode *N, const Expr *E,
+                                      CheckerContext &C, bool IsInvalidCap,
+                                      const NoteTag *Tag);
 };
 } // namespace
 
@@ -337,17 +338,19 @@ ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
   return ErrNode;
 }
 
-void ProvenanceSourceChecker::propagateProvenanceInfoForBinOp(
-    ExplodedNode *N, const BinaryOperator *BO, CheckerContext &C,
-    bool IsInvalidCap) {
+void ProvenanceSourceChecker::propagateProvenanceInfo(ExplodedNode *N,
+                                                      const Expr *E,
+                                                      CheckerContext &C,
+                                                      bool IsInvalidCap,
+                                                      const NoteTag *Tag) {
 
   ProgramStateRef State = N->getState();
-  SVal ResVal = C.getSVal(BO);
+  SVal ResVal = C.getSVal(E);
   if (ResVal.isUnknown()) {
     const LocationContext *LCtx = C.getLocationContext();
-    ResVal = C.getSValBuilder().conjureSymbolVal(nullptr, BO, LCtx,
-                                                 BO->getType(), C.blockCount());
-    State = State->BindExpr(BO, LCtx, ResVal);
+    ResVal = C.getSValBuilder().conjureSymbolVal(nullptr, E, LCtx, E->getType(),
+                                                 C.blockCount());
+    State = State->BindExpr(E, LCtx, ResVal);
   }
 
   if (SymbolRef ResSym = ResVal.getAsSymbol())
@@ -358,11 +361,7 @@ void ProvenanceSourceChecker::propagateProvenanceInfoForBinOp(
   else
     return; // no result to propagate to
 
-  const NoteTag *BinOpTag =
-      IsInvalidCap ? nullptr // note will be added in BugVisitor
-                   : C.getNoteTag("Binary operator has ambiguous provenance");
-
-  C.addTransition(State, N, BinOpTag);
+  C.addTransition(State, N, Tag);
 }
 
 // Report intcap binary expressions with ambiguous provenance,
@@ -422,7 +421,29 @@ void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
     return;
 
   // Propagate info for result
-  propagateProvenanceInfoForBinOp(N, BO, C, InvalidCap);
+  const NoteTag *BinOpTag =
+      InvalidCap ? nullptr // note will be added in BugVisitor
+                 : C.getNoteTag("Binary operator has ambiguous provenance");
+  propagateProvenanceInfo(N, BO, C, InvalidCap, BinOpTag);
+}
+
+void ProvenanceSourceChecker::checkPostStmt(const UnaryOperator *UO,
+                                            CheckerContext &C) const {
+  if (!isPureCapMode(C.getASTContext()))
+    return;
+
+  if (!UO->isArithmeticOp() && !UO->isIncrementDecrementOp())
+    return;
+
+  Expr *Op = UO->getSubExpr();
+  if (!Op->getType()->isIntCapType())
+    return;
+
+  ProgramStateRef State = C.getState();
+  const SVal &Val = C.getSVal(UO);
+  const SVal &SrcVal = C.getSVal(Op);
+  if (hasNoProvenance(State, SrcVal) && !hasNoProvenance(State, Val))
+    propagateProvenanceInfo(C.getPredecessor(), UO, C, true, nullptr);
 }
 
 void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -16,6 +16,7 @@
 #include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include <clang/Basic/DiagnosticSema.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugReporter.h>
 
 using namespace clang;
@@ -82,6 +83,7 @@ public:
   void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
   bool ShowFixIts = false;
+  bool ReportForAmbiguousProvenance = true;
 
 private:
   // Utility
@@ -373,8 +375,8 @@ const BugType &ProvenanceSourceChecker::explainWarning(
 ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
     const BinaryOperator *BO, CheckerContext &C, bool LHSIsAddr,
     bool LHSIsNullDerived, bool RHSIsAddr, bool RHSIsNullDerived) const {
-  bool const IsUnsigned = BO->getType()->isUnsignedIntegerType();
 
+  bool const IsUnsigned = BO->getType()->isUnsignedIntegerType();
   SmallString<350> ErrorMessage;
   llvm::raw_svector_ostream OS(ErrorMessage);
 
@@ -481,6 +483,14 @@ void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
   ExplodedNode *N;
   bool InvalidCap;
   if (LHSActiveProv && RHSActiveProv && !IsSub) {
+    if (!RHSIsAddr && !this->ReportForAmbiguousProvenance) {
+      // No strong evidence of a real bug here. This code will probably
+      // be fine with the default choice of LHS for capability derivation.
+      // Don't report if [-Wcheri-provenance] compiler warning is disabled
+      // and don't propagate ambiguous provenance flag further
+      return;
+    }
+
     N = emitAmbiguousProvenanceWarn(BO, C, LHSIsAddr, LHSIsNullDerived,
                                     RHSIsAddr, RHSIsNullDerived);
     if (!N)
@@ -643,6 +653,9 @@ void ento::registerProvenanceSourceChecker(CheckerManager &mgr) {
   auto *Checker = mgr.registerChecker<ProvenanceSourceChecker>();
   Checker->ShowFixIts =
       mgr.getAnalyzerOptions().getCheckerBooleanOption(Checker, "ShowFixIts");
+  Checker->ReportForAmbiguousProvenance =
+      mgr.getAnalyzerOptions().getCheckerBooleanOption(
+          Checker, "ReportForAmbiguousProvenance");
 }
 
 bool ento::shouldRegisterProvenanceSourceChecker(const CheckerManager &Mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -510,23 +510,10 @@ void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
     return;
 
   ProgramStateRef State = C.getState();
-
   bool Removed = false;
-  const InvalidCapTy &Set = State->get<InvalidCap>();
-  for (const auto &Sym : Set) {
-    if (!SymReaper.isDead(Sym))
-      continue;
-    State = State->remove<InvalidCap>(Sym);
-    Removed = true;
-  }
-
-  const AmbiguousProvenanceSymTy &Set2 = State->get<AmbiguousProvenanceSym>();
-  for (const auto &Sym : Set2) {
-    if (!SymReaper.isDead(Sym))
-      continue;
-    State = State->remove<AmbiguousProvenanceSym>(Sym);
-    Removed = true;
-  }
+  State = cleanDead<InvalidCap>(State, SymReaper, Removed);
+  State = cleanDead<AmbiguousProvenanceSym>(State, SymReaper, Removed);
+  State = cleanDead<AmbiguousProvenanceReg>(State, SymReaper, Removed);
 
   if (Removed)
     C.addTransition(State);

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -40,9 +40,8 @@ class ProvenanceSourceChecker
       "CHERI portability"};
   BugType InvalidCapPtrBugType{this, "NULL-derived capability used as pointer",
                                "CHERI portability"};
-  BugType NoProvPtrBugType{this,
-                           "cheri_no_provenance capability used as pointer",
-                           "CHERI portability"};
+  BugType ProvenanceLossBugType{
+      this, "NULL-derived capability: loss of provenance", "CHERI portability"};
 
 private:
   class InvalidCapBugVisitor : public BugReporterVisitor {
@@ -121,6 +120,14 @@ bool isIntegerToIntCapCast(const CastExpr *CE) {
     return false;
   if (!CE->getType()->isIntCapType() ||
       CE->getSubExpr()->getType()->isIntCapType())
+    return false;
+  return true;
+}
+
+bool isPointerToIntegerCast(const CastExpr *CE) {
+  if (CE->getCastKind() != CK_PointerToIntegral)
+    return false;
+  if (CE->getType()->isIntCapType())
     return false;
   return true;
 }
@@ -226,12 +233,14 @@ void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
         AmbigProvAsPtrBugType,
         "Capability with ambiguous provenance is used as pointer", ErrNode);
   } else if (hasNoProvenance(State, SrcVal) && !SrcVal.isConstant()) {
+    if (isNoProvToPtrCast(CE))
+      return; // intentional
     ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
     if (!ErrNode)
       return;
-    if (isNoProvToPtrCast(CE))
+    if (SrcVal.getAs<nonloc::LocAsInteger>())
       R = std::make_unique<PathSensitiveBugReport>(
-          NoProvPtrBugType, "cheri_no_provenance capability used as pointer",
+          ProvenanceLossBugType, "NULL-derived capability: loss of provenance",
           ErrNode);
     else
       R = std::make_unique<PathSensitiveBugReport>(
@@ -549,16 +558,16 @@ PathDiagnosticPieceRef ProvenanceSourceChecker::InvalidCapBugVisitor::VisitNode(
   llvm::raw_svector_ostream OS(Buf);
 
   if (const CastExpr *CE = dyn_cast<CastExpr>(S)) {
-    if (!isIntegerToIntCapCast(CE))
-      return nullptr;
-
     if (Sym != N->getSVal(CE).getAsSymbol())
       return nullptr;
-
-    if (!N->getState()->contains<InvalidCap>(Sym))
+    if (isIntegerToIntCapCast(CE)) {
+      if (!N->getState()->contains<InvalidCap>(Sym))
+        return nullptr;
+      OS << "NULL-derived capability: ";
+    } else if (isPointerToIntegerCast(CE)) {
+      OS << "Loss of provenance: ";
+    } else
       return nullptr;
-
-    OS << "NULL-derived capability: ";
     describeCast(OS, CE, BRC.getASTContext().getLangOpts());
   } else if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(S)) {
     BinaryOperatorKind const OpCode = BO->getOpcode();

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -1,0 +1,493 @@
+//===-- ProvenanceSourceChecker.cpp - Provenance Source Checker -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines checker that detects binary arithmetic expressions with
+// capability type operands where provenance source is ambiguous.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include <clang/StaticAnalyzer/Core/BugReporter/BugReporter.h>
+
+using namespace clang;
+using namespace ento;
+
+namespace {
+class ProvenanceSourceChecker
+    : public Checker<check::PostStmt<CastExpr>, check::PreStmt<CastExpr>,
+                     check::PostStmt<BinaryOperator>, check::DeadSymbols> {
+  std::unique_ptr<BugType> AmbiguousProvenanceBinOpBugType;
+  std::unique_ptr<BugType> AmbiguousProvenancePtrBugType;
+  std::unique_ptr<BugType> NullDerivedCapPtrBugType;
+
+private:
+  class NullDerivedCapBugVisitor : public BugReporterVisitor {
+  public:
+    NullDerivedCapBugVisitor(SymbolRef SR) : Sym(SR) {}
+
+    void Profile(llvm::FoldingSetNodeID &ID) const override {
+      static int X = 0;
+      ID.AddPointer(&X);
+      ID.AddPointer(Sym);
+    }
+
+    PathDiagnosticPieceRef VisitNode(const ExplodedNode *N,
+                                     BugReporterContext &BRC,
+                                     PathSensitiveBugReport &BR) override;
+
+  private:
+    SymbolRef Sym;
+  };
+
+  class Ptr2IntBugVisitor : public BugReporterVisitor {
+  public:
+    Ptr2IntBugVisitor(const MemRegion *R) : Reg(R) {}
+
+    void Profile(llvm::FoldingSetNodeID &ID) const override {
+      static int X = 0;
+      ID.AddPointer(&X);
+      ID.AddPointer(Reg);
+    }
+
+    PathDiagnosticPieceRef VisitNode(const ExplodedNode *N,
+                                     BugReporterContext &BRC,
+                                     PathSensitiveBugReport &BR) override;
+
+  private:
+    const MemRegion *Reg;
+  };
+
+public:
+  ProvenanceSourceChecker();
+
+  void checkPostStmt(const CastExpr *CE, CheckerContext &C) const;
+  void checkPreStmt(const CastExpr *CE, CheckerContext &C) const;
+  void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
+  void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
+
+private:
+  // Utility
+  ExplodedNode *emitAmbiguousProvenanceWarn(const BinaryOperator *BO,
+                                            CheckerContext &C, bool LHSIsAddr,
+                                            bool LHSIsNullDerived,
+                                            bool RHSIsAddr,
+                                            bool RHSIsNullDerived) const;
+
+  static void propagateProvenanceInfoForBinOp(ExplodedNode *N,
+                                              const BinaryOperator *BO,
+                                              CheckerContext &C,
+                                              bool NullDerivedCap);
+};
+} // namespace
+
+REGISTER_SET_WITH_PROGRAMSTATE(NullDerivedCap, SymbolRef)
+REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceSym, SymbolRef)
+REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceReg, const MemRegion *)
+REGISTER_TRAIT_WITH_PROGRAMSTATE(Ptr2IntCapId, unsigned)
+
+ProvenanceSourceChecker::ProvenanceSourceChecker() {
+  AmbiguousProvenanceBinOpBugType.reset(new BugType(
+      this, "Binary operation with ambiguous provenance", "CHERI portability"));
+  AmbiguousProvenancePtrBugType.reset(
+      new BugType(this, "Capability with ambiguous provenance used as pointer",
+                  "CHERI portability"));
+  NullDerivedCapPtrBugType.reset(new BugType(
+      this, "NULL-derived capability used as pointer", "CHERI portability"));
+}
+
+static bool isIntegerToIntCapCast(const CastExpr *CE) {
+  if (CE->getCastKind() != CK_IntegralCast)
+    return false;
+  if (!CE->getType()->isIntCapType() ||
+      CE->getSubExpr()->getType()->isIntCapType())
+    return false;
+  return true;
+}
+
+static bool isPointerToIntCapCast(const CastExpr *CE) {
+  if (CE->getCastKind() != clang::CK_PointerToIntegral)
+    return false;
+  if (!CE->getType()->isIntCapType())
+    return false;
+  return true;
+}
+
+void ProvenanceSourceChecker::checkPostStmt(const CastExpr *CE,
+                                            CheckerContext &C) const {
+  if (isIntegerToIntCapCast(CE)) {
+    SymbolRef IntCapSym = C.getSVal(CE).getAsSymbol();
+    if (!IntCapSym)
+      return;
+
+    if (C.getSVal(CE).getAsLocSymbol())
+      return; // skip locAsInteger
+
+    ProgramStateRef State = C.getState();
+    State = State->add<NullDerivedCap>(IntCapSym);
+    C.addTransition(State);
+  } else if (isPointerToIntCapCast(CE)) {
+    // Prev node may be reclaimed as "uninteresting", in this case we will not
+    // be able to create path diagnostic for it; therefore we modify the state,
+    // i.e. create the node that definitely will not be deleted
+    ProgramStateRef State = C.getState();
+    unsigned PrevId = State->get<Ptr2IntCapId>();
+    C.addTransition(State->set<Ptr2IntCapId>(PrevId + 1));
+  }
+}
+
+static bool hasAmbiguousProvenance(ProgramStateRef State, const SVal &Val) {
+  if (SymbolRef Sym = Val.getAsSymbol())
+    return State->contains<AmbiguousProvenanceSym>(Sym);
+
+  if (const MemRegion *Reg = Val.getAsRegion())
+    return State->contains<AmbiguousProvenanceReg>(Reg);
+
+  return false;
+}
+
+static bool hasNoProvenance(ProgramStateRef State, const SVal &Val) {
+  if (Val.isConstant())
+    return true;
+
+  if (const auto &LocAsInt = Val.getAs<nonloc::LocAsInteger>())
+    return !LocAsInt->hasProvenance();
+
+  SymbolRef Sym = Val.getAsSymbol();
+  if (Sym && State->contains<NullDerivedCap>(Sym))
+    return true;
+  return false;
+}
+
+static bool isAddress(const SVal &Val) {
+  if (!Val.getAsLocSymbol(true))
+    return false;
+
+  if (const auto &LocAsInt = Val.getAs<nonloc::LocAsInteger>())
+    return LocAsInt->hasProvenance();
+
+  return true;
+}
+
+static bool isIntToVoidPtrCast(const CastExpr *CE) {
+  if (!CE->getType()->isVoidPointerType())
+    return false;
+
+  const Expr *Src = CE->getSubExpr();
+  if (!Src->getType()->isIntCapType())
+    return false;
+
+  if (auto *CE2 = dyn_cast<CastExpr>(Src)) {
+    const QualType &T = CE2->getSubExpr()->getType();
+    return T->isIntegerType() && !T->isIntCapType();
+  }
+
+  return false;
+}
+
+// Report intcap with ambiguous or NULL-derived provenance cast to pointer
+void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
+                                           CheckerContext &C) const {
+  if (CE->getCastKind() != clang::CK_IntegralToPointer)
+    return;
+
+  ProgramStateRef const State = C.getState();
+  const SVal &SrcVal = C.getSVal(CE->getSubExpr());
+
+  std::unique_ptr<PathSensitiveBugReport> R;
+  if (hasAmbiguousProvenance(State, SrcVal)) {
+    ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+    if (!ErrNode)
+      return;
+    R = std::make_unique<PathSensitiveBugReport>(
+        *AmbiguousProvenancePtrBugType,
+        "Capability with ambiguous provenance is used as pointer", ErrNode);
+  } else if (hasNoProvenance(State, SrcVal) && !SrcVal.isConstant() &&
+             !isIntToVoidPtrCast(CE)) {
+    ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+    if (!ErrNode)
+      return;
+    R = std::make_unique<PathSensitiveBugReport>(
+        *NullDerivedCapPtrBugType, "NULL-derived capability is used as pointer",
+        ErrNode);
+    if (SymbolRef S = SrcVal.getAsSymbol())
+      R->addVisitor(std::make_unique<NullDerivedCapBugVisitor>(S));
+  } else
+    return;
+
+  R->markInteresting(SrcVal);
+  R->addRange(CE->getSourceRange());
+  C.emitReport(std::move(R));
+}
+
+static bool justConverted2IntCap(Expr *E, const ASTContext &Ctx) {
+  assert(E->getType()->isCHERICapabilityType(Ctx, true));
+  if (auto *CE = dyn_cast<CastExpr>(E)) {
+    const QualType OrigType = CE->getSubExpr()->getType();
+    if (!OrigType->isCHERICapabilityType(Ctx, true))
+      return true;
+  }
+  return false;
+}
+
+ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
+    const BinaryOperator *BO, CheckerContext &C, bool LHSIsAddr,
+    bool LHSIsNullDerived, bool RHSIsAddr, bool RHSIsNullDerived) const {
+  SmallString<350> ErrorMessage;
+  llvm::raw_svector_ostream OS(ErrorMessage);
+
+  const QualType &T = BO->getType();
+  bool const IsUnsigned = T->isUnsignedIntegerType();
+
+  OS << "Result of '" << BO->getOpcodeStr() << "' on capability type '";
+  T.print(OS, PrintingPolicy(C.getASTContext().getLangOpts()));
+  OS << "'; it is unclear which side should be used as the source "
+        "of provenance; consider indicating the provenance-carrying argument "
+        "explicitly by casting the other argument to '"
+     << (IsUnsigned ? "size_t" : "ptrdiff_t") << "'. ";
+
+  OS << "Note: along this path, ";
+  if (LHSIsAddr && RHSIsAddr)
+    OS << "LHS and RHS were derived from pointers";
+  else if (LHSIsNullDerived && RHSIsNullDerived) {
+    OS << "LHS and RHS were derived from NULL";
+  } else {
+    if (LHSIsAddr)
+      OS << "LHS was derived from pointer";
+    if (LHSIsNullDerived)
+      OS << "LHS was derived from NULL";
+    if ((LHSIsAddr || LHSIsNullDerived) && (RHSIsAddr || RHSIsNullDerived))
+      OS << ", ";
+    if (RHSIsAddr)
+      OS << "RHS was derived from pointer";
+    if (RHSIsNullDerived)
+      OS << "RHS was derived from NULL";
+  }
+
+  // Generate the report.
+  ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+  if (!ErrNode)
+    return nullptr;
+  auto R = std::make_unique<PathSensitiveBugReport>(
+      *AmbiguousProvenanceBinOpBugType, ErrorMessage, ErrNode);
+  R->addRange(BO->getSourceRange());
+
+  const SVal &LHSVal = C.getSVal(BO->getLHS());
+  R->markInteresting(LHSVal);
+  if (SymbolRef LS = LHSVal.getAsSymbol())
+    R->addVisitor(std::make_unique<NullDerivedCapBugVisitor>(LS));
+  if (const MemRegion *Reg = LHSVal.getAsRegion())
+    R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
+
+  const SVal &RHSVal = C.getSVal(BO->getRHS());
+  R->markInteresting(RHSVal);
+  if (SymbolRef RS = RHSVal.getAsSymbol())
+    R->addVisitor(std::make_unique<NullDerivedCapBugVisitor>(RS));
+  if (const MemRegion *Reg = RHSVal.getAsRegion())
+    R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
+
+  C.emitReport(std::move(R));
+  return ErrNode;
+}
+
+void ProvenanceSourceChecker::propagateProvenanceInfoForBinOp(
+    ExplodedNode *N, const BinaryOperator *BO, CheckerContext &C,
+    bool NullDerivedRes) {
+
+  ProgramStateRef State = N->getState();
+  SVal ResVal = C.getSVal(BO);
+  if (ResVal.isUnknown()) {
+    const LocationContext *LCtx = C.getLocationContext();
+    ResVal = C.getSValBuilder().conjureSymbolVal(nullptr, BO, LCtx,
+                                                 BO->getType(), C.blockCount());
+    State = State->BindExpr(BO, LCtx, ResVal);
+  }
+
+  if (SymbolRef ResSym = ResVal.getAsSymbol())
+    State = NullDerivedRes ? State->add<NullDerivedCap>(ResSym)
+                           : State->add<AmbiguousProvenanceSym>(ResSym);
+  else if (const MemRegion *Reg = ResVal.getAsRegion())
+    State = State->add<AmbiguousProvenanceReg>(Reg);
+  else
+    return; // no result to propagate to
+
+  const NoteTag *BinOpTag =
+      NullDerivedRes ? nullptr // note will be added in BugVisitor
+                     : C.getNoteTag("Binary operator has ambiguous provenance");
+
+  C.addTransition(State, N, BinOpTag);
+}
+
+// Report intcap binary expressions with ambiguous provenance,
+// store them to report again if used as pointer
+void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
+                                            CheckerContext &C) const {
+  BinaryOperatorKind const OpCode = BO->getOpcode();
+  if (!(BinaryOperator::isAdditiveOp(OpCode) ||
+        BinaryOperator::isMultiplicativeOp(OpCode) ||
+        BinaryOperator::isBitwiseOp(OpCode)))
+    return;
+  bool const IsSub = OpCode == clang::BO_Sub || OpCode == clang::BO_SubAssign;
+
+  Expr *LHS = BO->getLHS();
+  Expr *RHS = BO->getRHS();
+  if (!LHS->getType()->isIntCapType() || !RHS->getType()->isIntCapType())
+    return;
+
+  ProgramStateRef const State = C.getState();
+
+  const SVal &LHSVal = C.getSVal(LHS);
+  const SVal &RHSVal = C.getSVal(RHS);
+
+  bool const LHSIsAddr = isAddress(LHSVal);
+  bool const LHSIsNullDerived = !LHSIsAddr && hasNoProvenance(State, LHSVal);
+  bool const RHSIsAddr = isAddress(RHSVal);
+  bool const RHSIsNullDerived = !RHSIsAddr && hasNoProvenance(State, RHSVal);
+  if (!LHSIsAddr && !LHSIsNullDerived && !RHSIsAddr && !RHSIsNullDerived)
+    return;
+
+  // Operands that were converted to intcap for this binaryOp are not used to
+  // derive the provenance of the result
+  // FIXME: explicit attr::CHERINoProvenance
+  bool const LHSActiveProv = !justConverted2IntCap(LHS, C.getASTContext());
+  bool const RHSActiveProv = !justConverted2IntCap(RHS, C.getASTContext());
+
+  ExplodedNode *N;
+  bool const NullDerivedRes = LHSIsNullDerived && RHSIsNullDerived;
+  if (LHSActiveProv && RHSActiveProv && !IsSub) {
+    N = emitAmbiguousProvenanceWarn(BO, C, LHSIsAddr, LHSIsNullDerived,
+                                    RHSIsAddr, RHSIsNullDerived);
+    if (!N)
+      N = C.getPredecessor();
+  } else if (NullDerivedRes) {
+    N = C.getPredecessor();
+  } else
+    return;
+
+  // Propagate info for result
+  propagateProvenanceInfoForBinOp(N, BO, C, NullDerivedRes);
+}
+
+void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
+                                               CheckerContext &C) const {
+  ProgramStateRef State = C.getState();
+
+  bool Removed = false;
+  const NullDerivedCapTy &Set = State->get<NullDerivedCap>();
+  for (const auto &Sym : Set) {
+    if (!SymReaper.isDead(Sym))
+      continue;
+    State = State->remove<NullDerivedCap>(Sym);
+    Removed = true;
+  }
+
+  const AmbiguousProvenanceSymTy &Set2 = State->get<AmbiguousProvenanceSym>();
+  for (const auto &Sym : Set2) {
+    if (!SymReaper.isDead(Sym))
+      continue;
+    State = State->remove<AmbiguousProvenanceSym>(Sym);
+    Removed = true;
+  }
+
+  if (Removed)
+    C.addTransition(State);
+}
+
+static void describeCast(raw_ostream &OS, const CastExpr *CE,
+                         const LangOptions &LangOpts) {
+  OS << (dyn_cast<ImplicitCastExpr>(CE) ? "implicit" : "explicit");
+  OS << " cast from '";
+  CE->getSubExpr()->getType().print(OS, PrintingPolicy(LangOpts));
+  OS << "' to '";
+  CE->getType().print(OS, PrintingPolicy(LangOpts));
+  OS << "'";
+}
+
+PathDiagnosticPieceRef
+ProvenanceSourceChecker::NullDerivedCapBugVisitor::VisitNode(
+    const ExplodedNode *N, BugReporterContext &BRC,
+    PathSensitiveBugReport &BR) {
+
+  const Stmt *S = N->getStmtForDiagnostics();
+  if (!S)
+    return nullptr;
+
+  SmallString<256> Buf;
+  llvm::raw_svector_ostream OS(Buf);
+
+  if (const CastExpr *CE = dyn_cast<CastExpr>(S)) {
+    if (!isIntegerToIntCapCast(CE))
+      return nullptr;
+
+    if (Sym != N->getSVal(CE).getAsSymbol())
+      return nullptr;
+
+    if (!N->getState()->contains<NullDerivedCap>(Sym))
+      return nullptr;
+
+    OS << "NULL-derived capability: ";
+    describeCast(OS, CE, BRC.getASTContext().getLangOpts());
+  } else if (const BinaryOperator *BO = dyn_cast<BinaryOperator>(S)) {
+    BinaryOperatorKind const OpCode = BO->getOpcode();
+    if (!(BinaryOperator::isAdditiveOp(OpCode) ||
+          BinaryOperator::isMultiplicativeOp(OpCode) ||
+          BinaryOperator::isBitwiseOp(OpCode)))
+      return nullptr;
+
+    if (!BO->getType()->isIntCapType() || Sym != N->getSVal(BO).getAsSymbol())
+      return nullptr;
+
+    if (!N->getState()->contains<NullDerivedCap>(Sym))
+      return nullptr;
+
+    OS << "Result of '" << BO->getOpcodeStr()
+       << "' is a NULL-derived capability";
+  } else
+    return nullptr;
+
+  // Generate the extra diagnostic.
+  PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
+                                   N->getLocationContext());
+  return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
+}
+
+PathDiagnosticPieceRef ProvenanceSourceChecker::Ptr2IntBugVisitor::VisitNode(
+    const ExplodedNode *N, BugReporterContext &BRC,
+    PathSensitiveBugReport &BR) {
+
+  const Stmt *S = N->getStmtForDiagnostics();
+  if (!S)
+    return nullptr;
+
+  const CastExpr *CE = dyn_cast<CastExpr>(S);
+  if (!CE || !isPointerToIntCapCast(CE))
+    return nullptr;
+
+  if (Reg != N->getSVal(CE).getAsRegion())
+    return nullptr;
+
+  SmallString<256> Buf;
+  llvm::raw_svector_ostream OS(Buf);
+  OS << "Capability derived from pointer: ";
+  describeCast(OS, CE, BRC.getASTContext().getLangOpts());
+
+  // Generate the extra diagnostic.
+  PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
+                                   N->getLocationContext());
+  return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
+}
+
+void ento::registerProvenanceSourceChecker(CheckerManager &mgr) {
+  mgr.registerChecker<ProvenanceSourceChecker>();
+}
+
+bool ento::shouldRegisterProvenanceSourceChecker(const CheckerManager &Mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -78,6 +78,8 @@ public:
   void checkPostStmt(const UnaryOperator *BO, CheckerContext &C) const;
   void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
+  bool ShowFixIts = false;
+
 private:
   // Utility
   ExplodedNode *emitAmbiguousProvenanceWarn(const BinaryOperator *BO,
@@ -278,6 +280,24 @@ ProvenanceSourceChecker::emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
   return ErrNode;
 }
 
+namespace {
+
+FixItHint addFixIt(const Expr *NDOp, CheckerContext &C, bool IsUnsigned) {
+  const SourceRange &SrcRange = NDOp->getSourceRange();
+  bool InValidStr = true;
+  const StringRef &OpStr =
+      Lexer::getSourceText(CharSourceRange::getTokenRange(SrcRange),
+                           C.getSourceManager(), C.getLangOpts(), &InValidStr);
+  if (!InValidStr) {
+    return FixItHint::CreateReplacement(
+        SrcRange,
+        (IsUnsigned ? "(size_t)(" : "(ptrdiff_t)(") + OpStr.str() + ")");
+  }
+  return {};
+}
+
+} // namespace
+
 ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
     const BinaryOperator *BO, CheckerContext &C, bool LHSIsAddr,
     bool LHSIsNullDerived, bool RHSIsAddr, bool RHSIsNullDerived) const {
@@ -319,6 +339,15 @@ ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
   auto R = std::make_unique<PathSensitiveBugReport>(
       *AmbiguousProvenanceBinOpBugType, ErrorMessage, ErrNode);
   R->addRange(BO->getSourceRange());
+
+  if (ShowFixIts) {
+    if ((LHSIsAddr && RHSIsNullDerived) || (LHSIsNullDerived && RHSIsAddr)) {
+      const Expr *NDOp = LHSIsNullDerived ? BO->getLHS() : BO->getRHS();
+      const FixItHint &Fixit = addFixIt(NDOp, C, IsUnsigned);
+      if (!Fixit.isNull())
+        R->addFixItHint(Fixit);
+    }
+  }
 
   const SVal &LHSVal = C.getSVal(BO->getLHS());
   R->markInteresting(LHSVal);
@@ -563,7 +592,9 @@ PathDiagnosticPieceRef ProvenanceSourceChecker::Ptr2IntBugVisitor::VisitNode(
 }
 
 void ento::registerProvenanceSourceChecker(CheckerManager &mgr) {
-  mgr.registerChecker<ProvenanceSourceChecker>();
+  auto *Checker = mgr.registerChecker<ProvenanceSourceChecker>();
+  Checker->ShowFixIts =
+      mgr.getAnalyzerOptions().getCheckerBooleanOption(Checker, "ShowFixIts");
 }
 
 bool ento::shouldRegisterProvenanceSourceChecker(const CheckerManager &Mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/ProvenanceSourceChecker.cpp
@@ -26,12 +26,13 @@ class ProvenanceSourceChecker
                      check::PostStmt<BinaryOperator>, check::DeadSymbols> {
   std::unique_ptr<BugType> AmbiguousProvenanceBinOpBugType;
   std::unique_ptr<BugType> AmbiguousProvenancePtrBugType;
-  std::unique_ptr<BugType> NullDerivedCapPtrBugType;
+  std::unique_ptr<BugType> InvalidCapPtrBugType;
+  std::unique_ptr<BugType> PtrdiffAsIntCapBugType;
 
 private:
-  class NullDerivedCapBugVisitor : public BugReporterVisitor {
+  class InvalidCapBugVisitor : public BugReporterVisitor {
   public:
-    NullDerivedCapBugVisitor(SymbolRef SR) : Sym(SR) {}
+    InvalidCapBugVisitor(SymbolRef SR) : Sym(SR) {}
 
     void Profile(llvm::FoldingSetNodeID &ID) const override {
       static int X = 0;
@@ -81,14 +82,17 @@ private:
                                             bool RHSIsAddr,
                                             bool RHSIsNullDerived) const;
 
+  ExplodedNode *emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
+                                        CheckerContext &C) const;
+
   static void propagateProvenanceInfoForBinOp(ExplodedNode *N,
                                               const BinaryOperator *BO,
                                               CheckerContext &C,
-                                              bool NullDerivedCap);
+                                              bool IsInvalidCap);
 };
 } // namespace
 
-REGISTER_SET_WITH_PROGRAMSTATE(NullDerivedCap, SymbolRef)
+REGISTER_SET_WITH_PROGRAMSTATE(InvalidCap, SymbolRef)
 REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceSym, SymbolRef)
 REGISTER_SET_WITH_PROGRAMSTATE(AmbiguousProvenanceReg, const MemRegion *)
 REGISTER_TRAIT_WITH_PROGRAMSTATE(Ptr2IntCapId, unsigned)
@@ -99,6 +103,10 @@ ProvenanceSourceChecker::ProvenanceSourceChecker() {
   AmbiguousProvenancePtrBugType.reset(
       new BugType(this, "Capability with ambiguous provenance used as pointer",
                   "CHERI portability"));
+  InvalidCapPtrBugType.reset(new BugType(
+      this, "Invalid capability used as pointer", "CHERI portability"));
+  PtrdiffAsIntCapBugType.reset(new BugType(
+      this, "Pointer difference as capability", "CHERI portability"));
   NullDerivedCapPtrBugType.reset(new BugType(
       this, "NULL-derived capability used as pointer", "CHERI portability"));
 }
@@ -131,15 +139,14 @@ void ProvenanceSourceChecker::checkPostStmt(const CastExpr *CE,
       return; // skip locAsInteger
 
     ProgramStateRef State = C.getState();
-    State = State->add<NullDerivedCap>(IntCapSym);
+    State = State->add<InvalidCap>(IntCapSym);
     C.addTransition(State);
   } else if (isPointerToIntCapCast(CE)) {
     // Prev node may be reclaimed as "uninteresting", in this case we will not
     // be able to create path diagnostic for it; therefore we modify the state,
     // i.e. create the node that definitely will not be deleted
-    ProgramStateRef State = C.getState();
-    unsigned PrevId = State->get<Ptr2IntCapId>();
-    C.addTransition(State->set<Ptr2IntCapId>(PrevId + 1));
+    ProgramStateRef const State = C.getState();
+    C.addTransition(State->set<Ptr2IntCapId>(State->get<Ptr2IntCapId>() + 1));
   }
 }
 
@@ -161,7 +168,7 @@ static bool hasNoProvenance(ProgramStateRef State, const SVal &Val) {
     return !LocAsInt->hasProvenance();
 
   SymbolRef Sym = Val.getAsSymbol();
-  if (Sym && State->contains<NullDerivedCap>(Sym))
+  if (Sym && State->contains<InvalidCap>(Sym))
     return true;
   return false;
 }
@@ -215,10 +222,10 @@ void ProvenanceSourceChecker::checkPreStmt(const CastExpr *CE,
     if (!ErrNode)
       return;
     R = std::make_unique<PathSensitiveBugReport>(
-        *NullDerivedCapPtrBugType, "NULL-derived capability is used as pointer",
+        *InvalidCapPtrBugType, "Invalid capability is used as pointer",
         ErrNode);
     if (SymbolRef S = SrcVal.getAsSymbol())
-      R->addVisitor(std::make_unique<NullDerivedCapBugVisitor>(S));
+      R->addVisitor(std::make_unique<InvalidCapBugVisitor>(S));
   } else
     return;
 
@@ -235,6 +242,31 @@ static bool justConverted2IntCap(Expr *E, const ASTContext &Ctx) {
       return true;
   }
   return false;
+}
+
+ExplodedNode *
+ProvenanceSourceChecker::emitPtrdiffAsIntCapWarn(const BinaryOperator *BO,
+                                                 CheckerContext &C) const {
+  // Generate the report.
+  ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
+  if (!ErrNode)
+    return nullptr;
+  auto R = std::make_unique<PathSensitiveBugReport>(
+      *PtrdiffAsIntCapBugType, "Pointer difference as capability", ErrNode);
+  R->addRange(BO->getSourceRange());
+
+  const SVal &LHSVal = C.getSVal(BO->getLHS());
+  R->markInteresting(LHSVal);
+  if (const MemRegion *Reg = LHSVal.getAsRegion())
+    R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
+
+  const SVal &RHSVal = C.getSVal(BO->getRHS());
+  R->markInteresting(RHSVal);
+  if (const MemRegion *Reg = RHSVal.getAsRegion())
+    R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
+
+  C.emitReport(std::move(R));
+  return ErrNode;
 }
 
 ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
@@ -282,14 +314,14 @@ ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
   const SVal &LHSVal = C.getSVal(BO->getLHS());
   R->markInteresting(LHSVal);
   if (SymbolRef LS = LHSVal.getAsSymbol())
-    R->addVisitor(std::make_unique<NullDerivedCapBugVisitor>(LS));
+    R->addVisitor(std::make_unique<InvalidCapBugVisitor>(LS));
   if (const MemRegion *Reg = LHSVal.getAsRegion())
     R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
 
   const SVal &RHSVal = C.getSVal(BO->getRHS());
   R->markInteresting(RHSVal);
   if (SymbolRef RS = RHSVal.getAsSymbol())
-    R->addVisitor(std::make_unique<NullDerivedCapBugVisitor>(RS));
+    R->addVisitor(std::make_unique<InvalidCapBugVisitor>(RS));
   if (const MemRegion *Reg = RHSVal.getAsRegion())
     R->addVisitor(std::make_unique<Ptr2IntBugVisitor>(Reg));
 
@@ -299,7 +331,7 @@ ExplodedNode *ProvenanceSourceChecker::emitAmbiguousProvenanceWarn(
 
 void ProvenanceSourceChecker::propagateProvenanceInfoForBinOp(
     ExplodedNode *N, const BinaryOperator *BO, CheckerContext &C,
-    bool NullDerivedRes) {
+    bool IsInvalidCap) {
 
   ProgramStateRef State = N->getState();
   SVal ResVal = C.getSVal(BO);
@@ -311,16 +343,16 @@ void ProvenanceSourceChecker::propagateProvenanceInfoForBinOp(
   }
 
   if (SymbolRef ResSym = ResVal.getAsSymbol())
-    State = NullDerivedRes ? State->add<NullDerivedCap>(ResSym)
-                           : State->add<AmbiguousProvenanceSym>(ResSym);
+    State = IsInvalidCap ? State->add<InvalidCap>(ResSym)
+                         : State->add<AmbiguousProvenanceSym>(ResSym);
   else if (const MemRegion *Reg = ResVal.getAsRegion())
     State = State->add<AmbiguousProvenanceReg>(Reg);
   else
     return; // no result to propagate to
 
   const NoteTag *BinOpTag =
-      NullDerivedRes ? nullptr // note will be added in BugVisitor
-                     : C.getNoteTag("Binary operator has ambiguous provenance");
+      IsInvalidCap ? nullptr // note will be added in BugVisitor
+                   : C.getNoteTag("Binary operator has ambiguous provenance");
 
   C.addTransition(State, N, BinOpTag);
 }
@@ -360,19 +392,26 @@ void ProvenanceSourceChecker::checkPostStmt(const BinaryOperator *BO,
   bool const RHSActiveProv = !justConverted2IntCap(RHS, C.getASTContext());
 
   ExplodedNode *N;
-  bool const NullDerivedRes = LHSIsNullDerived && RHSIsNullDerived;
+  bool InvalidCap;
   if (LHSActiveProv && RHSActiveProv && !IsSub) {
     N = emitAmbiguousProvenanceWarn(BO, C, LHSIsAddr, LHSIsNullDerived,
                                     RHSIsAddr, RHSIsNullDerived);
     if (!N)
       N = C.getPredecessor();
-  } else if (NullDerivedRes) {
+    InvalidCap = false;
+  } else if (IsSub && LHSIsAddr && RHSIsAddr) {
+    N = emitPtrdiffAsIntCapWarn(BO, C);
+    if (!N)
+      N = C.getPredecessor();
+    InvalidCap = true;
+  } else if (LHSIsNullDerived && (RHSIsNullDerived || IsSub)) {
     N = C.getPredecessor();
+    InvalidCap = true;
   } else
     return;
 
   // Propagate info for result
-  propagateProvenanceInfoForBinOp(N, BO, C, NullDerivedRes);
+  propagateProvenanceInfoForBinOp(N, BO, C, InvalidCap);
 }
 
 void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
@@ -380,11 +419,11 @@ void ProvenanceSourceChecker::checkDeadSymbols(SymbolReaper &SymReaper,
   ProgramStateRef State = C.getState();
 
   bool Removed = false;
-  const NullDerivedCapTy &Set = State->get<NullDerivedCap>();
+  const InvalidCapTy &Set = State->get<InvalidCap>();
   for (const auto &Sym : Set) {
     if (!SymReaper.isDead(Sym))
       continue;
-    State = State->remove<NullDerivedCap>(Sym);
+    State = State->remove<InvalidCap>(Sym);
     Removed = true;
   }
 
@@ -410,8 +449,7 @@ static void describeCast(raw_ostream &OS, const CastExpr *CE,
   OS << "'";
 }
 
-PathDiagnosticPieceRef
-ProvenanceSourceChecker::NullDerivedCapBugVisitor::VisitNode(
+PathDiagnosticPieceRef ProvenanceSourceChecker::InvalidCapBugVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BRC,
     PathSensitiveBugReport &BR) {
 
@@ -429,7 +467,7 @@ ProvenanceSourceChecker::NullDerivedCapBugVisitor::VisitNode(
     if (Sym != N->getSVal(CE).getAsSymbol())
       return nullptr;
 
-    if (!N->getState()->contains<NullDerivedCap>(Sym))
+    if (!N->getState()->contains<InvalidCap>(Sym))
       return nullptr;
 
     OS << "NULL-derived capability: ";
@@ -440,15 +478,20 @@ ProvenanceSourceChecker::NullDerivedCapBugVisitor::VisitNode(
           BinaryOperator::isMultiplicativeOp(OpCode) ||
           BinaryOperator::isBitwiseOp(OpCode)))
       return nullptr;
+    bool const IsSub = OpCode == clang::BO_Sub || OpCode == clang::BO_SubAssign;
 
     if (!BO->getType()->isIntCapType() || Sym != N->getSVal(BO).getAsSymbol())
       return nullptr;
 
-    if (!N->getState()->contains<NullDerivedCap>(Sym))
+    if (!N->getState()->contains<InvalidCap>(Sym))
       return nullptr;
 
-    OS << "Result of '" << BO->getOpcodeStr()
-       << "' is a NULL-derived capability";
+    OS << "Result of '" << BO->getOpcodeStr() << "'";
+    if (hasNoProvenance(N->getState(), N->getSVal(BO->getLHS())) &&
+        (hasNoProvenance(N->getState(), N->getSVal(BO->getRHS())) || IsSub))
+      OS << " is a NULL-derived capability";
+    else
+      OS << " is an invalid capability";
   } else
     return nullptr;
 

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
@@ -1,0 +1,99 @@
+// ==-- PointerSizeAssumptionsChecker.cpp -------------------------*- C++ -*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This checker detects record fields that will not have precise bounds when
+// compiled with
+//      -cheri-bounds=subobject-safe
+// due to big size and underaligned offset, as narrowed capability will not
+// be representable
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/StmtVisitor.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+#include "clang/StaticAnalyzer/Core/PathSensitive/AnalysisManager.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/CHERI/CompressedCapability.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
+using namespace ento;
+
+namespace {
+class SubObjectRepresentabilityChecker
+    : public Checker<check::ASTDecl<RecordDecl>> {
+public:
+  void checkASTDecl(const RecordDecl *R, AnalysisManager &mgr,
+                    BugReporter &BR) const;
+};
+
+} // namespace
+
+void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
+                                                    AnalysisManager &mgr,
+                                                    BugReporter &BR) const {
+  if (!R->isCompleteDefinition())
+    return;
+
+  if (!R->getLocation().isValid())
+    return;
+
+  /*
+  SrcMgr::CharacteristicKind Kind =
+      BR.getSourceManager().getFileCharacteristic(Location);
+  // Ignore records in system headers
+  if (Kind != SrcMgr::C_User)
+    return;
+  */
+
+  for (FieldDecl *D : R->fields()) {
+    QualType T = D->getType();
+
+    ASTContext &ASTCtx = BR.getContext();
+    uint64_t Offset = ASTCtx.getFieldOffset(D) / 8;
+    if (Offset > 0) {
+      uint64_t Size = ASTCtx.getTypeSize(T) / 8;
+      uint64_t ReqAlign = llvm::CompressedCapability::GetRequiredAlignment(
+                              Size, llvm::CompressedCapability::Cheri128)
+                              .value();
+      if (1 << llvm::countr_zero(Offset) < ReqAlign) {
+        /* Emit warning */
+        SmallString<1024> Err;
+        llvm::raw_svector_ostream OS(Err);
+        const PrintingPolicy &PP = ASTCtx.getPrintingPolicy();
+        OS << "Field '";
+        D->getNameForDiagnostic(OS, PP, false);
+        OS << "' of type '" << T.getAsString(PP) << "'";
+        OS << " (size " << Size << ")";
+        OS << " requires " << ReqAlign << " byte alignment for precise bounds;";
+        OS << " field offset is " << Offset;
+
+        // Note that this will fire for every translation unit that uses this
+        // class.  This is suboptimal, but at least scan-build will merge
+        // duplicate HTML reports.
+        PathDiagnosticLocation L =
+            PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
+        BR.EmitBasicReport(R, this, "Field with imprecise subobject bounds",
+                           "CHERI portability", OS.str(), L);
+      }
+    }
+  }
+}
+
+void ento::registerSubObjectRepresentabilityChecker(CheckerManager &mgr) {
+  mgr.registerChecker<SubObjectRepresentabilityChecker>();
+}
+
+bool ento::shouldRegisterSubObjectRepresentabilityChecker(
+    const CheckerManager &mgr) {
+  return true;
+}

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
@@ -86,23 +86,26 @@ reportExposedFields(const FieldDecl *D, ASTContext &ASTCtx, BugReporter &BR,
 }
 
 #if 0
-// FIXME: CC_MORELLO is not set in cheri_compressed_cap
-// FIXME: other targets
-using Handler = CompressedCap128;
-Handler::cap_t getBoundedCap(uint64_t ParentSize, uint64_t Offset,
-                             uint64_t Size) {
-  Handler::addr_t InitLength = Handler ::representable_length(ParentSize);
-  Handler::cap_t MockCap = Handler::make_max_perms_cap(0, 0, InitLength);
-  bool exact = Handler::setbounds(&MockCap, Offset, Offset + Size);
+template <typename Handler>
+typename Handler::cap_t getBoundedCap(uint64_t ParentSize, uint64_t Offset,
+                                      uint64_t Size) {
+  typename Handler::addr_t InitLength =
+      Handler::representable_length(ParentSize);
+  typename Handler::cap_t MockCap =
+      Handler::make_max_perms_cap(0, Offset, InitLength);
+  bool exact = Handler::setbounds(&MockCap, Size);
   assert(!exact);
   return MockCap;
 }
 #endif
 
-} // namespace
+template <typename Handler> uint64_t getRepresentableAlignment(uint64_t Size) {
+  return ~Handler::representable_mask(Size) + 1;
+}
 
-std::unique_ptr<BugReport> checkField(const FieldDecl *D, AnalysisManager &mgr,
-                                      BugReporter &BR, const BugType &BT) {
+template <llvm::CompressedCapability::CapabilityFormat Handler>
+std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
+                                          const BugType &BT) {
   QualType T = D->getType();
 
   ASTContext &ASTCtx = BR.getContext();
@@ -126,17 +129,15 @@ std::unique_ptr<BugReport> checkField(const FieldDecl *D, AnalysisManager &mgr,
       OS << " field offset is " << Offset;
       OS << " (aligned to " << CurAlign << ");";
 
-      /*
-       * Print current bounds
-       * TODO: use cheri_compressed_cap correctly
-       *
+#if 0
       const RecordDecl *Parent = D->getParent();
       uint64_t ParentSize = ASTCtx.getTypeSize(Parent->getTypeForDecl()) / 8;
-      auto MockCap = getBoundedCap(ParentSize, Offset, Size);
+      typename Handler::cap_t MockCap =
+          getBoundedCap<Handler>(ParentSize, Offset, Size);
       uint64_t Base = MockCap.base();
       uint64_t Top = MockCap.top();
       OS << " Current bounds: " << Base << "-" << Top;
-       */
+#endif
 
       // Note that this will fire for every translation unit that uses this
       // class.  This is suboptimal, but at least scan-build will merge
@@ -147,11 +148,9 @@ std::unique_ptr<BugReport> checkField(const FieldDecl *D, AnalysisManager &mgr,
       Report->setDeclWithIssue(D);
       Report->addRange(D->getSourceRange());
 
-      /*
-       * Add exposed fields as notes
-       * TODO: use cheri_compressed_cap correctly
+#if 0
       Report = reportExposedFields(D, ASTCtx, BR, Base, Top, std::move(Report));
-       */
+#endif
 
       return Report;
     }
@@ -160,10 +159,27 @@ std::unique_ptr<BugReport> checkField(const FieldDecl *D, AnalysisManager &mgr,
   return nullptr;
 }
 
+std::unique_ptr<BugReport> checkField(const FieldDecl *D, BugReporter &BR,
+                                      const BugType &BT) {
+  // TODO: other targets
+  return checkFieldImpl<llvm::CompressedCapability::Cheri128>(D, BR, BT);
+}
+
+bool supportedTarget(const ASTContext &C) {
+  const TargetInfo &TI = C.getTargetInfo();
+  return TI.areAllPointersCapabilities() &&
+         TI.getTriple().isAArch64(); // morello
+}
+
+} // namespace
+
 void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
                                                     AnalysisManager &mgr,
                                                     BugReporter &BR) const {
-  if (!R->isCompleteDefinition())
+  if (!supportedTarget(mgr.getASTContext()))
+    return;
+
+  if (!R->isCompleteDefinition() || R->isDependentType())
     return;
 
   if (!R->getLocation().isValid())
@@ -178,7 +194,7 @@ void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
   */
 
   for (FieldDecl *D : R->fields()) {
-    auto Report = checkField(D, mgr, BR, BT_1);
+    auto Report = checkField(D, BR, BT_1);
     if (Report)
       BR.emitReport(std::move(Report));
   }
@@ -187,8 +203,10 @@ void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
 void SubObjectRepresentabilityChecker::checkASTCodeBody(const Decl *D,
                                                         AnalysisManager &mgr,
                                                         BugReporter &BR) const {
-  using namespace ast_matchers;
+  if (!supportedTarget(mgr.getASTContext()))
+    return;
 
+  using namespace ast_matchers;
   auto Member = memberExpr().bind("member");
   auto Decay =
       castExpr(hasCastKind(CK_ArrayToPointerDecay), has(Member)).bind("decay");
@@ -204,7 +222,7 @@ void SubObjectRepresentabilityChecker::checkASTCodeBody(const Decl *D,
       if (const MemberExpr *ME = Match.getNodeAs<MemberExpr>("member")) {
         ValueDecl *VD = ME->getMemberDecl();
         if (FieldDecl *FD = dyn_cast<FieldDecl>(VD)) {
-          auto Report = checkField(FD, mgr, BR, BT_2);
+          auto Report = checkField(FD, BR, BT_2);
           if (Report) {
             PathDiagnosticLocation LN = PathDiagnosticLocation::createBegin(
                 CE, BR.getSourceManager(), mgr.getAnalysisDeclContext(D));
@@ -218,7 +236,7 @@ void SubObjectRepresentabilityChecker::checkASTCodeBody(const Decl *D,
       if (const MemberExpr *ME = Match.getNodeAs<MemberExpr>("member")) {
         ValueDecl *VD = ME->getMemberDecl();
         if (FieldDecl *FD = dyn_cast<FieldDecl>(VD)) {
-          auto Report = checkField(FD, mgr, BR, BT_2);
+          auto Report = checkField(FD, BR, BT_2);
           if (Report) {
             PathDiagnosticLocation LN = PathDiagnosticLocation::createBegin(
                 UO, BR.getSourceManager(), mgr.getAnalysisDeclContext(D));

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
@@ -31,16 +31,134 @@ using namespace ento;
 
 namespace {
 class SubObjectRepresentabilityChecker
-    : public Checker<check::ASTDecl<RecordDecl>> {
+    : public Checker<check::ASTDecl<RecordDecl>, check::ASTCodeBody> {
   BugType BT_1{this, "Field with imprecise subobject bounds",
+               "CHERI portability"};
+  BugType BT_2{this, "Address taken of a field with imprecise subobject bounds",
                "CHERI portability"};
 
 public:
   void checkASTDecl(const RecordDecl *R, AnalysisManager &mgr,
                     BugReporter &BR) const;
+  void checkASTCodeBody(const Decl *D, AnalysisManager &mgr,
+                        BugReporter &BR) const;
 };
 
 } // namespace
+
+namespace {
+
+std::unique_ptr<BasicBugReport>
+reportExposedFields(const FieldDecl *D, ASTContext &ASTCtx, BugReporter &BR,
+                    uint64_t Base, uint64_t Top,
+                    std::unique_ptr<BasicBugReport> Report) {
+  const RecordDecl *Parent = D->getParent();
+  auto FI = Parent->field_begin();
+  while (FI != Parent->field_end() &&
+         ASTCtx.getFieldOffset(*FI) / 8 +
+                 ASTCtx.getTypeSize(FI->getType()) / 8 <=
+             Base)
+    FI++;
+
+  bool Before = true;
+  while (FI != Parent->field_end() && ASTCtx.getFieldOffset(*FI) / 8 < Top) {
+    if (*FI != D) {
+      SmallString<1024> Note;
+      llvm::raw_svector_ostream OS2(Note);
+
+      uint64_t CurFieldOffset = ASTCtx.getFieldOffset(*FI) / 8;
+      uint64_t CurFieldSize = ASTCtx.getTypeSize(FI->getType()) / 8;
+      uint64_t BytesExposed =
+          Before ? std::min(CurFieldSize, CurFieldOffset + CurFieldSize - Base)
+                 : std::min(CurFieldSize, Top - CurFieldOffset);
+      OS2 << BytesExposed << "/" << CurFieldSize << " bytes exposed";
+      if (cheri::hasCapability(FI->getType(), ASTCtx))
+        OS2 << " (may expose capability!)";
+
+      PathDiagnosticLocation LN =
+          PathDiagnosticLocation::createBegin(*FI, BR.getSourceManager());
+      Report->addNote(OS2.str(), LN);
+    } else
+      Before = false;
+    FI++;
+  }
+  return Report;
+}
+
+#if 0
+// FIXME: CC_MORELLO is not set in cheri_compressed_cap
+// FIXME: other targets
+using Handler = CompressedCap128;
+Handler::cap_t getBoundedCap(uint64_t ParentSize, uint64_t Offset,
+                             uint64_t Size) {
+  Handler::addr_t InitLength = Handler ::representable_length(ParentSize);
+  Handler::cap_t MockCap = Handler::make_max_perms_cap(0, 0, InitLength);
+  bool exact = Handler::setbounds(&MockCap, Offset, Offset + Size);
+  assert(!exact);
+  return MockCap;
+}
+#endif
+
+} // namespace
+
+std::unique_ptr<BugReport> checkField(const FieldDecl *D, AnalysisManager &mgr,
+                                      BugReporter &BR, const BugType &BT) {
+  QualType T = D->getType();
+
+  ASTContext &ASTCtx = BR.getContext();
+  uint64_t Offset = ASTCtx.getFieldOffset(D) / 8;
+  if (Offset > 0) {
+    uint64_t Size = ASTCtx.getTypeSize(T) / 8;
+    uint64_t ReqAlign = llvm::CompressedCapability::GetRequiredAlignment(
+                            Size, llvm::CompressedCapability::Cheri128)
+                            .value();
+    uint64_t CurAlign = 1 << llvm::countr_zero(Offset);
+    if (CurAlign < ReqAlign) {
+      /* Emit warning */
+      SmallString<1024> Err;
+      llvm::raw_svector_ostream OS(Err);
+      const PrintingPolicy &PP = ASTCtx.getPrintingPolicy();
+      OS << "Field '";
+      D->getNameForDiagnostic(OS, PP, false);
+      OS << "' of type '" << T.getAsString(PP) << "'";
+      OS << " (size " << Size << ")";
+      OS << " requires " << ReqAlign << " byte alignment for precise bounds;";
+      OS << " field offset is " << Offset;
+      OS << " (aligned to " << CurAlign << ");";
+
+      /*
+       * Print current bounds
+       * TODO: use cheri_compressed_cap correctly
+       *
+      const RecordDecl *Parent = D->getParent();
+      uint64_t ParentSize = ASTCtx.getTypeSize(Parent->getTypeForDecl()) / 8;
+      auto MockCap = getBoundedCap(ParentSize, Offset, Size);
+      uint64_t Base = MockCap.base();
+      uint64_t Top = MockCap.top();
+      OS << " Current bounds: " << Base << "-" << Top;
+       */
+
+      // Note that this will fire for every translation unit that uses this
+      // class.  This is suboptimal, but at least scan-build will merge
+      // duplicate HTML reports.
+      PathDiagnosticLocation L =
+          PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
+      auto Report = std::make_unique<BasicBugReport>(BT, OS.str(), L);
+      Report->setDeclWithIssue(D);
+      Report->addRange(D->getSourceRange());
+
+      /*
+       * Add exposed fields as notes
+       * TODO: use cheri_compressed_cap correctly
+      Report = reportExposedFields(D, ASTCtx, BR, Base, Top, std::move(Report));
+       */
+
+      return Report;
+    }
+  }
+
+  return nullptr;
+}
 
 void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
                                                     AnalysisManager &mgr,
@@ -60,85 +178,54 @@ void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
   */
 
   for (FieldDecl *D : R->fields()) {
-    QualType T = D->getType();
+    auto Report = checkField(D, mgr, BR, BT_1);
+    if (Report)
+      BR.emitReport(std::move(Report));
+  }
+}
 
-    ASTContext &ASTCtx = BR.getContext();
-    uint64_t Offset = ASTCtx.getFieldOffset(D) / 8;
-    if (Offset > 0) {
-      uint64_t Size = ASTCtx.getTypeSize(T) / 8;
-      uint64_t ReqAlign = llvm::CompressedCapability::GetRequiredAlignment(
-                              Size, llvm::CompressedCapability::Cheri128)
-                              .value();
-      uint64_t CurAlign = 1 << llvm::countr_zero(Offset);
-      if (CurAlign < ReqAlign) {
-        /* Emit warning */
-        SmallString<1024> Err;
-        llvm::raw_svector_ostream OS(Err);
-        const PrintingPolicy &PP = ASTCtx.getPrintingPolicy();
-        OS << "Field '";
-        D->getNameForDiagnostic(OS, PP, false);
-        OS << "' of type '" << T.getAsString(PP) << "'";
-        OS << " (size " << Size << ")";
-        OS << " requires " << ReqAlign << " byte alignment for precise bounds;";
-        OS << " field offset is " << Offset;
-        OS << " (aligned to " << CurAlign << ");";
+void SubObjectRepresentabilityChecker::checkASTCodeBody(const Decl *D,
+                                                        AnalysisManager &mgr,
+                                                        BugReporter &BR) const {
+  using namespace ast_matchers;
 
-#if 0
-        // CHERIOT FIXME: Get rid of dependency on compressed-cap-lib
-        using Handler = CompressedCap128;
-        uint64_t ParentSize = ASTCtx.getTypeSize(R->getTypeForDecl())/8;
-        Handler::addr_t InitLength = Handler ::representable_length(ParentSize);
-        Handler::cap_t MockCap = Handler::make_max_perms_cap(0, 0, InitLength);
-        bool exact = Handler::setbounds(&MockCap, Offset, Offset + Size);
-        assert(!exact);
-        auto Base = MockCap.base();
-        Handler::addr_t Top = MockCap.top();
-        OS << " Current bounds: " << Base << "-" << Top;
-#endif
+  auto Member = memberExpr().bind("member");
+  auto Decay =
+      castExpr(hasCastKind(CK_ArrayToPointerDecay), has(Member)).bind("decay");
+  auto Addr = unaryOperator(hasOperatorName("&"), has(Member)).bind("addr");
 
-        PathDiagnosticLocation L =
-            PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
-        auto Report = std::make_unique<BasicBugReport>(BT_1, OS.str(), L);
-        Report->setDeclWithIssue(D);
-        Report->addRange(D->getSourceRange());
+  auto PointerSizeCheck = traverse(TK_AsIs, stmt(anyOf(Decay, Addr)));
 
-#if 0
-        // CHERIOT FIXME: Get rid of dependency on compressed-cap-lib
-        auto FI = R->field_begin();
-        while (FI != R->field_end() &&
-               ASTCtx.getFieldOffset(*FI)/8
-                + ASTCtx.getTypeSize(FI->getType())/8 <= Base)
-          FI++;
+  auto Matcher = decl(forEachDescendant(PointerSizeCheck));
 
-        bool Before = true;
-        while (FI != R->field_end() && ASTCtx.getFieldOffset(*FI)/8 < Top) {
-          if (*FI != D) {
-            SmallString<1024> Note;
-            llvm::raw_svector_ostream OS2(Note);
-
-            uint64_t CurFieldOffset = ASTCtx.getFieldOffset(*FI)/8;
-            uint64_t CurFieldSize = ASTCtx.getTypeSize(FI->getType())/8;
-            uint64_t BytesExposed =
-                Before ? std::min(CurFieldSize,
-                                  CurFieldOffset + CurFieldSize - Base)
-                       : std::min(CurFieldSize, Top - CurFieldOffset);
-            OS2 << BytesExposed << "/" << CurFieldSize << " bytes exposed";
-            if (cheri::hasCapability(FI->getType(), ASTCtx))
-              OS2 << " (may expose capability!)";
-
-            PathDiagnosticLocation LN =
-                PathDiagnosticLocation::createBegin(*FI, BR.getSourceManager());
-            Report->addNote(OS2.str(), LN);
-          } else
-            Before = false;
-          FI++;
+  auto Matches = match(Matcher, *D, BR.getContext());
+  for (const auto &Match : Matches) {
+    if (const CastExpr *CE = Match.getNodeAs<CastExpr>("decay")) {
+      if (const MemberExpr *ME = Match.getNodeAs<MemberExpr>("member")) {
+        ValueDecl *VD = ME->getMemberDecl();
+        if (FieldDecl *FD = dyn_cast<FieldDecl>(VD)) {
+          auto Report = checkField(FD, mgr, BR, BT_2);
+          if (Report) {
+            PathDiagnosticLocation LN = PathDiagnosticLocation::createBegin(
+                CE, BR.getSourceManager(), mgr.getAnalysisDeclContext(D));
+            Report->addNote("Array to pointer decay", LN);
+            BR.emitReport(std::move(Report));
+          }
         }
-#endif
-
-        // Note that this will fire for every translation unit that uses this
-        // class.  This is suboptimal, but at least scan-build will merge
-        // duplicate HTML reports.
-        BR.emitReport(std::move(Report));
+      }
+    } else if (const UnaryOperator *UO =
+                   Match.getNodeAs<UnaryOperator>("addr")) {
+      if (const MemberExpr *ME = Match.getNodeAs<MemberExpr>("member")) {
+        ValueDecl *VD = ME->getMemberDecl();
+        if (FieldDecl *FD = dyn_cast<FieldDecl>(VD)) {
+          auto Report = checkField(FD, mgr, BR, BT_2);
+          if (Report) {
+            PathDiagnosticLocation LN = PathDiagnosticLocation::createBegin(
+                UO, BR.getSourceManager(), mgr.getAnalysisDeclContext(D));
+            Report->addNote("Address of a field taken", LN);
+            BR.emitReport(std::move(Report));
+          }
+        }
       }
     }
   }

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
@@ -30,6 +30,11 @@ using namespace clang;
 using namespace ento;
 
 namespace {
+
+template <llvm::CompressedCapability::CapabilityFormat>
+std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
+                                          const BugType &BT);
+
 class SubObjectRepresentabilityChecker
     : public Checker<check::ASTDecl<RecordDecl>, check::ASTCodeBody> {
   BugType BT_1{this, "Field with imprecise subobject bounds",
@@ -42,6 +47,23 @@ public:
                     BugReporter &BR) const;
   void checkASTCodeBody(const Decl *D, AnalysisManager &mgr,
                         BugReporter &BR) const;
+
+private:
+  using CheckFieldFn = std::function<std::unique_ptr<BugReport>(
+      const FieldDecl *D, BugReporter &BR, const BugType &BT)>;
+
+  const std::map<llvm::Triple::ArchType, CheckFieldFn> CheckFieldFnMap = {
+      //{llvm::Triple::aarch64, &checkFieldImpl<CompressedCap128m>},
+      {llvm::Triple::mips,
+       &checkFieldImpl<llvm::CompressedCapability::Cheri64>},
+      {llvm::Triple::mips64,
+       &checkFieldImpl<llvm::CompressedCapability::Cheri128>},
+      {llvm::Triple::riscv32,
+       &checkFieldImpl<llvm::CompressedCapability::Cheri64>},
+      {llvm::Triple::riscv64,
+       &checkFieldImpl<llvm::CompressedCapability::Cheri128>}};
+
+  CheckFieldFn getCheckFieldFn(ASTContext &ASTCtx) const;
 };
 
 } // namespace
@@ -112,9 +134,8 @@ std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
   uint64_t Offset = ASTCtx.getFieldOffset(D) / 8;
   if (Offset > 0) {
     uint64_t Size = ASTCtx.getTypeSize(T) / 8;
-    uint64_t ReqAlign = llvm::CompressedCapability::GetRequiredAlignment(
-                            Size, llvm::CompressedCapability::Cheri128)
-                            .value();
+    uint64_t ReqAlign =
+        llvm::CompressedCapability::GetRequiredAlignment(Size, Handler).value();
     uint64_t CurAlign = 1 << llvm::countr_zero(Offset);
     if (CurAlign < ReqAlign) {
       /* Emit warning */
@@ -129,15 +150,14 @@ std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
       OS << " field offset is " << Offset;
       OS << " (aligned to " << CurAlign << ");";
 
-#if 0
-      const RecordDecl *Parent = D->getParent();
-      uint64_t ParentSize = ASTCtx.getTypeSize(Parent->getTypeForDecl()) / 8;
-      typename Handler::cap_t MockCap =
-          getBoundedCap<Handler>(ParentSize, Offset, Size);
-      uint64_t Base = MockCap.base();
-      uint64_t Top = MockCap.top();
+      uint64_t OffsetToAlign = Offset % ReqAlign;
+      uint64_t Base = Offset - OffsetToAlign;
+      uint64_t AlignedSize = Size + OffsetToAlign;
+      uint64_t TailPadding = static_cast<uint64_t>(
+          llvm::CompressedCapability::GetRequiredTailPadding(AlignedSize,
+                                                             Handler));
+      uint64_t Top = Base + AlignedSize + TailPadding;
       OS << " Current bounds: " << Base << "-" << Top;
-#endif
 
       // Note that this will fire for every translation unit that uses this
       // class.  This is suboptimal, but at least scan-build will merge
@@ -148,10 +168,7 @@ std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
       Report->setDeclWithIssue(D);
       Report->addRange(D->getSourceRange());
 
-#if 0
       Report = reportExposedFields(D, ASTCtx, BR, Base, Top, std::move(Report));
-#endif
-
       return Report;
     }
   }
@@ -159,39 +176,32 @@ std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
   return nullptr;
 }
 
-std::unique_ptr<BugReport> checkField(const FieldDecl *D, BugReporter &BR,
-                                      const BugType &BT) {
-  // TODO: other targets
-  return checkFieldImpl<llvm::CompressedCapability::Cheri128>(D, BR, BT);
-}
-
-bool supportedTarget(const ASTContext &C) {
-  const TargetInfo &TI = C.getTargetInfo();
-  return TI.areAllPointersCapabilities() &&
-         TI.getTriple().isAArch64(); // morello
-}
-
 } // namespace
+
+SubObjectRepresentabilityChecker::CheckFieldFn
+SubObjectRepresentabilityChecker::getCheckFieldFn(ASTContext &ASTCtx) const {
+  const TargetInfo &TI = ASTCtx.getTargetInfo();
+  if (!TI.areAllPointersCapabilities())
+    return nullptr;
+
+  auto It = CheckFieldFnMap.find(TI.getTriple().getArch());
+  if (It == CheckFieldFnMap.end())
+    return nullptr;
+  return It->second;
+}
 
 void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
                                                     AnalysisManager &mgr,
                                                     BugReporter &BR) const {
-  if (!supportedTarget(mgr.getASTContext()))
-    return;
+  CheckFieldFn checkField = getCheckFieldFn(mgr.getASTContext());
+  if (!checkField)
+    return; // skip this target
 
   if (!R->isCompleteDefinition() || R->isDependentType())
     return;
 
   if (!R->getLocation().isValid())
     return;
-
-  /*
-  SrcMgr::CharacteristicKind Kind =
-      BR.getSourceManager().getFileCharacteristic(Location);
-  // Ignore records in system headers
-  if (Kind != SrcMgr::C_User)
-    return;
-  */
 
   for (FieldDecl *D : R->fields()) {
     auto Report = checkField(D, BR, BT_1);
@@ -203,8 +213,9 @@ void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
 void SubObjectRepresentabilityChecker::checkASTCodeBody(const Decl *D,
                                                         AnalysisManager &mgr,
                                                         BugReporter &BR) const {
-  if (!supportedTarget(mgr.getASTContext()))
-    return;
+  CheckFieldFn checkField = getCheckFieldFn(mgr.getASTContext());
+  if (!checkField)
+    return; // skip this target
 
   using namespace ast_matchers;
   auto Member = memberExpr().bind("member");

--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CHERIUtils.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
@@ -31,6 +32,9 @@ using namespace ento;
 namespace {
 class SubObjectRepresentabilityChecker
     : public Checker<check::ASTDecl<RecordDecl>> {
+  BugType BT_1{this, "Field with imprecise subobject bounds",
+               "CHERI portability"};
+
 public:
   void checkASTDecl(const RecordDecl *R, AnalysisManager &mgr,
                     BugReporter &BR) const;
@@ -65,7 +69,8 @@ void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
       uint64_t ReqAlign = llvm::CompressedCapability::GetRequiredAlignment(
                               Size, llvm::CompressedCapability::Cheri128)
                               .value();
-      if (1 << llvm::countr_zero(Offset) < ReqAlign) {
+      uint64_t CurAlign = 1 << llvm::countr_zero(Offset);
+      if (CurAlign < ReqAlign) {
         /* Emit warning */
         SmallString<1024> Err;
         llvm::raw_svector_ostream OS(Err);
@@ -76,14 +81,64 @@ void SubObjectRepresentabilityChecker::checkASTDecl(const RecordDecl *R,
         OS << " (size " << Size << ")";
         OS << " requires " << ReqAlign << " byte alignment for precise bounds;";
         OS << " field offset is " << Offset;
+        OS << " (aligned to " << CurAlign << ");";
+
+#if 0
+        // CHERIOT FIXME: Get rid of dependency on compressed-cap-lib
+        using Handler = CompressedCap128;
+        uint64_t ParentSize = ASTCtx.getTypeSize(R->getTypeForDecl())/8;
+        Handler::addr_t InitLength = Handler ::representable_length(ParentSize);
+        Handler::cap_t MockCap = Handler::make_max_perms_cap(0, 0, InitLength);
+        bool exact = Handler::setbounds(&MockCap, Offset, Offset + Size);
+        assert(!exact);
+        auto Base = MockCap.base();
+        Handler::addr_t Top = MockCap.top();
+        OS << " Current bounds: " << Base << "-" << Top;
+#endif
+
+        PathDiagnosticLocation L =
+            PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
+        auto Report = std::make_unique<BasicBugReport>(BT_1, OS.str(), L);
+        Report->setDeclWithIssue(D);
+        Report->addRange(D->getSourceRange());
+
+#if 0
+        // CHERIOT FIXME: Get rid of dependency on compressed-cap-lib
+        auto FI = R->field_begin();
+        while (FI != R->field_end() &&
+               ASTCtx.getFieldOffset(*FI)/8
+                + ASTCtx.getTypeSize(FI->getType())/8 <= Base)
+          FI++;
+
+        bool Before = true;
+        while (FI != R->field_end() && ASTCtx.getFieldOffset(*FI)/8 < Top) {
+          if (*FI != D) {
+            SmallString<1024> Note;
+            llvm::raw_svector_ostream OS2(Note);
+
+            uint64_t CurFieldOffset = ASTCtx.getFieldOffset(*FI)/8;
+            uint64_t CurFieldSize = ASTCtx.getTypeSize(FI->getType())/8;
+            uint64_t BytesExposed =
+                Before ? std::min(CurFieldSize,
+                                  CurFieldOffset + CurFieldSize - Base)
+                       : std::min(CurFieldSize, Top - CurFieldOffset);
+            OS2 << BytesExposed << "/" << CurFieldSize << " bytes exposed";
+            if (cheri::hasCapability(FI->getType(), ASTCtx))
+              OS2 << " (may expose capability!)";
+
+            PathDiagnosticLocation LN =
+                PathDiagnosticLocation::createBegin(*FI, BR.getSourceManager());
+            Report->addNote(OS2.str(), LN);
+          } else
+            Before = false;
+          FI++;
+        }
+#endif
 
         // Note that this will fire for every translation unit that uses this
         // class.  This is suboptimal, but at least scan-build will merge
         // duplicate HTML reports.
-        PathDiagnosticLocation L =
-            PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
-        BR.EmitBasicReport(R, this, "Field with imprecise subobject bounds",
-                           "CHERI portability", OS.str(), L);
+        BR.emitReport(std::move(Report));
       }
     }
   }

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -26,6 +26,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CheckSecuritySyntaxOnly.cpp
   CheckerDocumentation.cpp
   CHERI/ProvenanceSourceChecker.cpp
+  CHERI/CapabilityCopyChecker.cpp
   ChrootChecker.cpp
   CloneChecker.cpp
   ContainerModeling.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CheckerDocumentation.cpp
   CHERI/AllocationChecker.cpp
   CHERI/CapabilityCopyChecker.cpp
+  CHERI/CheriAPIModelling.cpp
   CHERI/CHERIUtils.cpp
   CHERI/PointerSizeAssumptionsChecker.cpp
   CHERI/ProvenanceSourceChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -25,10 +25,11 @@ add_clang_library(clangStaticAnalyzerCheckers
   CheckPlacementNew.cpp
   CheckSecuritySyntaxOnly.cpp
   CheckerDocumentation.cpp
+  CHERI/AllocationChecker.cpp
+  CHERI/CapabilityCopyChecker.cpp
   CHERI/CHERIUtils.cpp
   CHERI/PointerSizeAssumptionsChecker.cpp
   CHERI/ProvenanceSourceChecker.cpp
-  CHERI/CapabilityCopyChecker.cpp
   CHERI/SubObjectRepresentabilityChecker.cpp
   ChrootChecker.cpp
   CloneChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -25,6 +25,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CheckPlacementNew.cpp
   CheckSecuritySyntaxOnly.cpp
   CheckerDocumentation.cpp
+  CHERI/ProvenanceSourceChecker.cpp
   ChrootChecker.cpp
   CloneChecker.cpp
   ContainerModeling.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -28,6 +28,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CHERI/CHERIUtils.cpp
   CHERI/ProvenanceSourceChecker.cpp
   CHERI/CapabilityCopyChecker.cpp
+  CHERI/CapabilityAlignmentChecker.cpp
   ChrootChecker.cpp
   CloneChecker.cpp
   ContainerModeling.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -29,6 +29,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CHERI/PointerSizeAssumptionsChecker.cpp
   CHERI/ProvenanceSourceChecker.cpp
   CHERI/CapabilityCopyChecker.cpp
+  CHERI/SubObjectRepresentabilityChecker.cpp
   ChrootChecker.cpp
   CloneChecker.cpp
   ContainerModeling.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -25,6 +25,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CheckPlacementNew.cpp
   CheckSecuritySyntaxOnly.cpp
   CheckerDocumentation.cpp
+  CHERI/CHERIUtils.cpp
   CHERI/ProvenanceSourceChecker.cpp
   CHERI/CapabilityCopyChecker.cpp
   ChrootChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -26,6 +26,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   CheckSecuritySyntaxOnly.cpp
   CheckerDocumentation.cpp
   CHERI/CHERIUtils.cpp
+  CHERI/PointerSizeAssumptionsChecker.cpp
   CHERI/ProvenanceSourceChecker.cpp
   CHERI/CapabilityCopyChecker.cpp
   ChrootChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -28,7 +28,6 @@ add_clang_library(clangStaticAnalyzerCheckers
   CHERI/CHERIUtils.cpp
   CHERI/ProvenanceSourceChecker.cpp
   CHERI/CapabilityCopyChecker.cpp
-  CHERI/CapabilityAlignmentChecker.cpp
   ChrootChecker.cpp
   CloneChecker.cpp
   ContainerModeling.cpp
@@ -93,6 +92,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   ObjCUnusedIVarsChecker.cpp
   OSObjectCStyleCast.cpp
   PaddingChecker.cpp
+  PointerAlignmentChecker.cpp
   PointerArithChecker.cpp
   PointerSubChecker.cpp
   PthreadLockChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -427,21 +427,26 @@ void printAlign(raw_ostream &OS, unsigned TZC) {
   OS << ")";
 }
 
-void describeOriginalAllocation(const MemRegion *MR, PathSensitiveBugReport &W,
-                                const SourceManager &SM, ASTContext &ASTCtx) {
-  if (const DeclRegion *DR = MR->getAs<DeclRegion>()) {
-    const ValueDecl *SrcDecl = DR->getDecl();
-    SmallString<350> Note;
-    llvm::raw_svector_ostream OS2(Note);
-    const QualType &AllocType = SrcDecl->getType().getCanonicalType();
-    OS2 << "Original allocation of type ";
-    OS2 << "'" << AllocType.getAsString() << "'";
-    OS2 << " which has an alignment requirement ";
-    OS2 << ASTCtx.getTypeAlignInChars(AllocType).getQuantity();
-    OS2 << " bytes";
-    W.addNote(Note, PathDiagnosticLocation::create(SrcDecl, SM));
-  } else if (const ElementRegion *ER = MR->getAs<ElementRegion>())
-    describeOriginalAllocation(ER->getSuperRegion(), W, SM, ASTCtx);
+const DeclRegion *getOriginalAllocation(const MemRegion *MR) {
+  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
+    return DR;
+  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
+    return getOriginalAllocation(ER->getSuperRegion());
+  return nullptr;
+}
+
+void describeOriginalAllocation(const ValueDecl *SrcDecl,
+                                PathDiagnosticLocation SrcLoc,
+                                PathSensitiveBugReport &W, ASTContext &ASTCtx) {
+  SmallString<350> Note;
+  llvm::raw_svector_ostream OS2(Note);
+  const QualType &AllocType = SrcDecl->getType().getCanonicalType();
+  OS2 << "Original allocation of type ";
+  OS2 << "'" << AllocType.getAsString() << "'";
+  OS2 << " which has an alignment requirement ";
+  OS2 << ASTCtx.getTypeAlignInChars(AllocType).getQuantity();
+  OS2 << " bytes";
+  W.addNote(Note, SrcLoc);
 }
 
 } // namespace
@@ -468,16 +473,26 @@ PointerAlignmentChecker::emitCastAlignWarn(CheckerContext &C, unsigned SrcAlign,
   OS << " alignment " << DstReqAlign;
   OS << " bytes";
 
-  auto W = std::make_unique<PathSensitiveBugReport>(
-      DstAlignIsCap ? *CapCastAlignBug : *CastAlignBug, ErrorMessage, ErrNode);
-  W->addRange(CE->getSourceRange());
-
   const SVal &SrcVal = C.getSVal(CE->getSubExpr());
+  const ValueDecl *MRDecl = nullptr;
+  PathDiagnosticLocation MRDeclLoc;
+  if (const MemRegion *MR = SrcVal.getAsRegion()) {
+    if (const DeclRegion *OriginalAlloc = getOriginalAllocation(MR)) {
+      MRDecl = OriginalAlloc->getDecl();
+      MRDeclLoc = PathDiagnosticLocation::create(MRDecl, C.getSourceManager());
+    }
+  }
+
+  auto W = std::make_unique<PathSensitiveBugReport>(
+      DstAlignIsCap ? *CapCastAlignBug : *CastAlignBug, ErrorMessage, ErrNode,
+      MRDeclLoc, MRDecl);
+
   W->markInteresting(SrcVal);
   if (SymbolRef S = SrcVal.getAsSymbol())
     W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
-  else if (const MemRegion *MR = SrcVal.getAsRegion()) {
-    describeOriginalAllocation(MR, *W, C.getSourceManager(), C.getASTContext());
+
+  if (MRDecl) {
+    describeOriginalAllocation(MRDecl, MRDeclLoc, *W, C.getASTContext());
   }
 
   C.emitReport(std::move(W));

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -68,10 +68,11 @@ public:
   void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
 private:
-  ExplodedNode *
-  emitAlignmentWarning(CheckerContext &C, const SVal &UnderalignedPtrVal,
-                       const BugType &BT, StringRef ErrorMessage,
-                       const ValueDecl *CapSrcDecl = nullptr) const;
+  ExplodedNode *emitAlignmentWarning(CheckerContext &C,
+                                     const SVal &UnderalignedPtrVal,
+                                     const BugType &BT, StringRef ErrorMessage,
+                                     const ValueDecl *CapStorageDecl = nullptr,
+                                     StringRef CapSrcMsg = StringRef()) const;
 
   class AlignmentBugVisitor : public BugReporterVisitor {
   public:
@@ -414,6 +415,7 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   if (DstTy->isPointerType() && hasCapability(DstTy->getPointeeType(), ASTCtx))
     DstIsPtr2CapStorage = true;
 
+  const ValueDecl *CapDstDecl = nullptr;
   if (const MemRegion *MR = L.getAsRegion()) {
     if (const TypedValueRegion *TR = MR->getAs<TypedValueRegion>()) {
       const QualType &Ty = TR->getValueType();
@@ -423,6 +425,8 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
                              (isa<GlobalsSpaceRegion>(TR->getMemorySpace()) ||
                               isa<FieldRegion>(TR->StripCasts()));
     }
+    if (const DeclRegion *D = getOriginalAllocation(MR))
+      CapDstDecl = D->getDecl();
   }
 
   if (SymbolRef Sym = L.getAsSymbol()) {
@@ -477,13 +481,20 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   OS << " hold capabilities, for which " << CapAlign
      << "-byte capability alignment will be required";
 
-  const ValueDecl *CapDstDecl = nullptr;
-  if (const MemRegion *SR = L.getAsRegion()) {
-    if (const DeclRegion *D = getOriginalAllocation(SR))
-      CapDstDecl = D->getDecl();
-  }
-
-  emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage, CapDstDecl);
+  if (CapDstDecl) {
+    SmallString<350> Note;
+    llvm::raw_svector_ostream OS2(Note);
+    OS2 << "Memory pointed by";
+    if (DstIsPtr2CapStorage) {
+      const QualType &AllocType = CapDstDecl->getType().getCanonicalType();
+      OS2 << " '" << AllocType.getAsString() << "'"
+          << " value is supposed to hold capabilities";
+    } else
+      OS2 << " this value may be used to hold capabilities";
+    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage, CapDstDecl,
+                         Note);
+  } else
+    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage);
 }
 
 void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
@@ -539,7 +550,15 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
         CapSrcDecl = D->getDecl();
     }
 
-    emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage, CapSrcDecl);
+    if (CapSrcDecl) {
+      SmallString<350> Note;
+      llvm::raw_svector_ostream OS2(Note);
+      const QualType &AllocType = CapSrcDecl->getType().getCanonicalType();
+      OS2 << "Capabilities stored in " << "'" << AllocType.getAsString() << "'";
+      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage, CapSrcDecl,
+                           Note);
+    } else
+      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage);
     return;
   }
 
@@ -560,13 +579,21 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
           " that copied object may have its capabilities tags"
           " stripped earlier due to underaligned storage.";
 
-    const ValueDecl *CapSrcDecl = nullptr;
+    const ValueDecl *CapDstDecl = nullptr;
     if (const MemRegion *SR = DstVal.getAsRegion()) {
       if (const DeclRegion *D = getOriginalAllocation(SR))
-        CapSrcDecl = D->getDecl();
+        CapDstDecl = D->getDecl();
     }
 
-    emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage, CapSrcDecl);
+    if (CapDstDecl) {
+      SmallString<350> Note;
+      llvm::raw_svector_ostream OS2(Note);
+      const QualType &AllocType = CapDstDecl->getType().getCanonicalType();
+      OS2 << "Capabilities stored in " << "'" << AllocType.getAsString() << "'";
+      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage, CapDstDecl,
+                           Note);
+    } else
+      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage);
     return;
   }
 
@@ -816,20 +843,17 @@ void describeOriginalAllocation(const ValueDecl *SrcDecl,
 
 void describeCapabilityStorage(const ValueDecl *CapDecl,
                                PathDiagnosticLocation SrcLoc,
-                               PathSensitiveBugReport &W, ASTContext &ASTCtx) {
-  SmallString<350> Note;
-  llvm::raw_svector_ostream OS2(Note);
-  const QualType &AllocType = CapDecl->getType().getCanonicalType();
-  OS2 << "Capabilities stored in ";
-  OS2 << "'" << AllocType.getAsString() << "'";
-  W.addNote(Note, SrcLoc);
+                               PathSensitiveBugReport &W,
+                               StringRef CapStorageMsg) {
+  W.addNote(CapStorageMsg, SrcLoc);
 }
 
 } // namespace
 
 ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
     CheckerContext &C, const SVal &UnderalignedPtrVal, const BugType &BT,
-    StringRef ErrorMessage, const ValueDecl *CapSrcDecl) const {
+    StringRef ErrorMessage, const ValueDecl *CapStorageDecl,
+    StringRef CapStorageMsg) const {
   ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
   if (!ErrNode)
     return nullptr;
@@ -854,10 +878,10 @@ ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
     describeOriginalAllocation(MRDecl, MRDeclLoc, *W, C.getASTContext());
   }
 
-  if (CapSrcDecl) {
+  if (CapStorageDecl) {
     auto CapSrcDeclLoc =
-        PathDiagnosticLocation::create(CapSrcDecl, C.getSourceManager());
-    describeCapabilityStorage(CapSrcDecl, CapSrcDeclLoc, *W, C.getASTContext());
+        PathDiagnosticLocation::create(CapStorageDecl, C.getSourceManager());
+    describeCapabilityStorage(CapStorageDecl, CapSrcDeclLoc, *W, CapStorageMsg);
   }
 
   C.emitReport(std::move(W));

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -1,4 +1,4 @@
-//=== CapabilityAlignmentChecker.cpp - Capability Alignment Checker -*- C++ ==//
+//=== PointerAlignmentChecker.cpp - Capability Alignment Checker -*- C++ ==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -28,7 +28,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CHERIUtils.h"
+#include "CHERI/CHERIUtils.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
@@ -41,14 +41,14 @@ using namespace ento;
 using namespace cheri;
 
 namespace {
-class CapabilityAlignmentChecker
+class PointerAlignmentChecker
     : public Checker<check::PreStmt<CastExpr>, check::PostStmt<CastExpr>,
                      check::PostStmt<BinaryOperator>, check::DeadSymbols> {
   std::unique_ptr<BugType> CastAlignBug;
   std::unique_ptr<BugType> CapCastAlignBug;
 
 public:
-  CapabilityAlignmentChecker();
+  PointerAlignmentChecker();
 
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkPostStmt(const CastExpr *BO, CheckerContext &C) const;
@@ -83,7 +83,7 @@ private:
 
 REGISTER_MAP_WITH_PROGRAMSTATE(TrailingZerosMap, SymbolRef, int)
 
-CapabilityAlignmentChecker::CapabilityAlignmentChecker() {
+PointerAlignmentChecker::PointerAlignmentChecker() {
   CastAlignBug.reset(
       new BugType(this, "Cast increases required alignment", "Type Error"));
   CapCastAlignBug.reset(new BugType(
@@ -207,8 +207,8 @@ bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
 
 } // namespace
 
-void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
-                                              CheckerContext &C) const {
+void PointerAlignmentChecker::checkPreStmt(const CastExpr *CE,
+                                           CheckerContext &C) const {
   CastKind CK = CE->getCastKind();
   if (CK != CastKind::CK_BitCast && CK != CK_IntegralToPointer)
     return;
@@ -239,8 +239,8 @@ void CapabilityAlignmentChecker::checkPreStmt(const CastExpr *CE,
   }
 }
 
-void CapabilityAlignmentChecker::checkPostStmt(const CastExpr *CE,
-                                               CheckerContext &C) const {
+void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
+                                            CheckerContext &C) const {
   CastKind CK = CE->getCastKind();
   if (CK != CastKind::CK_BitCast && CK != CK_PointerToIntegral &&
       CK != CK_IntegralToPointer)
@@ -277,8 +277,8 @@ bool valueIsLTPow2(const Expr *E, unsigned P, CheckerContext &C) {
   return !State->assume(LT.castAs<DefinedOrUnknownSVal>(), false);
 }
 
-void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
-                                               CheckerContext &C) const {
+void PointerAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
+                                            CheckerContext &C) const {
   int LeftTZ = getTrailingZerosCount(BO->getLHS(), C);
   if (LeftTZ < 0)
     return;
@@ -369,8 +369,8 @@ void CapabilityAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   C.addTransition(State);
 }
 
-void CapabilityAlignmentChecker::checkDeadSymbols(SymbolReaper &SymReaper,
-                                                  CheckerContext &C) const {
+void PointerAlignmentChecker::checkDeadSymbols(SymbolReaper &SymReaper,
+                                               CheckerContext &C) const {
   ProgramStateRef State = C.getState();
   TrailingZerosMapTy TZMap = State->get<TrailingZerosMap>();
   bool Updated = false;
@@ -432,9 +432,10 @@ void describeOriginalAllocation(const MemRegion *MR, PathSensitiveBugReport &W,
 
 } // namespace
 
-ExplodedNode *CapabilityAlignmentChecker::emitCastAlignWarn(
-    CheckerContext &C, unsigned SrcAlign, unsigned DstReqAlign,
-    const CastExpr *CE) const {
+ExplodedNode *
+PointerAlignmentChecker::emitCastAlignWarn(CheckerContext &C, unsigned SrcAlign,
+                                           unsigned DstReqAlign,
+                                           const CastExpr *CE) const {
   ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
   if (!ErrNode)
     return nullptr;
@@ -469,8 +470,7 @@ ExplodedNode *CapabilityAlignmentChecker::emitCastAlignWarn(
   return ErrNode;
 }
 
-PathDiagnosticPieceRef
-CapabilityAlignmentChecker::AlignmentBugVisitor::VisitNode(
+PathDiagnosticPieceRef PointerAlignmentChecker::AlignmentBugVisitor::VisitNode(
     const ExplodedNode *N, BugReporterContext &BRC,
     PathSensitiveBugReport &BR) {
 
@@ -524,10 +524,10 @@ CapabilityAlignmentChecker::AlignmentBugVisitor::VisitNode(
   return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
 }
 
-void ento::registerCapabilityAlignmentChecker(CheckerManager &mgr) {
-  mgr.registerChecker<CapabilityAlignmentChecker>();
+void ento::registerPointerAlignmentChecker(CheckerManager &mgr) {
+  mgr.registerChecker<PointerAlignmentChecker>();
 }
 
-bool ento::shouldRegisterCapabilityAlignmentChecker(const CheckerManager &Mgr) {
+bool ento::shouldRegisterPointerAlignmentChecker(const CheckerManager &Mgr) {
   return true;
 }

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -47,10 +47,19 @@ class PointerAlignmentChecker
     : public Checker<check::PreStmt<CastExpr>, check::PostStmt<CastExpr>,
                      check::PostStmt<BinaryOperator>, check::Bind,
                      check::PreCall, check::DeadSymbols> {
-  std::unique_ptr<BugType> CastAlignBug;
-  std::unique_ptr<BugType> CapCastAlignBug;
-  std::unique_ptr<BugType> GenPtrEscapeAlignBug;
-  std::unique_ptr<BugType> MemcpyAlignBug;
+  BugType CastAlignBug{this, "Cast increases required alignment", "Type Error"};
+  BugType CapCastAlignBug{
+      this, "Cast increases required alignment to capability alignment",
+      "CHERI portability"};
+  BugType CapStorageAlignBug{
+      this, "Not capability-aligned pointer used as capability storage",
+      "CHERI portability"};
+  BugType GenPtrEscapeAlignBug{
+      this, "Not capability-aligned pointer stored as 'void*'",
+      "CHERI portability"};
+  BugType MemcpyAlignBug{this,
+                         "Copying capabilities through underaligned memory",
+                         "CHERI portability"};
 
   const CallDescriptionMap<std::pair<int, int>> MemCpyFn{
       {{CDM::SimpleFunc, {"memcpy"}, 3}, {0, 1}},
@@ -59,8 +68,6 @@ class PointerAlignmentChecker
   };
 
 public:
-  PointerAlignmentChecker();
-
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkPostStmt(const CastExpr *BO, CheckerContext &C) const;
   void checkPreStmt(const CastExpr *BO, CheckerContext &C) const;
@@ -117,20 +124,6 @@ private:
 
 REGISTER_MAP_WITH_PROGRAMSTATE(TrailingZerosMap, SymbolRef, int)
 REGISTER_SET_WITH_PROGRAMSTATE(CapStorageSet, const MemRegion *)
-
-PointerAlignmentChecker::PointerAlignmentChecker() {
-  CastAlignBug.reset(
-      new BugType(this, "Cast increases required alignment", "Type Error"));
-  CapCastAlignBug.reset(new BugType(
-      this, "Cast increases required alignment to capability alignment",
-      "CHERI portability"));
-  GenPtrEscapeAlignBug.reset(
-      new BugType(this, "Not capability-aligned pointer stored as 'void*'",
-                  "CHERI portability"));
-  MemcpyAlignBug.reset(
-      new BugType(this, "Copying capabilities through underaligned memory",
-                  "CHERI portability"));
-}
 
 namespace {
 
@@ -414,8 +407,15 @@ unsigned int getFragileAlignment(const MemRegion *MR,
 }
 
 bool hasCapStorageType(const Expr *E, ASTContext &ASTCtx) {
-  const QualType &Ty = E->IgnoreCasts()->getType();
-  return Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx);
+  const QualType &Ty = E->getType();
+  if (!Ty->isPointerType())
+    return false;
+  if (hasCapability(Ty->getPointeeType(), ASTCtx))
+    return true;
+  if (const CastExpr *CE = dyn_cast<CastExpr>(E)) {
+    return hasCapStorageType(CE->getSubExpr(), ASTCtx);
+  }
+  return false;
 }
 
 } // namespace
@@ -454,7 +454,7 @@ void PointerAlignmentChecker::checkPreStmt(const CastExpr *CE,
   /* Emit warning */
   const QualType &DstTy = CE->getType();
   bool DstAlignIsCap = hasCapability(DstTy->getPointeeType(), ASTCtx);
-  const BugType &BT = DstAlignIsCap ? *CapCastAlignBug : *CastAlignBug;
+  const BugType &BT = DstAlignIsCap ? CapCastAlignBug : CastAlignBug;
 
   SmallString<350> ErrorMessage;
   llvm::raw_svector_ostream OS(ErrorMessage);
@@ -576,11 +576,13 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
           << " value is supposed to hold capabilities";
     } else
       OS2 << " this value may be used to hold capabilities";
-    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage,
-                         CapStorageReg, CapDstDecl, Note);
+    emitAlignmentWarning(
+        C, V, DstIsPtr2CapStorage ? CapStorageAlignBug : GenPtrEscapeAlignBug,
+        ErrorMessage, CapStorageReg, CapDstDecl, Note);
   } else
-    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage,
-                         CapStorageReg);
+    emitAlignmentWarning(
+        C, V, DstIsPtr2CapStorage ? CapStorageAlignBug : GenPtrEscapeAlignBug,
+        ErrorMessage, CapStorageReg);
 }
 
 void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
@@ -656,10 +658,10 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
       llvm::raw_svector_ostream OS2(Note);
       const QualType &AllocType = CapSrcDecl->getType().getCanonicalType();
       OS2 << "Capabilities stored in " << "'" << AllocType.getAsString() << "'";
-      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage,
+      emitAlignmentWarning(C, DstVal, MemcpyAlignBug, ErrorMessage,
                            CapStorageReg, CapSrcDecl, Note);
     } else
-      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage,
+      emitAlignmentWarning(C, DstVal, MemcpyAlignBug, ErrorMessage,
                            CapStorageReg);
     return;
   }
@@ -693,10 +695,10 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
       llvm::raw_svector_ostream OS2(Note);
       const QualType &AllocType = CapDstDecl->getType().getCanonicalType();
       OS2 << "Capabilities stored in " << "'" << AllocType.getAsString() << "'";
-      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage,
+      emitAlignmentWarning(C, SrcVal, MemcpyAlignBug, ErrorMessage,
                            CapStorageReg, CapDstDecl, Note);
     } else
-      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage,
+      emitAlignmentWarning(C, SrcVal, MemcpyAlignBug, ErrorMessage,
                            CapStorageReg);
     return;
   }

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -916,17 +916,11 @@ void PointerAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
 
 void PointerAlignmentChecker::checkDeadSymbols(SymbolReaper &SymReaper,
                                                CheckerContext &C) const {
-  bool Updated = false;
   ProgramStateRef State = C.getState();
+  bool Updated = false;
 
-  TrailingZerosMapTy TZMap = State->get<TrailingZerosMap>();
-  for (TrailingZerosMapTy::iterator I = TZMap.begin(), E = TZMap.end(); I != E;
-       ++I) {
-    if (SymReaper.isDead(I->first)) {
-      State = State->remove<TrailingZerosMap>(I->first);
-      Updated = true;
-    }
-  }
+  State = cleanDead<TrailingZerosMap>(State, SymReaper, Updated);
+  State = cleanDead<CapStorageSet>(State, SymReaper, Updated);
 
   if (Updated)
     C.addTransition(State);

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -71,6 +71,7 @@ private:
   ExplodedNode *emitAlignmentWarning(CheckerContext &C,
                                      const SVal &UnderalignedPtrVal,
                                      const BugType &BT, StringRef ErrorMessage,
+                                     const MemRegion *CapStorageReg = nullptr,
                                      const ValueDecl *CapStorageDecl = nullptr,
                                      StringRef CapSrcMsg = StringRef()) const;
 
@@ -90,6 +91,24 @@ private:
 
   private:
     SymbolRef Sym;
+  };
+
+  class CapStorageBugVisitor : public BugReporterVisitor {
+  public:
+    CapStorageBugVisitor(const MemRegion *MR) : MemReg(MR) {}
+
+    void Profile(llvm::FoldingSetNodeID &ID) const override {
+      static int X = 0;
+      ID.AddPointer(&X);
+      ID.AddPointer(MemReg);
+    }
+
+    PathDiagnosticPieceRef VisitNode(const ExplodedNode *N,
+                                     BugReporterContext &BRC,
+                                     PathSensitiveBugReport &BR) override;
+
+  private:
+    const MemRegion *MemReg;
   };
 };
 
@@ -428,21 +447,25 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   /* Check if dst pointee type contains capabilities or is a generic storage
    * type (can contain arbitrary data) */
   bool DstIsPtr2CapStorage = false, DstIsPtr2GenStorage = false;
+  QualType DstCapStorageTy = DstTy;
 
   if (DstTy->isPointerType() && hasCapability(DstTy->getPointeeType(), ASTCtx))
     DstIsPtr2CapStorage = true;
 
   const ValueDecl *CapDstDecl = nullptr;
-  if (const MemRegion *MR = L.getAsRegion()) {
-    if (const TypedValueRegion *TR = MR->getAs<TypedValueRegion>()) {
+  const MemRegion *CapStorageReg = L.getAsRegion();
+  if (CapStorageReg) {
+    if (const TypedValueRegion *TR = CapStorageReg->getAs<TypedValueRegion>()) {
       const QualType &Ty = TR->getValueType();
-      DstIsPtr2CapStorage |=
-          Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx);
+      if (Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx)) {
+        DstIsPtr2CapStorage = true;
+        DstCapStorageTy = Ty;
+      }
       DstIsPtr2GenStorage |= isGenericPointerType(Ty, false) &&
                              (isa<GlobalsSpaceRegion>(TR->getMemorySpace()) ||
                               isa<FieldRegion>(TR->StripCasts()));
     }
-    if (const DeclRegion *D = getOriginalAllocation(MR))
+    if (const DeclRegion *D = getOriginalAllocation(CapStorageReg))
       CapDstDecl = D->getDecl();
   }
 
@@ -450,8 +473,11 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
     const QualType &SymTy = Sym->getType();
     if (SymTy->isPointerType()) {
       const QualType &CopyTy = SymTy->getPointeeType();
-      DstIsPtr2CapStorage |= CopyTy->isPointerType() &&
-                             hasCapability(CopyTy->getPointeeType(), ASTCtx);
+      if (!DstIsPtr2CapStorage && CopyTy->isPointerType() &&
+          hasCapability(CopyTy->getPointeeType(), ASTCtx)) {
+        DstIsPtr2CapStorage = true;
+        DstCapStorageTy = CopyTy;
+      }
       DstIsPtr2GenStorage |= isGenericStorage(Sym, CopyTy);
     }
   }
@@ -488,8 +514,8 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   SmallString<350> ErrorMessage;
   llvm::raw_svector_ostream OS(ErrorMessage);
   OS << "Pointer value aligned to a " << SrcAlign << " byte boundary";
-  OS << " stored as type '" << BO->getLHS()->getType().getAsString() << "'";
-  OS << ". Memory pointed by it";
+  OS << " stored as value of type '" << DstCapStorageTy.getAsString() << "'.";
+  OS << " Memory pointed by it";
   if (DstIsPtr2CapStorage)
     OS << " is supposed to";
   else
@@ -507,10 +533,11 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
           << " value is supposed to hold capabilities";
     } else
       OS2 << " this value may be used to hold capabilities";
-    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage, CapDstDecl,
-                         Note);
+    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage,
+                         CapStorageReg, CapDstDecl, Note);
   } else
-    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage);
+    emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage,
+                         CapStorageReg);
 }
 
 void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
@@ -560,9 +587,10 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
        << " Storing a capability at an underaligned address"
           " leads to tag stripping.";
 
+    const MemRegion *CapStorageReg = SrcVal.getAsRegion();
     const ValueDecl *CapSrcDecl = nullptr;
-    if (const MemRegion *SR = SrcVal.getAsRegion()) {
-      if (const DeclRegion *D = getOriginalAllocation(SR))
+    if (CapStorageReg) {
+      if (const DeclRegion *D = getOriginalAllocation(CapStorageReg))
         CapSrcDecl = D->getDecl();
     }
 
@@ -571,10 +599,11 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
       llvm::raw_svector_ostream OS2(Note);
       const QualType &AllocType = CapSrcDecl->getType().getCanonicalType();
       OS2 << "Capabilities stored in " << "'" << AllocType.getAsString() << "'";
-      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage, CapSrcDecl,
-                           Note);
+      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage,
+                           CapStorageReg, CapSrcDecl, Note);
     } else
-      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage);
+      emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage,
+                           CapStorageReg);
     return;
   }
 
@@ -585,19 +614,20 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
     OS << "Destination memory object";
     describeObjectType(OS, DstTy, ASTCtx.getLangOpts());
     if (!DstIsCapStorage)
-      OS << " may";
+      OS << " may be";
     else
-      OS << " is supposed to";
-    OS << " contain capabilities that require " << CapAlign
+      OS << " is";
+    OS << " supposed to contain capabilities that require " << CapAlign
        << "-byte capability alignment.";
     OS << " Source address alignment is " << SrcCurAlign
        << ", which means"
           " that copied object may have its capabilities tags"
           " stripped earlier due to underaligned storage.";
 
+    const MemRegion *CapStorageReg = DstVal.getAsRegion();
     const ValueDecl *CapDstDecl = nullptr;
-    if (const MemRegion *SR = DstVal.getAsRegion()) {
-      if (const DeclRegion *D = getOriginalAllocation(SR))
+    if (CapStorageReg) {
+      if (const DeclRegion *D = getOriginalAllocation(CapStorageReg))
         CapDstDecl = D->getDecl();
     }
 
@@ -606,31 +636,24 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
       llvm::raw_svector_ostream OS2(Note);
       const QualType &AllocType = CapDstDecl->getType().getCanonicalType();
       OS2 << "Capabilities stored in " << "'" << AllocType.getAsString() << "'";
-      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage, CapDstDecl,
-                           Note);
+      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage,
+                           CapStorageReg, CapDstDecl, Note);
     } else
-      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage);
+      emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage,
+                           CapStorageReg);
     return;
   }
 
   /* Propagate CapStorage flag */
   if (SrcIsCapStorage && !DstIsCapStorage) {
     if (const MemRegion *R = DstVal.getAsRegion()) {
-      const ProgramStateRef State =
-          C.getState()->add<CapStorageSet>(R->StripCasts());
-      const NoteTag *Tag =
-          C.getNoteTag("Copied memory object contains capabilities");
-      C.addTransition(State, C.getPredecessor(), Tag);
+      C.addTransition(C.getState()->add<CapStorageSet>(R->StripCasts()));
     }
   }
 
   if (!SrcIsCapStorage && DstIsCapStorage) {
     if (const MemRegion *R = SrcVal.getAsRegion()) {
-      const ProgramStateRef State =
-          C.getState()->add<CapStorageSet>(R->StripCasts());
-      const NoteTag *Tag =
-          C.getNoteTag("Copied memory object should contain capabilities");
-      C.addTransition(State, C.getPredecessor(), Tag);
+      C.addTransition(C.getState()->add<CapStorageSet>(R->StripCasts()));
     }
   }
 }
@@ -700,8 +723,6 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
       if (const MemRegion *R = DstVal.getAsRegion()) {
         State = State->add<CapStorageSet>(R->StripCasts());
         Updated = true;
-        if (DstIsCapStorage)
-          Tag = C.getNoteTag("Cast to capability-containing type");
       }
     }
   }
@@ -851,25 +872,21 @@ void describeOriginalAllocation(const ValueDecl *SrcDecl,
   const QualType &AllocType = SrcDecl->getType().getCanonicalType();
   OS2 << "Original allocation of type ";
   OS2 << "'" << AllocType.getAsString() << "'";
-  OS2 << " which has an alignment requirement ";
-  OS2 << ASTCtx.getTypeAlignInChars(AllocType).getQuantity();
-  OS2 << " bytes";
+  OS2 << " has an alignment requirement ";
+  unsigned Align = ASTCtx.getTypeAlignInChars(AllocType).getQuantity();
+  if (Align == 1)
+    OS2 << "1 byte";
+  else
+    OS2 << Align << " bytes";
   W.addNote(Note, SrcLoc);
-}
-
-void describeCapabilityStorage(const ValueDecl *CapDecl,
-                               PathDiagnosticLocation SrcLoc,
-                               PathSensitiveBugReport &W,
-                               StringRef CapStorageMsg) {
-  W.addNote(CapStorageMsg, SrcLoc);
 }
 
 } // namespace
 
 ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
     CheckerContext &C, const SVal &UnderalignedPtrVal, const BugType &BT,
-    StringRef ErrorMessage, const ValueDecl *CapStorageDecl,
-    StringRef CapStorageMsg) const {
+    StringRef ErrorMessage, const MemRegion *CapStorageReg,
+    const ValueDecl *CapStorageDecl, StringRef CapStorageMsg) const {
   ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
   if (!ErrNode)
     return nullptr;
@@ -897,7 +914,11 @@ ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
   if (CapStorageDecl) {
     auto CapSrcDeclLoc =
         PathDiagnosticLocation::create(CapStorageDecl, C.getSourceManager());
-    describeCapabilityStorage(CapStorageDecl, CapSrcDeclLoc, *W, CapStorageMsg);
+    W->addNote(CapStorageMsg, CapSrcDeclLoc);
+  }
+
+  if (CapStorageReg) {
+    W->addVisitor(std::make_unique<CapStorageBugVisitor>(CapStorageReg));
   }
 
   C.emitReport(std::move(W));
@@ -951,6 +972,42 @@ PathDiagnosticPieceRef PointerAlignmentChecker::AlignmentBugVisitor::VisitNode(
     }
   }
   printAlign(OS, *NewAlign);
+
+  // Generate the extra diagnostic.
+  PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),
+                                   N->getLocationContext());
+  return std::make_shared<PathDiagnosticEventPiece>(Pos, OS.str(), true);
+}
+
+PathDiagnosticPieceRef PointerAlignmentChecker::CapStorageBugVisitor::VisitNode(
+    const ExplodedNode *N, BugReporterContext &BRC,
+    PathSensitiveBugReport &BR) {
+
+  const Stmt *S = N->getStmtForDiagnostics();
+  if (!S)
+    return nullptr;
+
+  ProgramStateRef State = N->getState();
+  ProgramStateRef Pred = N->getFirstPred()->getState();
+  if (!State->contains<CapStorageSet>(MemReg) ||
+      Pred->contains<CapStorageSet>(MemReg))
+    return nullptr;
+
+  SmallString<256> Buf;
+  llvm::raw_svector_ostream OS(Buf);
+  if (const CastExpr *CE = dyn_cast<CastExpr>(S)) {
+    if (!CE->getType()->isPointerType() ||
+        isGenericPointerType(CE->getType(), true))
+      return nullptr;
+    const QualType &DstPTy = CE->getType()->getPointeeType();
+    if (!DstPTy->isIncompleteType() ||
+        !hasCapability(DstPTy, N->getCodeDecl().getASTContext()))
+      return nullptr;
+    OS << "Cast to capability-containing type";
+  } else if (isa<CallExpr>(S)) {
+    OS << "Copying memory object containing capabilities";
+  } else
+    return nullptr;
 
   // Generate the extra diagnostic.
   PathDiagnosticLocation const Pos(S, BRC.getSourceManager(),

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -34,6 +34,7 @@
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
+#include <clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h>
 
 using namespace clang;
@@ -43,9 +44,18 @@ using namespace cheri;
 namespace {
 class PointerAlignmentChecker
     : public Checker<check::PreStmt<CastExpr>, check::PostStmt<CastExpr>,
-                     check::PostStmt<BinaryOperator>, check::DeadSymbols> {
+                     check::PostStmt<BinaryOperator>, check::Bind,
+                     check::PreCall, check::DeadSymbols> {
   std::unique_ptr<BugType> CastAlignBug;
   std::unique_ptr<BugType> CapCastAlignBug;
+  std::unique_ptr<BugType> GenPtrEscapeAlignBug;
+  std::unique_ptr<BugType> MemcpyAlignBug;
+
+  const CallDescriptionMap<std::pair<int, int>> MemCpyFn{
+      {{CDM::SimpleFunc, {"memcpy"}, 3}, {0, 1}},
+      {{CDM::SimpleFunc, {"mempcpy"}, 3}, {0, 1}},
+      {{CDM::SimpleFunc, {"memmove"}, 3}, {0, 1}},
+  };
 
 public:
   PointerAlignmentChecker();
@@ -53,12 +63,15 @@ public:
   void checkPostStmt(const BinaryOperator *BO, CheckerContext &C) const;
   void checkPostStmt(const CastExpr *BO, CheckerContext &C) const;
   void checkPreStmt(const CastExpr *BO, CheckerContext &C) const;
+  void checkBind(SVal L, SVal V, const Stmt *S, CheckerContext &C) const;
+  void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
   void checkDeadSymbols(SymbolReaper &SymReaper, CheckerContext &C) const;
 
 private:
-  ExplodedNode *emitCastAlignWarn(CheckerContext &C, unsigned SrcAlign,
-                                  unsigned DstReqAlign,
-                                  const CastExpr *CE) const;
+  ExplodedNode *
+  emitAlignmentWarning(CheckerContext &C, const SVal &UnderalignedPtrVal,
+                       const BugType &BT, StringRef ErrorMessage,
+                       const ValueDecl *CapSrcDecl = nullptr) const;
 
   class AlignmentBugVisitor : public BugReporterVisitor {
   public:
@@ -82,6 +95,7 @@ private:
 } // namespace
 
 REGISTER_MAP_WITH_PROGRAMSTATE(TrailingZerosMap, SymbolRef, int)
+REGISTER_SET_WITH_PROGRAMSTATE(CapStorageSet, const MemRegion *)
 
 PointerAlignmentChecker::PointerAlignmentChecker() {
   CastAlignBug.reset(
@@ -89,9 +103,37 @@ PointerAlignmentChecker::PointerAlignmentChecker() {
   CapCastAlignBug.reset(new BugType(
       this, "Cast increases required alignment to capability alignment",
       "CHERI portability"));
+  GenPtrEscapeAlignBug.reset(
+      new BugType(this, "Not capability-aligned pointer stored as 'void*'",
+                  "CHERI portability"));
+  MemcpyAlignBug.reset(
+      new BugType(this, "Copying capabilities through underaligned memory",
+                  "CHERI portability"));
 }
 
 namespace {
+
+std::optional<QualType> globalOrParamPointeeType(SymbolRef Sym) {
+  const MemRegion *BaseRegOrigin = Sym->getOriginRegion();
+  if (!BaseRegOrigin)
+    return std::nullopt;
+
+  bool HasGlobalsOrParametersStorage =
+      isa<StackArgumentsSpaceRegion, GlobalsSpaceRegion>(
+          BaseRegOrigin->getMemorySpace());
+  if (!HasGlobalsOrParametersStorage)
+    return std::nullopt;
+
+  const QualType &SymTy = Sym->getType();
+  if (SymTy->isPointerType()) {
+    const QualType &PT = SymTy->getPointeeType();
+    if (!PT->isIncompleteType()) {
+      return PT;
+    }
+  }
+
+  return std::nullopt;
+}
 
 int getTrailingZerosCount(const SVal &V, ProgramStateRef State,
                           ASTContext &ASTCtx);
@@ -103,20 +145,11 @@ int getTrailingZerosCount(SymbolRef Sym, ProgramStateRef State,
     return *Align;
 
   // Is function argument or global?
-  if (const MemRegion *BaseRegOrigin = Sym->getOriginRegion()) {
-    bool HasGlobalsOrParametersStorage =
-        isa<StackArgumentsSpaceRegion, GlobalsSpaceRegion>(
-            BaseRegOrigin->getMemorySpace());
-    if (HasGlobalsOrParametersStorage) {
-      const QualType &SymTy = Sym->getType();
-      if (SymTy->isPointerType() && !isGenericPointerType(SymTy)) {
-        const QualType &PT = SymTy->getPointeeType();
-        if (!PT->isIncompleteType()) {
-          unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
-          return llvm::APSInt::getUnsigned(A).countTrailingZeros();
-        }
-      }
-    }
+  auto GlobalPointeeTy = globalOrParamPointeeType(Sym);
+  if (GlobalPointeeTy) {
+    QualType &PT = GlobalPointeeTy.value();
+    unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
+    return llvm::APSInt::getUnsigned(A).countTrailingZeros();
   }
 
   return -1;
@@ -195,6 +228,70 @@ int getTrailingZerosCount(const Expr *E, CheckerContext &C) {
   return getTrailingZerosCount(V, C.getState(), C.getASTContext());
 }
 
+bool isCapabilityStorage(SymbolRef Sym, ASTContext &ASTCtx) {
+  const std::optional<QualType> GlobalPointeeTy = globalOrParamPointeeType(Sym);
+  if (GlobalPointeeTy)
+    return hasCapability(*GlobalPointeeTy, ASTCtx);
+  return false;
+}
+
+bool isCapabilityStorage(const MemRegion *R, ProgramStateRef State,
+                         ASTContext &ASTCtx) {
+  R = R->StripCasts();
+
+  if (State->contains<CapStorageSet>(R))
+    return true;
+
+  if (const SymbolicRegion *SR = R->getAs<SymbolicRegion>())
+    return isCapabilityStorage(SR->getSymbol(), ASTCtx);
+
+  if (const TypedValueRegion *TR = R->getAs<TypedValueRegion>()) {
+    const QualType PT = TR->getDesugaredValueType(ASTCtx);
+    return hasCapability(PT, ASTCtx);
+  }
+
+  return false;
+}
+
+bool isCapabilityStorage(const SVal &V, ProgramStateRef State,
+                         ASTContext &ASTCtx) {
+  if (const MemRegion *MR = V.getAsRegion()) {
+    return isCapabilityStorage(MR, State, ASTCtx);
+  }
+  if (SymbolRef Sym = V.getAsSymbol()) {
+    return isCapabilityStorage(Sym, ASTCtx);
+  }
+  return false;
+}
+
+std::optional<unsigned> getActualAlignment(CheckerContext &C,
+                                           const SVal &SrcVal) {
+  if (SrcVal.isConstant()) // special value
+    return std::nullopt;
+
+  ASTContext &ASTCtx = C.getASTContext();
+  int SrcTZC = getTrailingZerosCount(SrcVal, C.getState(), ASTCtx);
+  if (SrcTZC < 0)
+    return std::nullopt;
+
+  if ((unsigned)SrcTZC >= sizeof(unsigned int) * 8)
+    return std::nullopt; // Too aligned, probably zero
+  return (1U << SrcTZC);
+}
+
+std::optional<unsigned> getRequiredAlignment(ASTContext &ASTCtx,
+                                             const QualType &PtrTy,
+                                             bool AssumeCapAlignForVoidPtr) {
+  if (!PtrTy->isPointerType())
+    return std::nullopt;
+  const QualType &PointeeTy = PtrTy->getPointeeType();
+  if (!PointeeTy->isIncompleteType())
+    return ASTCtx.getTypeAlignInChars(PointeeTy).getQuantity();
+  else if (AssumeCapAlignForVoidPtr && isGenericPointerType(PtrTy, false))
+    return getCapabilityTypeAlign(ASTCtx).getQuantity();
+  return std::nullopt;
+}
+
 /* Introduced by clang, not in C standard */
 bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
   using namespace clang::ast_matchers;
@@ -204,6 +301,51 @@ bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
                                 hasCastKind(CK_BitCast), hasParent(CmpM));
   auto M = match(expr(CastM), *S, C.getASTContext());
   return !M.empty();
+}
+
+bool isGenericStorage(CheckerContext &C, const SVal &V) {
+  if (SymbolRef Sym = V.getAsSymbol()) {
+    if (!isGenericPointerType(Sym->getType(), false))
+      return false;
+    if (const MemRegion *R = Sym->getOriginRegion()) {
+      const MemSpaceRegion *MS = R->getMemorySpace();
+      if (isa<GlobalsSpaceRegion>(MS))
+        return true; // global variable
+      if (auto SR = dyn_cast<StackArgumentsSpaceRegion>(MS))
+        return SR->getStackFrame()->inTopFrame(); // top-level argument
+
+      if (isa<FieldRegion>(R))
+        return true; // struct field
+    }
+  }
+  return false;
+}
+
+bool isGenericStorage(CheckerContext &C, const Expr *E) {
+  if (!isGenericPointerType(E->IgnoreImpCasts()->getType(), false))
+    return false;
+  return isGenericStorage(C, C.getSVal(E));
+}
+
+static void describeObjectType(raw_ostream &OS, const QualType &Ty,
+                               const LangOptions &LangOpts) {
+  if (Ty->isPointerType()) {
+    OS << " pointed by '";
+    Ty.print(OS, PrintingPolicy(LangOpts));
+    OS << "' pointer";
+  } else {
+    OS << " of type '";
+    Ty.print(OS, PrintingPolicy(LangOpts));
+    OS << "'";
+  }
+}
+
+const DeclRegion *getOriginalAllocation(const MemRegion *MR) {
+  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
+    return DR;
+  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
+    return getOriginalAllocation(ER->getSuperRegion());
+  return nullptr;
 }
 
 } // namespace
@@ -216,27 +358,222 @@ void PointerAlignmentChecker::checkPreStmt(const CastExpr *CE,
   if (isImplicitConversionFromVoidPtr(CE, C))
     return;
 
-  const QualType &DstType = CE->getType();
-  if (!DstType->isPointerType())
-    return;
-  const QualType &DstPointeeTy = DstType->getPointeeType();
-  if (DstPointeeTy->isIncompleteType())
-    return;
-
-  const SVal &SrcVal = C.getSVal(CE->getSubExpr());
-  if (SrcVal.isConstant())
-    return; // special value
-  int SrcTZC = getTrailingZerosCount(SrcVal, C.getState(), C.getASTContext());
-  if (SrcTZC < 0)
-    return;
-  if ((unsigned)SrcTZC >= sizeof(unsigned int) * 8)
-    return; // Too aligned, probably a Zero
-  unsigned SrcAlign = (1U << SrcTZC);
-
   ASTContext &ASTCtx = C.getASTContext();
-  unsigned DstReqAlign = ASTCtx.getTypeAlignInChars(DstPointeeTy).getQuantity();
-  if (SrcAlign < DstReqAlign) {
-    emitCastAlignWarn(C, SrcAlign, DstReqAlign, CE);
+
+  /* Calculate required alignment */
+  const std::optional<unsigned int> &DstReqAlign =
+      getRequiredAlignment(ASTCtx, CE->getType(), false);
+  if (!DstReqAlign)
+    return;
+
+  /* Calculate actual alignment */
+  const SVal &SrcVal = C.getSVal(CE->getSubExpr());
+  const std::optional<unsigned int> &SrcAlign = getActualAlignment(C, SrcVal);
+  if (!SrcAlign)
+    return;
+
+  if (SrcAlign >= DstReqAlign) // OK
+    return;
+
+  /* Emit warning */
+  const QualType &DstTy = CE->getType();
+  bool DstAlignIsCap = hasCapability(DstTy->getPointeeType(), ASTCtx);
+  const BugType &BT = DstAlignIsCap ? *CapCastAlignBug : *CastAlignBug;
+
+  SmallString<350> ErrorMessage;
+  llvm::raw_svector_ostream OS(ErrorMessage);
+  OS << "Pointer value aligned to a " << SrcAlign << " byte boundary"
+     << " cast to type '" << DstTy.getAsString() << "'"
+     << " with " << DstReqAlign << "-byte";
+  if (DstAlignIsCap)
+    OS << " capability";
+  OS << " alignment";
+
+  emitAlignmentWarning(C, SrcVal, BT, ErrorMessage);
+}
+
+void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
+                                        CheckerContext &C) const {
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return;
+
+  const BinaryOperator *BO = dyn_cast<BinaryOperator>(S);
+  if (!BO || !BO->isAssignmentOp())
+    return;
+
+  const QualType &DstTy = BO->getLHS()->getType();
+  if (!DstTy->isCHERICapabilityType(ASTCtx, true))
+    return;
+
+  bool DstIsCapStorage = false, DstIsGenericStorage = false;
+
+  if (DstTy->isPointerType() && hasCapability(DstTy->getPointeeType(), ASTCtx))
+    DstIsCapStorage = true;
+
+  if (const MemRegion *MR = L.getAsRegion()) {
+    if (const TypedValueRegion *TR = MR->getAs<TypedValueRegion>()) {
+      const QualType &Ty = TR->getValueType();
+      DstIsCapStorage |=
+          Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx);
+      DstIsGenericStorage |= isGenericPointerType(Ty, false) &&
+                             (isa<GlobalsSpaceRegion>(TR->getMemorySpace()) ||
+                              isa<FieldRegion>(TR->StripCasts()));
+    }
+  }
+
+  if (SymbolRef Sym = L.getAsSymbol()) {
+    const QualType &SymTy = Sym->getType();
+    if (SymTy->isPointerType()) {
+      const QualType &CopyTy = SymTy->getPointeeType();
+      DstIsCapStorage |= CopyTy->isPointerType() &&
+                         hasCapability(CopyTy->getPointeeType(), ASTCtx);
+      if (const MemRegion *R = Sym->getOriginRegion()) {
+        const MemSpaceRegion *MS = R->getMemorySpace();
+        bool TopLevelArg = false;
+        if (auto SS = dyn_cast<StackArgumentsSpaceRegion>(MS))
+          TopLevelArg = SS->getStackFrame()->inTopFrame();
+        DstIsGenericStorage |= isGenericPointerType(CopyTy, false) &&
+                               (TopLevelArg || isa<GlobalsSpaceRegion>(MS) ||
+                                isa<FieldRegion>(R->StripCasts()));
+      }
+    }
+  }
+
+  if (!DstIsCapStorage && !DstIsGenericStorage)
+    return;
+
+  /* Calculate actual alignment */
+  unsigned CapAlign = getCapabilityTypeAlign(ASTCtx).getQuantity();
+  const std::optional<unsigned int> &SrcAlign = getActualAlignment(C, V);
+  if (!SrcAlign || *SrcAlign >= CapAlign)
+    return;
+
+  /* Emit warning */
+  SmallString<350> ErrorMessage;
+  llvm::raw_svector_ostream OS(ErrorMessage);
+  OS << "Pointer value aligned to a " << SrcAlign << " byte boundary";
+  OS << " stored as type '" << BO->getLHS()->getType().getAsString() << "'";
+  OS << ". Memory pointed by it";
+  if (DstIsCapStorage)
+    OS << " is supposed to";
+  else
+    OS << " may be used to";
+  OS << " hold capabilities, for which " << CapAlign
+     << "-byte capability alignment will be required";
+
+  const ValueDecl *CapDstDecl = nullptr;
+  if (const MemRegion *SR = L.getAsRegion()) {
+    if (const DeclRegion *D = getOriginalAllocation(SR))
+      CapDstDecl = D->getDecl();
+  }
+
+  emitAlignmentWarning(C, V, *GenPtrEscapeAlignBug, ErrorMessage, CapDstDecl);
+}
+
+void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
+                                           CheckerContext &C) const {
+  ASTContext &ASTCtx = C.getASTContext();
+  if (!isPureCapMode(ASTCtx))
+    return;
+
+  if (!Call.isGlobalCFunction())
+    return;
+
+  const std::pair<int, int> *MemCpyParamPair = MemCpyFn.lookup(Call);
+  if (!MemCpyParamPair)
+    return;
+
+  unsigned CapAlign = getCapabilityTypeAlign(ASTCtx).getQuantity();
+
+  /* Destination alignment */
+  const Expr *DstExpr = Call.getArgExpr(MemCpyParamPair->first);
+  const QualType &DstTy = DstExpr->IgnoreImplicit()->getType();
+  const SVal &DstVal = C.getSVal(DstExpr);
+  const std::optional<unsigned> &DstCurAlign = getActualAlignment(C, DstVal);
+  bool DstIsCapStorage = isCapabilityStorage(DstVal, C.getState(), ASTCtx);
+  bool DstIsGenStorage = isGenericStorage(C, DstExpr);
+
+  /* Source alignment */
+  const Expr *SrcExpr = Call.getArgExpr(MemCpyParamPair->second);
+  const QualType &SrcTy = SrcExpr->IgnoreImplicit()->getType();
+  const SVal &SrcVal = C.getSVal(SrcExpr);
+  const std::optional<unsigned> &SrcCurAlign = getActualAlignment(C, SrcVal);
+  bool SrcIsCapStorage = isCapabilityStorage(SrcVal, C.getState(), ASTCtx);
+  bool SrcIsGenStorage = isGenericStorage(C, SrcExpr);
+
+  if ((SrcIsCapStorage || SrcIsGenStorage) && DstCurAlign &&
+      *DstCurAlign < CapAlign) {
+    SmallString<350> ErrorMessage;
+    llvm::raw_svector_ostream OS(ErrorMessage);
+    OS << "Copied memory object";
+    describeObjectType(OS, SrcTy, ASTCtx.getLangOpts());
+    if (!SrcIsCapStorage)
+      OS << " may contain";
+    else
+      OS << " contains";
+    OS << " capabilities that require " << CapAlign
+       << "-byte capability alignment.";
+    OS << " Destination address alignment is " << DstCurAlign << "."
+       << " Storing a capability at an underaligned address"
+          " leads to tag stripping.";
+
+    const ValueDecl *CapSrcDecl = nullptr;
+    if (const MemRegion *SR = SrcVal.getAsRegion()) {
+      if (const DeclRegion *D = getOriginalAllocation(SR))
+        CapSrcDecl = D->getDecl();
+    }
+
+    emitAlignmentWarning(C, DstVal, *MemcpyAlignBug, ErrorMessage, CapSrcDecl);
+    return;
+  }
+
+  if ((DstIsCapStorage || DstIsGenStorage) && SrcCurAlign &&
+      *SrcCurAlign < CapAlign) {
+    SmallString<350> ErrorMessage;
+    llvm::raw_svector_ostream OS(ErrorMessage);
+    OS << "Destination memory object";
+    describeObjectType(OS, DstTy, ASTCtx.getLangOpts());
+    if (!DstIsCapStorage)
+      OS << " may";
+    else
+      OS << " is supposed to";
+    OS << " contain capabilities that require " << CapAlign
+       << "-byte capability alignment.";
+    OS << " Source address alignment is " << SrcCurAlign
+       << ", which means"
+          " that copied object may have its capabilities tags"
+          " stripped earlier due to underaligned storage.";
+
+    const ValueDecl *CapSrcDecl = nullptr;
+    if (const MemRegion *SR = DstVal.getAsRegion()) {
+      if (const DeclRegion *D = getOriginalAllocation(SR))
+        CapSrcDecl = D->getDecl();
+    }
+
+    emitAlignmentWarning(C, SrcVal, *MemcpyAlignBug, ErrorMessage, CapSrcDecl);
+    return;
+  }
+
+  /* Propagate CapStorage flag */
+  if (SrcIsCapStorage && !DstIsCapStorage) {
+    if (const MemRegion *R = DstVal.getAsRegion()) {
+      const ProgramStateRef State =
+          C.getState()->add<CapStorageSet>(R->StripCasts());
+      const NoteTag *Tag =
+          C.getNoteTag("Copied memory object contains capabilities");
+      C.addTransition(State, C.getPredecessor(), Tag);
+    }
+  }
+
+  if (!SrcIsCapStorage && DstIsCapStorage) {
+    if (const MemRegion *R = SrcVal.getAsRegion()) {
+      const ProgramStateRef State =
+          C.getState()->add<CapStorageSet>(R->StripCasts());
+      const NoteTag *Tag =
+          C.getNoteTag("Copied memory object should contain capabilities");
+      C.addTransition(State, C.getPredecessor(), Tag);
+    }
   }
 }
 
@@ -252,20 +589,26 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
 
   ASTContext &ASTCtx = C.getASTContext();
   int DstReqTZC = -1;
+  bool DstIsCapStorage = false;
   if (CE->getType()->isPointerType()) {
     if (!isGenericPointerType(CE->getType(), true)) {
       const QualType &DstPTy = CE->getType()->getPointeeType();
       if (!DstPTy->isIncompleteType()) {
         unsigned ReqAl = ASTCtx.getTypeAlignInChars(DstPTy).getQuantity();
         DstReqTZC = llvm::APSInt::getUnsigned(ReqAl).countTrailingZeros();
+        DstIsCapStorage = hasCapability(DstPTy, ASTCtx);
       }
     }
   }
 
+  SVal DstVal = C.getSVal(CE);
+  SVal SrcVal = C.getSVal(CE->getSubExpr());
+  ProgramStateRef State = C.getState();
+  bool Updated = false;
+
+  /* Update TrailingZerosMap */
   int NewAlign = std::max(SrcTZC, DstReqTZC);
   if (DstTZC < NewAlign) {
-    SVal DstVal = C.getSVal(CE);
-    ProgramStateRef State = C.getState();
     if (DstVal.isUnknown()) {
       const LocationContext *LCtx = C.getLocationContext();
       DstVal = C.getSValBuilder().conjureSymbolVal(
@@ -274,9 +617,24 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
     }
     if (SymbolRef Sym = DstVal.getAsSymbol()) {
       State = State->set<TrailingZerosMap>(Sym, NewAlign);
-      C.addTransition(State);
+      Updated = true;
     }
   }
+
+  /* Update CapStorageSet */
+  const ProgramPointTag *Tag = nullptr;
+  if ((isCapabilityStorage(SrcVal, State, ASTCtx) || DstIsCapStorage) &&
+      !isCapabilityStorage(DstVal, State, ASTCtx)) {
+    if (const MemRegion *R = DstVal.getAsRegion()) {
+      State = State->add<CapStorageSet>(R->StripCasts());
+      Updated = true;
+      if (DstIsCapStorage)
+        Tag = C.getNoteTag("Cast to capability-containing type");
+    }
+  }
+
+  if (Updated)
+    C.addTransition(State, Tag);
 }
 
 bool valueIsLTPow2(const Expr *E, unsigned P, CheckerContext &C) {
@@ -385,9 +743,10 @@ void PointerAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
 
 void PointerAlignmentChecker::checkDeadSymbols(SymbolReaper &SymReaper,
                                                CheckerContext &C) const {
-  ProgramStateRef State = C.getState();
-  TrailingZerosMapTy TZMap = State->get<TrailingZerosMap>();
   bool Updated = false;
+  ProgramStateRef State = C.getState();
+
+  TrailingZerosMapTy TZMap = State->get<TrailingZerosMap>();
   for (TrailingZerosMapTy::iterator I = TZMap.begin(), E = TZMap.end(); I != E;
        ++I) {
     if (SymReaper.isDead(I->first)) {
@@ -395,28 +754,12 @@ void PointerAlignmentChecker::checkDeadSymbols(SymbolReaper &SymReaper,
       Updated = true;
     }
   }
+
   if (Updated)
     C.addTransition(State);
 }
 
 namespace {
-
-bool hasCapability(const QualType OrigTy, ASTContext &Ctx) {
-  QualType Ty = OrigTy.getCanonicalType();
-  if (Ty->isCHERICapabilityType(Ctx, true))
-    return true;
-  if (const auto *Record = dyn_cast<RecordType>(Ty)) {
-    for (const auto *Field : Record->getDecl()->fields()) {
-      if (hasCapability(Field->getType(), Ctx))
-        return true;
-    }
-    return false;
-  }
-  if (const auto *Array = dyn_cast<ArrayType>(Ty)) {
-    return hasCapability(Array->getElementType(), Ctx);
-  }
-  return false;
-}
 
 void printAlign(raw_ostream &OS, unsigned TZC) {
   OS << "aligned(";
@@ -425,14 +768,6 @@ void printAlign(raw_ostream &OS, unsigned TZC) {
   else
     OS << "2^(" << TZC << ")";
   OS << ")";
-}
-
-const DeclRegion *getOriginalAllocation(const MemRegion *MR) {
-  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
-    return DR;
-  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
-    return getOriginalAllocation(ER->getSuperRegion());
-  return nullptr;
 }
 
 void describeOriginalAllocation(const ValueDecl *SrcDecl,
@@ -449,50 +784,50 @@ void describeOriginalAllocation(const ValueDecl *SrcDecl,
   W.addNote(Note, SrcLoc);
 }
 
+void describeCapabilityStorage(const ValueDecl *CapDecl,
+                               PathDiagnosticLocation SrcLoc,
+                               PathSensitiveBugReport &W, ASTContext &ASTCtx) {
+  SmallString<350> Note;
+  llvm::raw_svector_ostream OS2(Note);
+  const QualType &AllocType = CapDecl->getType().getCanonicalType();
+  OS2 << "Capabilities stored in ";
+  OS2 << "'" << AllocType.getAsString() << "'";
+  W.addNote(Note, SrcLoc);
+}
+
 } // namespace
 
-ExplodedNode *
-PointerAlignmentChecker::emitCastAlignWarn(CheckerContext &C, unsigned SrcAlign,
-                                           unsigned DstReqAlign,
-                                           const CastExpr *CE) const {
+ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
+    CheckerContext &C, const SVal &UnderalignedPtrVal, const BugType &BT,
+    StringRef ErrorMessage, const ValueDecl *CapSrcDecl) const {
   ExplodedNode *ErrNode = C.generateNonFatalErrorNode();
   if (!ErrNode)
     return nullptr;
 
-  ASTContext &ASTCtx = C.getASTContext();
-  const QualType &DstTy = CE->getType();
-  bool DstAlignIsCap = hasCapability(DstTy->getPointeeType(), ASTCtx);
-
-  SmallString<350> ErrorMessage;
-  llvm::raw_svector_ostream OS(ErrorMessage);
-  OS << "Pointer value aligned to a " << SrcAlign << " byte boundary";
-  OS << " cast to type '" << DstTy.getAsString() << "'";
-  OS << " with required";
-  if (DstAlignIsCap)
-    OS << " capability";
-  OS << " alignment " << DstReqAlign;
-  OS << " bytes";
-
-  const SVal &SrcVal = C.getSVal(CE->getSubExpr());
   const ValueDecl *MRDecl = nullptr;
   PathDiagnosticLocation MRDeclLoc;
-  if (const MemRegion *MR = SrcVal.getAsRegion()) {
+  if (const MemRegion *MR = UnderalignedPtrVal.getAsRegion()) {
     if (const DeclRegion *OriginalAlloc = getOriginalAllocation(MR)) {
       MRDecl = OriginalAlloc->getDecl();
       MRDeclLoc = PathDiagnosticLocation::create(MRDecl, C.getSourceManager());
     }
   }
 
-  auto W = std::make_unique<PathSensitiveBugReport>(
-      DstAlignIsCap ? *CapCastAlignBug : *CastAlignBug, ErrorMessage, ErrNode,
-      MRDeclLoc, MRDecl);
+  auto W = std::make_unique<PathSensitiveBugReport>(BT, ErrorMessage, ErrNode,
+                                                    MRDeclLoc, MRDecl);
 
-  W->markInteresting(SrcVal);
-  if (SymbolRef S = SrcVal.getAsSymbol())
+  W->markInteresting(UnderalignedPtrVal);
+  if (SymbolRef S = UnderalignedPtrVal.getAsSymbol())
     W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
 
   if (MRDecl) {
     describeOriginalAllocation(MRDecl, MRDeclLoc, *W, C.getASTContext());
+  }
+
+  if (CapSrcDecl) {
+    auto CapSrcDeclLoc =
+        PathDiagnosticLocation::create(CapSrcDecl, C.getSourceManager());
+    describeCapabilityStorage(CapSrcDecl, CapSrcDeclLoc, *W, C.getASTContext());
   }
 
   C.emitReport(std::move(W));

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -65,6 +65,7 @@ class PointerAlignmentChecker
       {{CDM::SimpleFunc, {"memcpy"}, 3}, {0, 1}},
       {{CDM::SimpleFunc, {"mempcpy"}, 3}, {0, 1}},
       {{CDM::SimpleFunc, {"memmove"}, 3}, {0, 1}},
+      {{CDM::SimpleFunc, {"bcopy"}, 3}, {1, 0}},
   };
 
 public:

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -350,6 +350,11 @@ const DeclRegion *getOriginalAllocation(const MemRegion *MR) {
   return nullptr;
 }
 
+bool hasCapStorageType(const Expr *E, ASTContext &ASTCtx) {
+  const QualType &Ty = E->IgnoreCasts()->getType();
+  return Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx);
+}
+
 } // namespace
 
 void PointerAlignmentChecker::checkPreStmt(const CastExpr *CE,
@@ -361,6 +366,12 @@ void PointerAlignmentChecker::checkPreStmt(const CastExpr *CE,
     return;
 
   ASTContext &ASTCtx = C.getASTContext();
+
+  if (hasCapStorageType(CE->getSubExpr(), ASTCtx)) {
+    /* Src value must have been already checked for capability alignment by this
+     * time */
+    return;
+  }
 
   /* Calculate required alignment */
   const std::optional<unsigned int> &DstReqAlign =
@@ -408,6 +419,12 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   if (!DstTy->isCHERICapabilityType(ASTCtx, true))
     return;
 
+  if (hasCapStorageType(BO->getRHS(), ASTCtx)) {
+    /* Src value must have been already checked for capability alignment by this
+     * time */
+    return;
+  }
+
   /* Check if dst pointee type contains capabilities or is a generic storage
    * type (can contain arbitrary data) */
   bool DstIsPtr2CapStorage = false, DstIsPtr2GenStorage = false;
@@ -448,8 +465,9 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   if (!SrcAlign || *SrcAlign >= CapAlign)
     return;
 
-  if (DstIsPtr2GenStorage) {
-    /* Skip if src pointee value is known and contains no capabilities  */
+  if (!DstIsPtr2CapStorage) {
+    /* Dst is generic pointer;
+     * Skip if src pointee value is known and contains no capabilities  */
     if (const MemRegion *SrcMR = V.getAsRegion()) {
       if (const TypedValueRegion *SrcTR =
               SrcMR->StripCasts()->getAs<TypedValueRegion>()) {
@@ -459,10 +477,8 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
 
         // Emit if SrcDeref is undef/unknown or represents initial value of this
         // region
-        if (!DerefSym)
-          return;
-        auto OriginRegion = DerefSym->getOriginRegion();
-        if (OriginRegion && OriginRegion->StripCasts() != SrcTR)
+        if (!DerefSym || (DerefSym->getOriginRegion() &&
+                          DerefSym->getOriginRegion()->StripCasts() != SrcTR))
           return;
       }
     }

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -385,14 +385,6 @@ static void describeObjectType(raw_ostream &OS, const QualType &Ty,
   }
 }
 
-const DeclRegion *getOriginalAllocation(const MemRegion *MR) {
-  if (const DeclRegion *DR = MR->getAs<DeclRegion>())
-    return DR;
-  if (const ElementRegion *ER = MR->getAs<ElementRegion>())
-    return getOriginalAllocation(ER->getSuperRegion());
-  return nullptr;
-}
-
 unsigned int getFragileAlignment(const MemRegion *MR,
                                  const ProgramStateRef State,
                                  ASTContext &ASTCtx) {
@@ -510,7 +502,7 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
                              (isa<GlobalsSpaceRegion>(TR->getMemorySpace()) ||
                               isa<FieldRegion>(TR->StripCasts()));
     }
-    if (const DeclRegion *D = getOriginalAllocation(CapStorageReg))
+    if (const DeclRegion *D = getAllocationDecl(CapStorageReg))
       CapDstDecl = D->getDecl();
   }
 
@@ -650,7 +642,7 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
     const MemRegion *CapStorageReg = SrcVal.getAsRegion();
     const ValueDecl *CapSrcDecl = nullptr;
     if (CapStorageReg) {
-      if (const DeclRegion *D = getOriginalAllocation(CapStorageReg))
+      if (const DeclRegion *D = getAllocationDecl(CapStorageReg))
         CapSrcDecl = D->getDecl();
     }
 
@@ -687,7 +679,7 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
     const MemRegion *CapStorageReg = DstVal.getAsRegion();
     const ValueDecl *CapDstDecl = nullptr;
     if (CapStorageReg) {
-      if (const DeclRegion *D = getOriginalAllocation(CapStorageReg))
+      if (const DeclRegion *D = getAllocationDecl(CapStorageReg))
         CapDstDecl = D->getDecl();
     }
 
@@ -986,7 +978,7 @@ ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
   unsigned FragileAlignment = 0;
   if (const MemRegion *MR = UnderalignedPtrVal.getAsRegion()) {
     FragileAlignment = getFragileAlignment(MR, C.getState(), C.getASTContext());
-    if (const DeclRegion *OriginalAlloc = getOriginalAllocation(MR)) {
+    if (const DeclRegion *OriginalAlloc = getAllocationDecl(MR)) {
       MRDecl = OriginalAlloc->getDecl();
       MRDeclLoc = PathDiagnosticLocation::create(MRDecl, C.getSourceManager());
     }

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -577,6 +577,18 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
   }
 }
 
+namespace {
+
+bool isNonZeroShift(const SVal &V) {
+  if (const MemRegion *MR = V.getAsRegion())
+    if (auto *ER = MR->getAs<ElementRegion>())
+      if (!ER->getIndex().isZeroConstant())
+        return true;
+  return false;
+}
+
+} // namespace
+
 void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
                                             CheckerContext &C) const {
   CastKind CK = CE->getCastKind();
@@ -623,13 +635,16 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
 
   /* Update CapStorageSet */
   const ProgramPointTag *Tag = nullptr;
-  if ((isCapabilityStorage(SrcVal, State, ASTCtx) || DstIsCapStorage) &&
-      !isCapabilityStorage(DstVal, State, ASTCtx)) {
-    if (const MemRegion *R = DstVal.getAsRegion()) {
-      State = State->add<CapStorageSet>(R->StripCasts());
-      Updated = true;
-      if (DstIsCapStorage)
-        Tag = C.getNoteTag("Cast to capability-containing type");
+  if (!isCapabilityStorage(DstVal, State, ASTCtx)) {
+    if ((isCapabilityStorage(SrcVal, State, ASTCtx) &&
+         !isNonZeroShift(SrcVal)) ||
+        DstIsCapStorage) {
+      if (const MemRegion *R = DstVal.getAsRegion()) {
+        State = State->add<CapStorageSet>(R->StripCasts());
+        Updated = true;
+        if (DstIsCapStorage)
+          Tag = C.getNoteTag("Cast to capability-containing type");
+      }
     }
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -40,6 +40,7 @@
 using namespace clang;
 using namespace ento;
 using namespace cheri;
+using llvm::APSInt;
 
 namespace {
 class PointerAlignmentChecker
@@ -170,11 +171,13 @@ int getTrailingZerosCount(SymbolRef Sym, ProgramStateRef State,
     return *Align;
 
   // Is function argument or global?
-  auto GlobalPointeeTy = globalOrParamPointeeType(Sym);
+  std::optional<QualType> GlobalPointeeTy = globalOrParamPointeeType(Sym);
   if (GlobalPointeeTy) {
-    QualType &PT = GlobalPointeeTy.value();
+    QualType &PT = *GlobalPointeeTy;
+    if (PT->isCharType())
+      return -1; // char* can be used as generic pointer
     unsigned A = ASTCtx.getTypeAlignInChars(PT).getQuantity();
-    return llvm::APSInt::getUnsigned(A).countTrailingZeros();
+    return APSInt::getUnsigned(A).countTrailingZeros();
   }
 
   return -1;
@@ -194,14 +197,35 @@ int getTrailingZerosCount(const MemRegion *R, ProgramStateRef State,
     unsigned NaturalAlign = ASTCtx.getTypeAlignInChars(PT).getQuantity();
 
     if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
-      int ElTyTZ = llvm::APSInt::getUnsigned(NaturalAlign).countTrailingZeros();
+      int ElTyTZ = APSInt::getUnsigned(NaturalAlign).countTrailingZeros();
 
       const MemRegion *Base = ER->getSuperRegion();
       int BaseTZC = getTrailingZerosCount(Base, State, ASTCtx);
       if (BaseTZC < 0)
         return ElTyTZ > 0 ? ElTyTZ : -1;
 
-      int IdxTZC = getTrailingZerosCount(ER->getIndex(), State, ASTCtx);
+      NonLoc Idx = ER->getIndex();
+      auto ConstIdx = Idx.getAs<nonloc::ConcreteInt>();
+      if (ConstIdx) {
+        const APSInt &CIdx = ConstIdx->getValue();
+        if (CIdx.isNegative()) {
+          // offsetof ?
+          if (const FieldRegion *BaseField = dyn_cast<FieldRegion>(Base)) {
+            const RegionOffset &Offset = BaseField->getAsOffset();
+            if (!Offset.hasSymbolicOffset()) {
+              uint64_t FieldOffsetBits = Offset.getOffset();
+              const CharUnits &FO = ASTCtx.toCharUnitsFromBits(FieldOffsetBits);
+              if (CIdx.getExtValue() == -FO.getQuantity()) {
+                const MemRegion *Parent = BaseField->getSuperRegion();
+                return getTrailingZerosCount(Parent, State, ASTCtx);
+              }
+            }
+          }
+          return -1;
+        }
+      }
+
+      int IdxTZC = getTrailingZerosCount(Idx, State, ASTCtx);
       if (IdxTZC < 0 && NaturalAlign == 1)
         return -1;
 
@@ -217,7 +241,7 @@ int getTrailingZerosCount(const MemRegion *R, ProgramStateRef State,
     }
 
     unsigned A = std::max(NaturalAlign, AlignAttrVal);
-    return llvm::APSInt::getUnsigned(A).countTrailingZeros();
+    return APSInt::getUnsigned(A).countTrailingZeros();
   }
   return -1;
 }
@@ -375,6 +399,20 @@ const DeclRegion *getOriginalAllocation(const MemRegion *MR) {
   return nullptr;
 }
 
+unsigned int getFragileAlignment(const MemRegion *MR,
+                                 const ProgramStateRef State,
+                                 ASTContext &ASTCtx) {
+  const RegionOffset &RO = MR->getAsOffset();
+  if (RO.hasSymbolicOffset())
+    return 0;
+  int BaseAlign = getTrailingZerosCount(RO.getRegion(), State, ASTCtx);
+  if (BaseAlign < 0)
+    return 0;
+  assert(BaseAlign < 64);
+  unsigned OffsetAlign = APSInt::get(RO.getOffset()).countTrailingZeros();
+  return 1L << std::min((unsigned)BaseAlign, OffsetAlign);
+}
+
 bool hasCapStorageType(const Expr *E, ASTContext &ASTCtx) {
   const QualType &Ty = E->IgnoreCasts()->getType();
   return Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx);
@@ -393,8 +431,8 @@ void PointerAlignmentChecker::checkPreStmt(const CastExpr *CE,
   ASTContext &ASTCtx = C.getASTContext();
 
   if (hasCapStorageType(CE->getSubExpr(), ASTCtx)) {
-    /* Src value must have been already checked for capability alignment by this
-     * time */
+    /* Src value must have been already checked
+     * for capability alignment by this time */
     return;
   }
 
@@ -445,13 +483,13 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
     return;
 
   if (hasCapStorageType(BO->getRHS(), ASTCtx)) {
-    /* Src value must have been already checked for capability alignment by this
-     * time */
+    /* Src value must have been already checked
+     * for capability alignment by this time */
     return;
   }
 
-  /* Check if dst pointee type contains capabilities or is a generic storage
-   * type (can contain arbitrary data) */
+  /* Check if dst pointee type contains capabilities or
+   * is a generic storage type (can contain arbitrary data) */
   bool DstIsPtr2CapStorage = false, DstIsPtr2GenStorage = false;
   QualType DstCapStorageTy = DstTy;
 
@@ -506,9 +544,8 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
         const QualType &SrcValTy = SrcTR->getValueType();
         const SVal &SrcDeref = C.getState()->getSVal(SrcMR, SrcValTy);
         SymbolRef DerefSym = SrcDeref.getAsSymbol();
-
-        // Emit if SrcDeref is undef/unknown or represents initial value of this
-        // region
+        // Emit if SrcDeref is undef/unknown or represents
+        // the initial value of this region
         if (!DerefSym || (DerefSym->getOriginRegion() &&
                           DerefSym->getOriginRegion()->StripCasts() != SrcTR))
           return;
@@ -558,6 +595,20 @@ void PointerAlignmentChecker::checkPreCall(const CallEvent &Call,
   const std::pair<int, int> *MemCpyParamPair = MemCpyFn.lookup(Call);
   if (!MemCpyParamPair)
     return;
+
+  /* Check size if big enough to copy a capability */
+  SValBuilder &SVB = C.getSValBuilder();
+  unsigned CapSize = getCapabilityTypeSize(ASTCtx).getQuantity();
+  const NonLoc &CapSizeV = SVB.makeIntVal(CapSize, true);
+  const SVal &CopySizeV = C.getSVal(Call.getArgExpr(2));
+  auto CSN = CopySizeV.getAs<NonLoc>();
+  if (CSN) {
+    auto LongCopy = SVB.evalBinOpNN(C.getState(), clang::BO_GE, *CSN, CapSizeV,
+                                    SVB.getConditionType());
+    if (auto LC = LongCopy.getAs<DefinedOrUnknownSVal>())
+      if (!C.getState()->assume(*LC, true))
+        return;
+  }
 
   unsigned CapAlign = getCapabilityTypeAlign(ASTCtx).getQuantity();
 
@@ -674,6 +725,42 @@ bool isNonZeroShift(const SVal &V) {
   return false;
 }
 
+bool valueIsLTPow2(const Expr *E, unsigned P, CheckerContext &C) {
+  if (P >= sizeof(uint64_t) * 8)
+    return true;
+  SValBuilder &SVB = C.getSValBuilder();
+  const NonLoc &B = SVB.makeIntVal((uint64_t)1 << P, true);
+
+  ProgramStateRef State = C.getState();
+  const SVal &V = C.getSVal(E);
+  auto LT = SVB.evalBinOp(State, BO_LT, V, B, E->getType());
+  return !State->assume(LT.castAs<DefinedOrUnknownSVal>(), false);
+}
+
+unsigned getBaseAlignFromOffsetOf(const Expr *E, ASTContext &Ctx) {
+  if (const CastExpr *CE = dyn_cast<CastExpr>(E))
+    return getBaseAlignFromOffsetOf(CE->IgnoreCasts(), Ctx);
+
+  const OffsetOfExpr *OOE = dyn_cast<OffsetOfExpr>(E);
+  if (!OOE)
+    return 0;
+
+  unsigned res = 0;
+  const OffsetOfNode &BaseNode = OOE->getComponent(0);
+  switch (BaseNode.getKind()) {
+  case clang::OffsetOfNode::Field: {
+    RecordDecl *BaseRec = BaseNode.getField()->getParent();
+    const QualType &BaseType = Ctx.getRecordType(BaseRec);
+    res = Ctx.getTypeAlignInChars(BaseType).getQuantity();
+    break;
+  }
+  default:
+    break;
+  }
+
+  return res;
+}
+
 } // namespace
 
 void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
@@ -687,14 +774,11 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
   int SrcTZC = getTrailingZerosCount(CE->getSubExpr(), C);
 
   ASTContext &ASTCtx = C.getASTContext();
-  int DstReqTZC = -1;
   bool DstIsCapStorage = false;
   if (CE->getType()->isPointerType()) {
     if (!isGenericPointerType(CE->getType(), true)) {
       const QualType &DstPTy = CE->getType()->getPointeeType();
       if (!DstPTy->isIncompleteType()) {
-        unsigned ReqAl = ASTCtx.getTypeAlignInChars(DstPTy).getQuantity();
-        DstReqTZC = llvm::APSInt::getUnsigned(ReqAl).countTrailingZeros();
         DstIsCapStorage = hasCapability(DstPTy, ASTCtx);
       }
     }
@@ -706,8 +790,7 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
   bool Updated = false;
 
   /* Update TrailingZerosMap */
-  int NewAlign = std::max(SrcTZC, DstReqTZC);
-  if (DstTZC < NewAlign) {
+  if (DstTZC < SrcTZC) {
     if (DstVal.isUnknown()) {
       const LocationContext *LCtx = C.getLocationContext();
       DstVal = C.getSValBuilder().conjureSymbolVal(
@@ -715,7 +798,7 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
       State = State->BindExpr(CE, LCtx, DstVal);
     }
     if (SymbolRef Sym = DstVal.getAsSymbol()) {
-      State = State->set<TrailingZerosMap>(Sym, NewAlign);
+      State = State->set<TrailingZerosMap>(Sym, SrcTZC);
       Updated = true;
     }
   }
@@ -737,18 +820,6 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
     C.addTransition(State, Tag);
 }
 
-bool valueIsLTPow2(const Expr *E, unsigned P, CheckerContext &C) {
-  if (P >= sizeof(uint64_t) * 8)
-    return true;
-  SValBuilder &SVB = C.getSValBuilder();
-  const NonLoc &B = SVB.makeIntVal((uint64_t)1 << P, true);
-
-  ProgramStateRef State = C.getState();
-  const SVal &V = C.getSVal(E);
-  auto LT = SVB.evalBinOp(State, BO_LT, V, B, E->getType());
-  return !State->assume(LT.castAs<DefinedOrUnknownSVal>(), false);
-}
-
 void PointerAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
                                             CheckerContext &C) const {
   int LeftTZ = getTrailingZerosCount(BO->getLHS(), C);
@@ -763,7 +834,9 @@ void PointerAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   if (!ResVal.isUnknown() && !ResVal.getAsSymbol())
     return;
 
+  ASTContext &ASTCtx = C.getASTContext();
   const SVal &RHSVal = C.getSVal(BO->getRHS());
+  unsigned BaseAlignFromOffsetOf;
   int BitWidth = C.getASTContext().getTypeSize(BO->getType());
   int Res = 0;
   int RHSConst = 0;
@@ -789,15 +862,20 @@ void PointerAlignmentChecker::checkPostStmt(const BinaryOperator *BO,
   case clang::BO_OrAssign:
     Res = std::min(LeftTZ, RightTZ);
     break;
-  case clang::BO_Add:
-  case clang::BO_AddAssign:
   case clang::BO_Sub:
   case clang::BO_SubAssign:
+    BaseAlignFromOffsetOf = getBaseAlignFromOffsetOf(BO->getRHS(), ASTCtx);
+    if (BaseAlignFromOffsetOf > 0) {
+      Res = APSInt::getUnsigned(BaseAlignFromOffsetOf).countTrailingZeros();
+      break;
+    }
+    [[clang::fallthrough]];
+  case clang::BO_Add:
+  case clang::BO_AddAssign:
     if (BO->getLHS()->getType()->isPointerType()) {
       const QualType &PointeeTy = BO->getLHS()->getType()->getPointeeType();
-      const CharUnits A = C.getASTContext().getTypeAlignInChars(PointeeTy);
-      RightTZ +=
-          llvm::APSInt::getUnsigned(A.getQuantity()).countTrailingZeros();
+      const CharUnits A = ASTCtx.getTypeAlignInChars(PointeeTy);
+      RightTZ += APSInt::getUnsigned(A.getQuantity()).countTrailingZeros();
     }
     Res = std::min(LeftTZ, RightTZ);
     break;
@@ -872,7 +950,8 @@ void printAlign(raw_ostream &OS, unsigned TZC) {
 
 void describeOriginalAllocation(const ValueDecl *SrcDecl,
                                 PathDiagnosticLocation SrcLoc,
-                                PathSensitiveBugReport &W, ASTContext &ASTCtx) {
+                                PathSensitiveBugReport &W, ASTContext &ASTCtx,
+                                unsigned FragileAlign) {
   SmallString<350> Note;
   llvm::raw_svector_ostream OS2(Note);
   const QualType &AllocType = SrcDecl->getType().getCanonicalType();
@@ -884,6 +963,8 @@ void describeOriginalAllocation(const ValueDecl *SrcDecl,
     OS2 << "1 byte";
   else
     OS2 << Align << " bytes";
+  if (FragileAlign > Align)
+    OS2 << " (fragile alignment " << FragileAlign << " bytes)";
   W.addNote(Note, SrcLoc);
 }
 
@@ -899,7 +980,9 @@ ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
 
   const ValueDecl *MRDecl = nullptr;
   PathDiagnosticLocation MRDeclLoc;
+  unsigned FragileAlignment = 0;
   if (const MemRegion *MR = UnderalignedPtrVal.getAsRegion()) {
+    FragileAlignment = getFragileAlignment(MR, C.getState(), C.getASTContext());
     if (const DeclRegion *OriginalAlloc = getOriginalAllocation(MR)) {
       MRDecl = OriginalAlloc->getDecl();
       MRDeclLoc = PathDiagnosticLocation::create(MRDecl, C.getSourceManager());
@@ -914,7 +997,8 @@ ExplodedNode *PointerAlignmentChecker::emitAlignmentWarning(
     W->addVisitor(std::make_unique<AlignmentBugVisitor>(S));
 
   if (MRDecl) {
-    describeOriginalAllocation(MRDecl, MRDeclLoc, *W, C.getASTContext());
+    describeOriginalAllocation(MRDecl, MRDeclLoc, *W, C.getASTContext(),
+                               FragileAlignment);
   }
 
   if (CapStorageDecl) {

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -184,8 +184,8 @@ int getTrailingZerosCount(const MemRegion *R, ProgramStateRef State,
     }
 
     unsigned AlignAttrVal = 0;
-    if (auto DR = R->getAs<DeclRegion>()) {
-      if (auto AA = DR->getDecl()->getAttr<AlignedAttr>()) {
+    if (const auto *DR = R->getAs<DeclRegion>()) {
+      if (auto *AA = DR->getDecl()->getAttr<AlignedAttr>()) {
         if (!AA->isAlignmentDependent())
           AlignAttrVal = AA->getAlignment(ASTCtx) / ASTCtx.getCharWidth();
       }
@@ -287,7 +287,7 @@ std::optional<unsigned> getRequiredAlignment(ASTContext &ASTCtx,
   const QualType &PointeeTy = PtrTy->getPointeeType();
   if (!PointeeTy->isIncompleteType())
     return ASTCtx.getTypeAlignInChars(PointeeTy).getQuantity();
-  else if (AssumeCapAlignForVoidPtr && isGenericPointerType(PtrTy, false))
+  if (AssumeCapAlignForVoidPtr && isGenericPointerType(PtrTy, false))
     return getCapabilityTypeAlign(ASTCtx).getQuantity();
   return std::nullopt;
 }
@@ -303,20 +303,18 @@ bool isImplicitConversionFromVoidPtr(const Stmt *S, CheckerContext &C) {
   return !M.empty();
 }
 
-bool isGenericStorage(CheckerContext &C, const SVal &V) {
-  if (SymbolRef Sym = V.getAsSymbol()) {
-    if (!isGenericPointerType(Sym->getType(), false))
-      return false;
-    if (const MemRegion *R = Sym->getOriginRegion()) {
-      const MemSpaceRegion *MS = R->getMemorySpace();
-      if (isa<GlobalsSpaceRegion>(MS))
-        return true; // global variable
-      if (auto SR = dyn_cast<StackArgumentsSpaceRegion>(MS))
-        return SR->getStackFrame()->inTopFrame(); // top-level argument
+bool isGenericStorage(SymbolRef Sym, QualType CopyTy) {
+  if (!isGenericPointerType(CopyTy, false))
+    return false;
+  if (const MemRegion *R = Sym->getOriginRegion()) {
+    const MemSpaceRegion *MS = R->getMemorySpace();
+    if (isa<GlobalsSpaceRegion>(MS))
+      return true; // global variable
+    if (const auto *SR = dyn_cast<StackArgumentsSpaceRegion>(MS))
+      return SR->getStackFrame()->inTopFrame(); // top-level argument
 
-      if (isa<FieldRegion>(R))
-        return true; // struct field
-    }
+    if (isa<FieldRegion>(R))
+      return true; // struct field
   }
   return false;
 }
@@ -324,7 +322,10 @@ bool isGenericStorage(CheckerContext &C, const SVal &V) {
 bool isGenericStorage(CheckerContext &C, const Expr *E) {
   if (!isGenericPointerType(E->IgnoreImpCasts()->getType(), false))
     return false;
-  return isGenericStorage(C, C.getSVal(E));
+  if (SymbolRef Sym = C.getSVal(E).getAsSymbol()) {
+    return isGenericStorage(Sym, Sym->getType());
+  }
+  return false;
 }
 
 static void describeObjectType(raw_ostream &OS, const QualType &Ty,
@@ -406,17 +407,19 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   if (!DstTy->isCHERICapabilityType(ASTCtx, true))
     return;
 
-  bool DstIsCapStorage = false, DstIsGenericStorage = false;
+  /* Check if dst pointee type contains capabilities or is a generic storage
+   * type (can contain arbitrary data) */
+  bool DstIsPtr2CapStorage = false, DstIsPtr2GenStorage = false;
 
   if (DstTy->isPointerType() && hasCapability(DstTy->getPointeeType(), ASTCtx))
-    DstIsCapStorage = true;
+    DstIsPtr2CapStorage = true;
 
   if (const MemRegion *MR = L.getAsRegion()) {
     if (const TypedValueRegion *TR = MR->getAs<TypedValueRegion>()) {
       const QualType &Ty = TR->getValueType();
-      DstIsCapStorage |=
+      DstIsPtr2CapStorage |=
           Ty->isPointerType() && hasCapability(Ty->getPointeeType(), ASTCtx);
-      DstIsGenericStorage |= isGenericPointerType(Ty, false) &&
+      DstIsPtr2GenStorage |= isGenericPointerType(Ty, false) &&
                              (isa<GlobalsSpaceRegion>(TR->getMemorySpace()) ||
                               isa<FieldRegion>(TR->StripCasts()));
     }
@@ -426,28 +429,40 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
     const QualType &SymTy = Sym->getType();
     if (SymTy->isPointerType()) {
       const QualType &CopyTy = SymTy->getPointeeType();
-      DstIsCapStorage |= CopyTy->isPointerType() &&
-                         hasCapability(CopyTy->getPointeeType(), ASTCtx);
-      if (const MemRegion *R = Sym->getOriginRegion()) {
-        const MemSpaceRegion *MS = R->getMemorySpace();
-        bool TopLevelArg = false;
-        if (auto SS = dyn_cast<StackArgumentsSpaceRegion>(MS))
-          TopLevelArg = SS->getStackFrame()->inTopFrame();
-        DstIsGenericStorage |= isGenericPointerType(CopyTy, false) &&
-                               (TopLevelArg || isa<GlobalsSpaceRegion>(MS) ||
-                                isa<FieldRegion>(R->StripCasts()));
-      }
+      DstIsPtr2CapStorage |= CopyTy->isPointerType() &&
+                             hasCapability(CopyTy->getPointeeType(), ASTCtx);
+      DstIsPtr2GenStorage |= isGenericStorage(Sym, CopyTy);
     }
   }
 
-  if (!DstIsCapStorage && !DstIsGenericStorage)
+  if (!DstIsPtr2CapStorage && !DstIsPtr2GenStorage)
     return;
 
-  /* Calculate actual alignment */
+  /* Source alignment */
   unsigned CapAlign = getCapabilityTypeAlign(ASTCtx).getQuantity();
   const std::optional<unsigned int> &SrcAlign = getActualAlignment(C, V);
   if (!SrcAlign || *SrcAlign >= CapAlign)
     return;
+
+  if (DstIsPtr2GenStorage) {
+    /* Skip if src pointee value is known and contains no capabilities  */
+    if (const MemRegion *SrcMR = V.getAsRegion()) {
+      if (const TypedValueRegion *SrcTR =
+              SrcMR->StripCasts()->getAs<TypedValueRegion>()) {
+        const QualType &SrcValTy = SrcTR->getValueType();
+        const SVal &SrcDeref = C.getState()->getSVal(SrcMR, SrcValTy);
+        SymbolRef DerefSym = SrcDeref.getAsSymbol();
+
+        // Emit if SrcDeref is undef/unknown or represents initial value of this
+        // region
+        if (!DerefSym)
+          return;
+        auto OriginRegion = DerefSym->getOriginRegion();
+        if (OriginRegion && OriginRegion->StripCasts() != SrcTR)
+          return;
+      }
+    }
+  }
 
   /* Emit warning */
   SmallString<350> ErrorMessage;
@@ -455,7 +470,7 @@ void PointerAlignmentChecker::checkBind(SVal L, SVal V, const Stmt *S,
   OS << "Pointer value aligned to a " << SrcAlign << " byte boundary";
   OS << " stored as type '" << BO->getLHS()->getType().getAsString() << "'";
   OS << ". Memory pointed by it";
-  if (DstIsCapStorage)
+  if (DstIsPtr2CapStorage)
     OS << " is supposed to";
   else
     OS << " may be used to";

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -136,17 +136,18 @@ int getTrailingZerosCount(const MemRegion *R, ProgramStateRef State,
     unsigned NaturalAlign = ASTCtx.getTypeAlignInChars(PT).getQuantity();
 
     if (const ElementRegion *ER = R->getAs<ElementRegion>()) {
+      int ElTyTZ = llvm::APSInt::getUnsigned(NaturalAlign).countTrailingZeros();
+
       const MemRegion *Base = ER->getSuperRegion();
       int BaseTZC = getTrailingZerosCount(Base, State, ASTCtx);
+      if (BaseTZC < 0)
+        return ElTyTZ > 0 ? ElTyTZ : -1;
+
       int IdxTZC = getTrailingZerosCount(ER->getIndex(), State, ASTCtx);
-      if (BaseTZC >= 0) {
-        if (IdxTZC < 0 && NaturalAlign == 1)
-          return -1;
-        int ElemTyTZC =
-            llvm::APSInt::getUnsigned(NaturalAlign).countTrailingZeros();
-        return std::min(BaseTZC, std::max(IdxTZC, 0) + ElemTyTZC);
-      }
-      return -1;
+      if (IdxTZC < 0 && NaturalAlign == 1)
+        return -1;
+
+      return std::min(BaseTZC, std::max(IdxTZC, 0) + ElTyTZ);
     }
 
     unsigned AlignAttrVal = 0;
@@ -249,7 +250,20 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
   int DstTZC = getTrailingZerosCount(CE, C);
   int SrcTZC = getTrailingZerosCount(CE->getSubExpr(), C);
 
-  if (DstTZC < SrcTZC) {
+  ASTContext &ASTCtx = C.getASTContext();
+  int DstReqTZC = -1;
+  if (CE->getType()->isPointerType()) {
+    if (!isGenericPointerType(CE->getType(), true)) {
+      const QualType &DstPTy = CE->getType()->getPointeeType();
+      if (!DstPTy->isIncompleteType()) {
+        unsigned ReqAl = ASTCtx.getTypeAlignInChars(DstPTy).getQuantity();
+        DstReqTZC = llvm::APSInt::getUnsigned(ReqAl).countTrailingZeros();
+      }
+    }
+  }
+
+  int NewAlign = std::max(SrcTZC, DstReqTZC);
+  if (DstTZC < NewAlign) {
     SVal DstVal = C.getSVal(CE);
     ProgramStateRef State = C.getState();
     if (DstVal.isUnknown()) {
@@ -259,7 +273,7 @@ void PointerAlignmentChecker::checkPostStmt(const CastExpr *CE,
       State = State->BindExpr(CE, LCtx, DstVal);
     }
     if (SymbolRef Sym = DstVal.getAsSymbol()) {
-      State = State->set<TrailingZerosMap>(Sym, SrcTZC);
+      State = State->set<TrailingZerosMap>(Sym, NewAlign);
       C.addTransition(State);
     }
   }

--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -133,15 +133,20 @@ PointerAlignmentChecker::PointerAlignmentChecker() {
 
 namespace {
 
+bool isGlobalOrTopLevelArg(const MemSpaceRegion *MS) {
+  if (isa<GlobalsSpaceRegion>(MS))
+    return true; // global variable
+  if (const auto *SR = dyn_cast<StackArgumentsSpaceRegion>(MS))
+    return SR->getStackFrame()->inTopFrame(); // top-level argument
+  return false;
+}
+
 std::optional<QualType> globalOrParamPointeeType(SymbolRef Sym) {
   const MemRegion *BaseRegOrigin = Sym->getOriginRegion();
   if (!BaseRegOrigin)
     return std::nullopt;
 
-  bool HasGlobalsOrParametersStorage =
-      isa<StackArgumentsSpaceRegion, GlobalsSpaceRegion>(
-          BaseRegOrigin->getMemorySpace());
-  if (!HasGlobalsOrParametersStorage)
+  if (!isGlobalOrTopLevelArg(BaseRegOrigin->getMemorySpace()))
     return std::nullopt;
 
   const QualType &SymTy = Sym->getType();
@@ -249,9 +254,13 @@ int getTrailingZerosCount(const Expr *E, CheckerContext &C) {
 }
 
 bool isCapabilityStorage(SymbolRef Sym, ASTContext &ASTCtx) {
-  const std::optional<QualType> GlobalPointeeTy = globalOrParamPointeeType(Sym);
-  if (GlobalPointeeTy)
-    return hasCapability(*GlobalPointeeTy, ASTCtx);
+  const QualType &SymTy = Sym->getType();
+  if (SymTy->isPointerType()) {
+    const QualType &PT = SymTy->getPointeeType();
+    if (!PT->isIncompleteType()) {
+      return hasCapability(PT, ASTCtx);
+    }
+  }
   return false;
 }
 
@@ -327,11 +336,8 @@ bool isGenericStorage(SymbolRef Sym, QualType CopyTy) {
   if (!isGenericPointerType(CopyTy, false))
     return false;
   if (const MemRegion *R = Sym->getOriginRegion()) {
-    const MemSpaceRegion *MS = R->getMemorySpace();
-    if (isa<GlobalsSpaceRegion>(MS))
-      return true; // global variable
-    if (const auto *SR = dyn_cast<StackArgumentsSpaceRegion>(MS))
-      return SR->getStackFrame()->inTopFrame(); // top-level argument
+    if (isGlobalOrTopLevelArg(R->getMemorySpace()))
+      return true; // global variable or top-level function argument
 
     if (isa<FieldRegion>(R))
       return true; // struct field

--- a/clang/lib/StaticAnalyzer/Core/HTMLDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Core/HTMLDiagnostics.cpp
@@ -598,7 +598,7 @@ void HTMLDiagnostics::FinalizeHTML(const PathDiagnostic &D, Rewriter &R,
        << D.getVerboseDescription() << "</td></tr>\n";
 
     // The navigation across the extra notes pieces.
-    unsigned NumExtraPieces = 0;
+    unsigned NumExtraPieces = 1;
     for (const auto &Piece : path) {
       if (const auto *P = dyn_cast<PathDiagnosticNotePiece>(Piece.get())) {
         int LineNumber =

--- a/clang/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
@@ -747,10 +747,10 @@ void PlistDiagnostics::FlushDiagnosticsImpl(
           // the leak location even after code is added between the allocation
           // site and the end of scope (leak report location).
           if (UPDLoc.isValid()) {
-            FullSourceLoc UFunL(
-                SM.getExpansionLoc(
-                    D->getUniqueingDecl()->getBody()->getBeginLoc()),
-                SM);
+            const Decl *UD = D->getUniqueingDecl();
+            SourceLocation Loc = UD->hasBody() ? UD->getBody()->getBeginLoc()
+                                               : UD->getBeginLoc();
+            FullSourceLoc UFunL(SM.getExpansionLoc(Loc), SM);
             o << "  <key>issue_hash_function_offset</key><string>"
               << L.getExpansionLineNumber() - UFunL.getExpansionLineNumber()
               << "</string>\n";

--- a/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SValBuilder.cpp
@@ -633,11 +633,13 @@ private:
   SValBuilder &VB;
   ASTContext &Context;
   QualType CastTy, OriginalTy;
+  bool SrcHasProvenance;
 
 public:
-  EvalCastVisitor(SValBuilder &VB, QualType CastTy, QualType OriginalTy)
+  EvalCastVisitor(SValBuilder &VB, QualType CastTy, QualType OriginalTy,
+                  bool SrcProv)
       : VB(VB), Context(VB.getContext()), CastTy(CastTy),
-        OriginalTy(OriginalTy) {}
+        OriginalTy(OriginalTy), SrcHasProvenance(SrcProv) {}
 
   SVal Visit(SVal V) {
     if (CastTy.isNull())
@@ -695,7 +697,7 @@ public:
     // Pointer to integer.
     if (CastTy->isIntegralOrEnumerationType()) {
       const unsigned BitWidth = Context.getIntWidth(CastTy);
-      return VB.makeLocAsInteger(V, BitWidth);
+      return VB.makeLocAsInteger(V, BitWidth, CastTy->isIntCapType());
     }
 
     const bool IsUnknownOriginalType = OriginalTy.isNull();
@@ -762,7 +764,8 @@ public:
         //    QualType pointerTy = C.getPointerType(elemTy);
       }
       const unsigned BitWidth = Context.getIntWidth(CastTy);
-      return VB.makeLocAsInteger(Val.castAs<Loc>(), BitWidth);
+      bool HasProvenance = this->SrcHasProvenance && CastTy->isIntCapType();
+      return VB.makeLocAsInteger(Val.castAs<Loc>(), BitWidth, HasProvenance);
     }
 
     // Pointer to pointer.
@@ -942,7 +945,7 @@ public:
         if (CastSize == V.getNumBits())
           return V;
 
-        return VB.makeLocAsInteger(L, CastSize);
+        return VB.makeLocAsInteger(L, CastSize, this->SrcHasProvenance);
       }
     }
 
@@ -1100,6 +1103,13 @@ public:
 /// FIXME: If `OriginalTy.isNull()` is true, then cast performs based on CastTy
 /// only. This behavior is uncertain and should be improved.
 SVal SValBuilder::evalCast(SVal V, QualType CastTy, QualType OriginalTy) {
-  EvalCastVisitor TRV{*this, CastTy, OriginalTy};
+  bool SrcHasProvenance = false;
+  if (V.getAs<Loc>())
+    SrcHasProvenance = true;
+  if (auto LaI = V.getAs<nonloc::LocAsInteger>()) {
+    SrcHasProvenance = LaI->hasProvenance();
+  }
+
+  EvalCastVisitor TRV{*this, CastTy, OriginalTy, SrcHasProvenance};
   return TRV.Visit(V);
 }

--- a/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
+++ b/clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp
@@ -420,6 +420,19 @@ static std::optional<NonLoc> tryRearrange(ProgramStateRef State,
   return doRearrangeUnchecked(State, Op, LSym, LInt, RSym, RInt);
 }
 
+static SVal evalAdditiveIntptrOp(ProgramStateRef State,
+                                 BinaryOperator::Opcode op, Loc LHS, NonLoc RHS,
+                                 QualType LocTy, QualType ResultTy,
+                                 SimpleSValBuilder &SVB) {
+  ASTContext &Context = SVB.getContext();
+  const CanQualType &CharPtrTy = Context.getPointerType(Context.CharTy);
+
+  const SVal &RawPtr = SVB.evalCast(LHS, CharPtrTy, LocTy);
+  const Loc &RawPtrLoc = RawPtr.castAs<Loc>();
+  const SVal &NewLoc = SVB.evalBinOpLN(State, op, RawPtrLoc, RHS, CharPtrTy);
+  return SVB.evalCast(NewLoc, ResultTy, CharPtrTy);
+}
+
 SVal SimpleSValBuilder::evalBinOpNN(ProgramStateRef state,
                                   BinaryOperator::Opcode op,
                                   NonLoc lhs, NonLoc rhs,
@@ -492,24 +505,43 @@ SVal SimpleSValBuilder::evalBinOpNN(ProgramStateRef state,
                            resultTy);
       case nonloc::ConcreteIntKind: {
         // FIXME: at the moment the implementation
-        // of modeling "pointers as integers" is not complete.
-        if (!BinaryOperator::isComparisonOp(op))
-          return UnknownVal();
-        // Transform the integer into a location and compare.
-        // FIXME: This only makes sense for comparisons. If we want to, say,
-        // add 1 to a LocAsInteger, we'd better unpack the Loc and add to it,
-        // then pack it back into a LocAsInteger.
+        //  of modeling "pointers as integers" is not complete.
         llvm::APSInt i = rhs.castAs<nonloc::ConcreteInt>().getValue();
-        // If the region has a symbolic base, pay attention to the type; it
-        // might be coming from a non-default address space. For non-symbolic
-        // regions it doesn't matter that much because such comparisons would
-        // most likely evaluate to concrete false anyway. FIXME: We might
-        // still need to handle the non-comparison case.
-        if (SymbolRef lSym = lhs.getAsLocSymbol(true))
-          BasicVals.getAPSIntType(lSym->getType()).apply(i);
-        else
-          BasicVals.getAPSIntType(Context.VoidPtrTy).apply(i);
-        return evalBinOpLL(state, op, lhsL, makeLoc(i), resultTy);
+
+        // FIXME: If the region has a symbolic base, pay attention to the
+        //  type; it might be coming from a non-default address space.
+        // For comparisons with non-symbolic regions it doesn't matter that
+        // much because such comparisons would most likely evaluate to
+        // concrete false anyway.
+        if (BinaryOperator::isComparisonOp(op)) {
+          // Transform the integer into a location and compare.
+          SymbolRef LSym = lhsL.getAsLocSymbol(true);
+          const QualType &symType = LSym ? LSym->getType() : Context.VoidPtrTy;
+          BasicVals.getAPSIntType(symType).apply(i);
+          return evalBinOpLL(state, op, lhsL, makeLoc(i), resultTy);
+        }
+
+        // If we want to, say, add 1 to a LocAsInteger, we'd better unpack
+        // the Loc and add to it, then pack it back into a LocAsInteger.
+        if (BinaryOperator::isAdditiveOp(op))
+          if (SymbolRef lSym = lhsL.getAsLocSymbol(false))
+            return evalAdditiveIntptrOp(state, op, lhsL, rhs, lSym->getType(),
+                                        resultTy, *this);
+
+        return UnknownVal();
+      }
+      case nonloc::SymbolValKind: {
+        if (BinaryOperator::isEqualityOp(op))
+          return makeTruthVal(op != BO_EQ, resultTy);
+
+        if (BinaryOperator::isAdditiveOp(op)) {
+          if (SymbolRef lSym = lhsL.getAsLocSymbol(false))
+            return evalAdditiveIntptrOp(state, op, lhsL, rhs, lSym->getType(),
+                                        resultTy, *this);
+        }
+
+        // This case also handles pointer arithmetic.
+        return makeSymExprValNN(op, InputLHS, InputRHS, resultTy);
       }
         default:
           switch (op) {

--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -440,9 +440,25 @@ SVal StoreManager::getLValueIvar(const ObjCIvarDecl *decl, SVal base) {
   return getLValueFieldOrIvar(decl, base);
 }
 
-SVal StoreManager::getLValueElement(QualType elementType, NonLoc Offset,
-                                    SVal Base) {
+static const SVal getNewIndex(ProgramStateRef State, SValBuilder &SVB,
+                              NonLoc Offset, NonLoc BaseIdx) {
+  if (isa<nonloc::ConcreteInt>(BaseIdx) && isa<nonloc::ConcreteInt>(Offset)) {
+    const llvm::APSInt &BIdxI =
+        BaseIdx.castAs<nonloc::ConcreteInt>().getValue();
+    assert(BIdxI.isSigned());
+    const llvm::APSInt &OffI = Offset.castAs<nonloc::ConcreteInt>().getValue();
+    const llvm::APSInt &NewIdxI = BIdxI + OffI;
+    return nonloc::ConcreteInt(SVB.getBasicValueFactory().getValue(NewIdxI));
+  }
+  if (isa<nonloc::LocAsInteger>(BaseIdx) || isa<nonloc::LocAsInteger>(Offset))
+    return UnknownVal();
 
+  const QualType &Ty = SVB.getArrayIndexType();
+  return SVB.evalBinOpNN(State, BO_Add, BaseIdx, Offset, Ty);
+}
+
+SVal StoreManager::getLValueElement(ProgramStateRef State, QualType elementType,
+                                    NonLoc Offset, SVal Base) {
   // Special case, if index is 0, return the same type as if
   // this was not an array dereference.
   if (Offset.isZeroConstant()) {
@@ -496,36 +512,24 @@ SVal StoreManager::getLValueElement(QualType elementType, NonLoc Offset,
                                                     BaseRegion, Ctx));
   }
 
-  SVal BaseIdx = ElemR->getIndex();
+  const SubRegion *ArrayR = cast<SubRegion>(ElemR->getSuperRegion());
+  // Avoid creating NewIndex if BaseIdx is 0
+  if (!isa<ElementRegion>(BaseRegion->StripCasts()))
+    return loc::MemRegionVal(
+        MRMgr.getElementRegion(elementType, Offset, ArrayR, Ctx));
 
-  if (!isa<nonloc::ConcreteInt>(BaseIdx))
+  SVal BaseIdx = ElemR->getIndex();
+  if (!isa<NonLoc>(BaseIdx))
     return UnknownVal();
 
-  const llvm::APSInt &BaseIdxI =
-      BaseIdx.castAs<nonloc::ConcreteInt>().getValue();
-
-  // Only allow non-integer offsets if the base region has no offset itself.
-  // FIXME: This is a somewhat arbitrary restriction. We should be using
-  // SValBuilder here to add the two offsets without checking their types.
-  if (!isa<nonloc::ConcreteInt>(Offset)) {
-    if (isa<ElementRegion>(BaseRegion->StripCasts()))
-      return UnknownVal();
-
-    return loc::MemRegionVal(MRMgr.getElementRegion(
-        elementType, Offset, cast<SubRegion>(ElemR->getSuperRegion()), Ctx));
+  SVal NIdx = getNewIndex(State, svalBuilder, Offset, BaseIdx.castAs<NonLoc>());
+  if (auto NewIdx = NIdx.getAs<NonLoc>()) {
+    // Construct the new ElementRegion.
+    return loc::MemRegionVal(
+        MRMgr.getElementRegion(elementType, *NewIdx, ArrayR, Ctx));
   }
 
-  const llvm::APSInt& OffI = Offset.castAs<nonloc::ConcreteInt>().getValue();
-  assert(BaseIdxI.isSigned());
-
-  // Compute the new index.
-  nonloc::ConcreteInt NewIdx(svalBuilder.getBasicValueFactory().getValue(BaseIdxI +
-                                                                    OffI));
-
-  // Construct the new ElementRegion.
-  const SubRegion *ArrayR = cast<SubRegion>(ElemR->getSuperRegion());
-  return loc::MemRegionVal(MRMgr.getElementRegion(elementType, NewIdx, ArrayR,
-                                                  Ctx));
+  return UnknownVal();
 }
 
 StoreManager::BindingsHandler::~BindingsHandler() = default;

--- a/clang/test/Analysis/Checkers/CHERI/allocation.c
+++ b/clang/test/Analysis/Checkers/CHERI/allocation.c
@@ -1,0 +1,43 @@
+// RUN: %cheri_purecap_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,unix,alpha.cheri.Allocation
+
+typedef __typeof__(sizeof(int)) size_t;
+extern void * malloc(size_t);
+
+
+struct S1 {
+  int *a[3];
+  int *d[1];
+};
+
+struct S2 {
+  int x[3];
+  int *px;
+};
+
+struct S2 * test_1(int n1, int n2) {
+  struct S1 *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
+  struct S2 *p2 = (struct S2 *)(p1+n1); // expected-warning{{Allocation partition}}
+  return p2;
+}
+
+double buf[100] __attribute__((aligned(_Alignof(void*))));
+struct S2 * test_2(int n1) {
+  struct S1 *p1 = (struct S1 *)buf; // ?
+  struct S2 *p2 = (struct S2 *)(p1+n1); // expected-warning{{Allocation partition}}
+  return p2;
+}
+
+int * test_3(int n1, int n2) {
+  void *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
+  struct S2 *p2 = (struct S2 *)(p1+n1);
+  int *p3 = (int*)(p2 + n2); // expected-warning{{Allocation partition}}
+  return p3;
+}
+
+void array(int i, int j) {
+  int a[100][200];
+  int (*p1)[200] = &a[i];
+  int *p2 = p1[j]; // no warn
+  *p2 = 42;
+}

--- a/clang/test/Analysis/Checkers/CHERI/allocation.c
+++ b/clang/test/Analysis/Checkers/CHERI/allocation.c
@@ -28,11 +28,10 @@ struct S2 * test_2(int n1) {
   return p2;
 }
 
-int * test_3(int n1, int n2) {
-  void *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
-  struct S2 *p2 = (struct S2 *)(p1+n1);
-  int *p3 = (int*)(p2 + n2); // expected-warning{{Allocation partition}}
-  return p3;
+struct S2 * test_3(int n1, int n2) {
+  struct S1 *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
+  struct S2 *p2 = (struct S2 *)(p1+n1); // expected-warning{{Allocation partition}}
+  return p2;
 }
 
 void array(int i, int j) {
@@ -40,4 +39,15 @@ void array(int i, int j) {
   int (*p1)[200] = &a[i];
   int *p2 = p1[j]; // no warn
   *p2 = 42;
+}
+
+struct S3 {
+  struct S2 s2;
+  int y;
+};
+
+struct S2 * first_field(void *p, int n1) {
+  struct S3 *p3 = p;
+  struct S2 *p2 = (struct S2 *)(p3+n1); // no warn
+  return p2;
 }

--- a/clang/test/Analysis/Checkers/CHERI/allocation.c
+++ b/clang/test/Analysis/Checkers/CHERI/allocation.c
@@ -51,3 +51,14 @@ struct S2 * first_field(void *p, int n1) {
   struct S2 *p2 = (struct S2 *)(p3+n1); // no warn
   return p2;
 }
+
+struct S4 {
+  long len;
+  int buf[];
+};
+
+int* flex_array(int len) {
+  struct S4 *p = malloc(sizeof(struct S4) + len*sizeof(int));
+  int *pB = (int*)(p + 1); // no warn
+  return pB;
+}

--- a/clang/test/Analysis/Checkers/CHERI/allocation.c
+++ b/clang/test/Analysis/Checkers/CHERI/allocation.c
@@ -1,5 +1,5 @@
 // RUN: %cheri_purecap_cc1 -analyze -verify %s \
-// RUN:   -analyzer-checker=core,unix,alpha.cheri.Allocation
+// RUN:   -analyzer-checker=core,unix,alpha.cheri.Allocation,cheri.CheriAPIModelling
 
 typedef __typeof__(sizeof(int)) size_t;
 extern void * malloc(size_t);
@@ -80,4 +80,12 @@ void test_6(int n1, int n2) {
   struct S1 **p1 = malloc(sizeof(struct S1*)*n1 + sizeof(struct S2*)*n2);
   struct S2 **p2 = (struct S2 **)(p1+n1);
   foo(p2); // no warn
+}
+
+void *cheri_bounds_set(void *c, size_t x);
+void test_7(int n1, int n2) {
+  struct S1 *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
+  struct S2 *p2 = (struct S2 *)(p1+n1);
+  struct S2 *p3 = cheri_bounds_set(p2, sizeof(struct S2)*n2);
+  foo(p3); // no-warn
 }

--- a/clang/test/Analysis/Checkers/CHERI/allocation.c
+++ b/clang/test/Analysis/Checkers/CHERI/allocation.c
@@ -3,11 +3,11 @@
 
 typedef __typeof__(sizeof(int)) size_t;
 extern void * malloc(size_t);
-
+void foo(void*);
 
 struct S1 {
   int *a[3];
-  int *d[1];
+  int *d[3];
 };
 
 struct S2 {
@@ -17,28 +17,28 @@ struct S2 {
 
 struct S2 * test_1(int n1, int n2) {
   struct S1 *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
-  struct S2 *p2 = (struct S2 *)(p1+n1); // expected-warning{{Allocation partition}}
-  return p2;
+  struct S2 *p2 = (struct S2 *)(p1+n1);
+  return p2; // expected-warning{{Pointer to suballocation returned from function}}
 }
 
-double buf[100] __attribute__((aligned(_Alignof(void*))));
-struct S2 * test_2(int n1) {
+double buf[100] __attribute__((aligned(_Alignof(void*)))); // expected-note{{Original allocation}}
+void test_2(int n1) {
   struct S1 *p1 = (struct S1 *)buf; // ?
-  struct S2 *p2 = (struct S2 *)(p1+n1); // expected-warning{{Allocation partition}}
-  return p2;
+  struct S2 *p2 = (struct S2 *)(p1+n1);
+  foo(p2); // expected-warning{{Pointer to suballocation passed to function}}
 }
 
-struct S2 * test_3(int n1, int n2) {
+void test_3(int n1, int n2) {
   struct S1 *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
-  struct S2 *p2 = (struct S2 *)(p1+n1); // expected-warning{{Allocation partition}}
-  return p2;
+  struct S2 *p2 = (struct S2 *)(p1+n1);
+  foo(p2); // expected-warning{{Pointer to suballocation passed to function}}
 }
 
 void array(int i, int j) {
   int a[100][200];
   int (*p1)[200] = &a[i];
-  int *p2 = p1[j]; // no warn
-  *p2 = 42;
+  int *p2 = p1[j];
+  foo(p2); // no warn
 }
 
 struct S3 {
@@ -48,8 +48,8 @@ struct S3 {
 
 struct S2 * first_field(void *p, int n1) {
   struct S3 *p3 = p;
-  struct S2 *p2 = (struct S2 *)(p3+n1); // no warn
-  return p2;
+  struct S2 *p2 = (struct S2 *)(p3+n1);
+  return p2;  // no warn
 }
 
 struct S4 {
@@ -59,6 +59,25 @@ struct S4 {
 
 int* flex_array(int len) {
   struct S4 *p = malloc(sizeof(struct S4) + len*sizeof(int));
-  int *pB = (int*)(p + 1); // no warn
-  return pB;
+  int *pB = (int*)(p + 1);
+  return pB; // no warn
+}
+
+void test_4(struct S2 *pS2) {
+  double a[100];  // expected-note{{Original allocation}}
+  double *p1 = a;
+  pS2->px = (int*)(p1 + 10); // expected-warning{{Pointer to suballocation escaped on assign}}
+                             // expected-warning@-1{{Address of stack memory associated with local variable 'a' is still referred to by the caller variable 'pS2' upon returning to the caller.  This will be a dangling reference}}
+}
+
+void test_5(int n1, int n2) {
+  int *p1 = malloc(sizeof(struct S1)*n1 + sizeof(struct S2)*n2);
+  unsigned *p2 = (unsigned*)(p1+n1);
+  foo(p2); // no warn
+}
+
+void test_6(int n1, int n2) {
+  struct S1 **p1 = malloc(sizeof(struct S1*)*n1 + sizeof(struct S2*)*n2);
+  struct S2 **p2 = (struct S2 **)(p1+n1);
+  foo(p2); // no warn
 }

--- a/clang/test/Analysis/Checkers/CHERI/assume-ptr-size.c
+++ b/clang/test/Analysis/Checkers/CHERI/assume-ptr-size.c
@@ -1,0 +1,64 @@
+// RUN: %cheri_purecap_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,cheri.PointerSizeAssumptions
+
+
+typedef __intcap_t intptr_t;
+typedef __typeof__(sizeof(int)) size_t;
+extern void *memcpy(void *dest, const void *src, size_t n);
+
+void *f(long i64) {
+  void *p;
+  if (sizeof(i64) == sizeof(p)) { // expected-warning{{This code may fail to consider the case of 128-bit pointers}}
+    memcpy(&p, &i64, sizeof(p));
+  } else {
+    int i32 = i64 & 0xffffffffL;
+    memcpy(&p, &i32, sizeof(p));
+  }
+  return p;
+}
+
+void *f2(long i64){
+  void *p;
+  if( sizeof(i64)==i64 ){
+    memcpy(&p, &i64, sizeof(p));
+  }else{
+    int i32 = i64 & 0xffffffffL;
+    memcpy(&p, &i32, sizeof(p));
+  }
+  return p;
+}
+
+void *f3(long i64){
+  void *p;
+  if( sizeof(p)==8 ){ // expected-warning{{This code may fail to consider the case of 128-bit pointers}}
+    memcpy(&p, &i64, sizeof(p));
+  }else{
+    int i32 = i64 & 0xffffffffL;
+    memcpy(&p, &i32, sizeof(p));
+  }
+  return p;
+}
+
+void *f4(long i64){
+  void *p;
+  if( sizeof(p)==sizeof(long) ){ // expected-warning{{This code may fail to consider the case of 128-bit pointers}}
+    memcpy(&p, &i64, sizeof(p));
+  }else{
+    int i32 = i64 & 0xffffffffL;
+    memcpy(&p, &i32, sizeof(p));
+  }
+  return p;
+}
+
+void *f5(long i64){
+  void *p;
+  if( sizeof(p)==sizeof(i64) ){ // no warn
+    memcpy(&p, &i64, sizeof(p));
+  }else if (sizeof(p)==sizeof(int)) {
+    int i32 = i64 & 0xffffffffL;
+    memcpy(&p, &i32, sizeof(p));
+  } else if (sizeof(p)==sizeof(intptr_t)) {
+    p = 0;
+  }
+  return p;
+}

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -8,17 +8,21 @@ double a[2048], *next = a;
 #define	roundup2(x, y)	(((x)+((y)-1))&(~((y)-1)))
 
 #define NULL (void*)0
+#define MINUS_ONE (void*)-1
 uintptr_t *u;
 
-void foo(void *v) {
+void foo(void *v, int *pi, void *pv) {
   char *p0 = (char*)a;
   *(void**)p0 = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
   char *p1 = (char*)roundup2((uintptr_t)p0, sizeof(void*));
-  *(void**)p1 = v; // no warn
+  *(void**)p1 = v; // no warning
   char *p2 = p1 + 5*sizeof(double);
   *(void**)p2 = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
 
-  if (u == NULL)
-    return; // no warning
-}
+  *(void**)pi = v; // expected-warning{{Cast increases required alignment: 4 -> 16}}
+  *(void**)pv = v; // no warning
+  *(void**)next = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
 
+  if (u == NULL || u == MINUS_ONE) // no warning
+    return;
+}

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -1,5 +1,5 @@
 // RUN: %cheri_purecap_cc1 -analyze -verify %s \
-// RUN:   -analyzer-checker=core,alpha.cheri.CapabilityAlignmentChecker
+// RUN:   -analyzer-checker=core,cheri.CapabilityAlignmentChecker
 
 typedef __uintcap_t uintptr_t;
 typedef __intcap_t intptr_t;

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -2,6 +2,7 @@
 // RUN:   -analyzer-checker=core,alpha.cheri.CapabilityAlignmentChecker
 
 typedef __uintcap_t uintptr_t;
+typedef __intcap_t intptr_t;
 typedef __typeof__(sizeof(int)) size_t;
 
 double a[2048], *next = a;
@@ -37,4 +38,14 @@ uintptr_t* bar(uintptr_t *p) {
   uintptr_t offset = align_offset((char*)(p) + 2 *sizeof(size_t));
   p = (uintptr_t*)((char*)p + offset); // no warning
   return p;
+}
+
+struct S {
+  intptr_t u[10];
+  int i[10];
+};
+int baz(struct S *s) {
+  uintptr_t* p1 = (uintptr_t*)&s->u[3];  // no warning
+  uintptr_t* p2 = (uintptr_t*)&s->i[6];  // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  return p2 - p1;
 }

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -5,7 +5,8 @@ typedef __uintcap_t uintptr_t;
 typedef __intcap_t intptr_t;
 typedef __typeof__(sizeof(int)) size_t;
 
-double a[2048], *next = a;
+double a[2048], // expected-note{{Original allocation}}
+    *next = a;
 
 #define	roundup2(x, y)	(((x)+((y)-1))&(~((y)-1)))
 
@@ -42,8 +43,8 @@ uintptr_t* bar(uintptr_t *p) {
 
 struct S {
   intptr_t u[40];
-  int i[40];
-  int i_aligned[40] __attribute__((aligned(16)));
+  int i[40]; // expected-note{{Original allocation}}
+  int i_aligned[40] __attribute__((aligned(16))); // expected-note{{Original allocation}}
 };
 int struct_field(struct S *s) {
   uintptr_t* p1 = (uintptr_t*)&s->u[3];  // no warning
@@ -54,15 +55,15 @@ int struct_field(struct S *s) {
 }
 
 void local_var(void) {
-  char buf[4];
-  char buf_underaligned[4] __attribute__((aligned(2)));
+  char buf[4]; // expected-note{{Original allocation}}
+  char buf_underaligned[4] __attribute__((aligned(2))); // expected-note{{Original allocation}}
   char buf_aligned[4] __attribute__((aligned(4)));
   *(int*)buf = 42; // expected-warning{{Cast increases required alignment: 1 -> 4}}
   *(int*)buf_underaligned = 42; // expected-warning{{Cast increases required alignment: 2 -> 4}}
   *(int*)buf_aligned = 42; // no warning
 }
 
-char st_buf[4];
+char st_buf[4]; // expected-note{{Original allocation}}
 char st_buf_aligned[4] __attribute__((aligned(_Alignof(int*))));
 void static_var(void) {
   *(int*)st_buf = 42; // expected-warning{{Cast increases required alignment: 1 -> 4}}

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -5,7 +5,7 @@ typedef __uintcap_t uintptr_t;
 typedef __intcap_t intptr_t;
 typedef __typeof__(sizeof(int)) size_t;
 
-double a[2048], // expected-note{{Original allocation}}
+double a[2048], // expected-note{{Original allocation of type 'double[2048]'}}
     *next = a;
 
 #define	roundup2(x, y)	(((x)+((y)-1))&(~((y)-1)))
@@ -16,15 +16,15 @@ uintptr_t *u;
 
 void foo(void *v, int *pi, void *pv) {
   char *p0 = (char*)a;
-  *(void**)p0 = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  *(void**)p0 = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
   char *p1 = (char*)roundup2((uintptr_t)p0, sizeof(void*));
   *(void**)p1 = v; // no warning
   char *p2 = p1 + 5*sizeof(double);
-  *(void**)p2 = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  *(void**)p2 = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
 
-  *(void**)pi = v; // expected-warning{{Cast increases required alignment: 4 -> 16}}
+  *(void**)pi = v; // expected-warning{{Pointer value aligned to a 4 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
   *(void**)pv = v; // no warning
-  *(void**)next = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  *(void**)next = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
 
   if (u == NULL || u == MINUS_ONE) // no warning
     return;
@@ -48,8 +48,8 @@ struct S {
 };
 int struct_field(struct S *s) {
   uintptr_t* p1 = (uintptr_t*)&s->u[3];  // no warning
-  uintptr_t* p2 = (uintptr_t*)&s->i[8];  // expected-warning{{Cast increases required alignment: 4 -> 16}}
-  uintptr_t* p3 = (uintptr_t*)&s->i_aligned[6];  // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  uintptr_t* p2 = (uintptr_t*)&s->i[8];  // expected-warning{{Pointer value aligned to a 4 byte boundary cast to type 'uintptr_t * __capability' with required capability alignment 16 bytes}}
+  uintptr_t* p3 = (uintptr_t*)&s->i_aligned[6];  // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'uintptr_t * __capability' with required capability alignment 16 bytes}}
   uintptr_t* p4 = (uintptr_t*)&s->i_aligned[4];  // no warning
   return (p4 - p3) + (p2 - p1);
 }
@@ -58,21 +58,21 @@ void local_var(void) {
   char buf[4]; // expected-note{{Original allocation}}
   char buf_underaligned[4] __attribute__((aligned(2))); // expected-note{{Original allocation}}
   char buf_aligned[4] __attribute__((aligned(4)));
-  *(int*)buf = 42; // expected-warning{{Cast increases required alignment: 1 -> 4}}
-  *(int*)buf_underaligned = 42; // expected-warning{{Cast increases required alignment: 2 -> 4}}
+  *(int*)buf = 42; // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
+  *(int*)buf_underaligned = 42; // expected-warning{{Pointer value aligned to a 2 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
   *(int*)buf_aligned = 42; // no warning
 }
 
 char st_buf[4]; // expected-note{{Original allocation}}
 char st_buf_aligned[4] __attribute__((aligned(_Alignof(int*))));
 void static_var(void) {
-  *(int*)st_buf = 42; // expected-warning{{Cast increases required alignment: 1 -> 4}}
+  *(int*)st_buf = 42; // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
   *(int*)st_buf_aligned = 42; // no warning
 }
 
 int voidptr_cast(int *ip1, int *ip2) {
   intptr_t w = (intptr_t)(ip2) | 1;
-  int b1 = (ip1 == (int*)w);  // expected-warning{{Cast increases required alignment: 1 -> 4}}
+  int b1 = (ip1 == (int*)w);  // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
   int b2 = (ip1 == (void*)w); // no-warn
   return b1 || b2;
 }

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -1,0 +1,24 @@
+// RUN: %cheri_purecap_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,alpha.cheri.CapabilityAlignmentChecker
+
+typedef __uintcap_t uintptr_t;
+
+double a[2048], *next = a;
+
+#define	roundup2(x, y)	(((x)+((y)-1))&(~((y)-1)))
+
+#define NULL (void*)0
+uintptr_t *u;
+
+void foo(void *v) {
+  char *p0 = (char*)a;
+  *(void**)p0 = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  char *p1 = (char*)roundup2((uintptr_t)p0, sizeof(void*));
+  *(void**)p1 = v; // no warn
+  char *p2 = p1 + 5*sizeof(double);
+  *(void**)p2 = v; // expected-warning{{Cast increases required alignment: 8 -> 16}}
+
+  if (u == NULL)
+    return; // no warning
+}
+

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -2,6 +2,7 @@
 // RUN:   -analyzer-checker=core,alpha.cheri.CapabilityAlignmentChecker
 
 typedef __uintcap_t uintptr_t;
+typedef __typeof__(sizeof(int)) size_t;
 
 double a[2048], *next = a;
 
@@ -25,4 +26,15 @@ void foo(void *v, int *pi, void *pv) {
 
   if (u == NULL || u == MINUS_ONE) // no warning
     return;
+}
+
+#define align_offset(A) \
+  ((((uintptr_t)(A)&7) == 0) \
+       ? 0              \
+       : ((8 - ((uintptr_t)(A)&7)) & 7))
+
+uintptr_t* bar(uintptr_t *p) {
+  uintptr_t offset = align_offset((char*)(p) + 2 *sizeof(size_t));
+  p = (uintptr_t*)((char*)p + offset); // no warning
+  return p;
 }

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -41,15 +41,16 @@ uintptr_t* bar(uintptr_t *p) {
 }
 
 struct S {
-  intptr_t u[10];
-  int i[10];
-  int i_aligned[10] __attribute__((aligned(16)));
+  intptr_t u[40];
+  int i[40];
+  int i_aligned[40] __attribute__((aligned(16)));
 };
-uintptr_t* struct_field(struct S *s) {
+int struct_field(struct S *s) {
   uintptr_t* p1 = (uintptr_t*)&s->u[3];  // no warning
-  uintptr_t* p2 = (uintptr_t*)&s->i[6];  // expected-warning{{Cast increases required alignment: 8 -> 16}}
-  uintptr_t* p3 = (uintptr_t*)&s->i_aligned[6];  // FIXME: expected-warning{{Cast increases required alignment: 8 -> 16}}
-  return p3 + (p2 - p1);
+  uintptr_t* p2 = (uintptr_t*)&s->i[8];  // expected-warning{{Cast increases required alignment: 4 -> 16}}
+  uintptr_t* p3 = (uintptr_t*)&s->i_aligned[6];  // expected-warning{{Cast increases required alignment: 8 -> 16}}
+  uintptr_t* p4 = (uintptr_t*)&s->i_aligned[4];  // no warning
+  return (p4 - p3) + (p2 - p1);
 }
 
 void local_var(void) {

--- a/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-alignment.c
@@ -67,3 +67,12 @@ void static_var(void) {
   *(int*)st_buf = 42; // expected-warning{{Cast increases required alignment: 1 -> 4}}
   *(int*)st_buf_aligned = 42; // no warning
 }
+
+int voidptr_cast(int *ip1, int *ip2) {
+  intptr_t w = (intptr_t)(ip2) | 1;
+  int b1 = (ip1 == (int*)w);  // expected-warning{{Cast increases required alignment: 1 -> 4}}
+  int b2 = (ip1 == (void*)w); // no-warn
+  return b1 || b2;
+}
+
+

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy-hybrid.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy-hybrid.c
@@ -1,11 +1,9 @@
-// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.CapabilityCopyChecker -verify %s
+// RUN: %cheri_cc1 -analyze -analyzer-checker=core,alpha.cheri.CapabilityCopyChecker -verify %s
 
-// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.ProvenanceSourceChecker,alpha.cheri.CapabilityCopyChecker -verify %s
+// Don't emit anywarnings fot hybrid mode
+// expected-no-diagnostics
 
-typedef __intcap_t intptr_t;
-typedef __uintcap_t uintptr_t;
-
-#define BLOCK_TYPE uintptr_t
+#define BLOCK_TYPE long
 #define BLOCK_SIZE sizeof(BLOCK_TYPE)
 
 typedef __typeof__(sizeof(int)) size_t;
@@ -21,29 +19,14 @@ void copy_intptr_byte(int **ppy) {
   int **ppx = &px;
   void *q = ppx;
   char *s = (char*)q; 
-  *(char*)ppy = *s; // expected-warning{{Tag-stripping store of a capability}}
+  *(char*)ppy = *s; 
 }
 
 void copy_intptr_byte2(int *px, int **ppy) {
   int **ppx = &px;
   void *q = ppx;
   char *s = (char*)q; 
-  *(char*)ppy = *s; // expected-warning{{Tag-stripping store of a capability}}
-}
-
-void copy_int_byte(int *py) {
-  int *px = &x;
-  void *q = px;
-  char *s = (char*)q;
-  *(char*)py = *s;  // no-warning: copying int value
-}
-
-void copy_intptr(int **ppy) {
-  int *px = &x;
-  int **ppx = &px;
-  void *q = ppx;
-  int **v = (int**)q;
-  *ppy = *v; // no-warning: copy as int*
+  *(char*)ppy = *s; 
 }
 
 static void swapfunc(void *a, void *b, int n) {
@@ -52,8 +35,8 @@ static void swapfunc(void *a, void *b, int n) {
   char *pj = (char *)(b);
   do {
     char t = *pi;
-    *pi++ = *pj; // expected-warning{{Tag-stripping store of a capability}}
-    *pj++ = t; // expected-warning{{Tag-stripping store of a capability}}
+    *pi++ = *pj; 
+    *pj++ = t; 
   } while (--i > 0);
 }
 
@@ -62,20 +45,11 @@ void *realloc_impl(void *ptr, size_t size) {
   if (size <= sizeof(size)) {
     size_t *mcsrc = (size_t *)(ptr);
     size_t *mcdst = (size_t *)(dst);
-    *mcdst = *mcsrc; // expected-warning{{Tag-stripping store of a capability}}
+    *mcdst = *mcsrc; 
   } else
     memmove(dst, ptr, size);
   free(ptr);
   return dst;
-}
-
-void memcpy_impl_good(void* src0, void *dst0, size_t len) {
-  char *src = src0;
-  char *dst = dst0;
-
-  if ((len < sizeof(BLOCK_TYPE)))
-    while (len--)
-      *dst++ = *src++; // no-warn
 }
 
 void memcpy_impl_unaligned(void* src0, void *dst0, size_t len) {
@@ -84,7 +58,7 @@ void memcpy_impl_unaligned(void* src0, void *dst0, size_t len) {
 
   if ((len < sizeof(BLOCK_TYPE)) || ((long)src & (BLOCK_SIZE - 1)) || ((long)dst & (BLOCK_SIZE - 1)))
     while (len--)
-      *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
+      *dst++ = *src++; 
 }
 
 void memcpy_impl_bad(void* src0, void *dst0, size_t len) {
@@ -93,7 +67,7 @@ void memcpy_impl_bad(void* src0, void *dst0, size_t len) {
 
   if (len < sizeof(BLOCK_TYPE)+1)
     while (len--)
-      *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
+      *dst++ = *src++; 
 }
 
 char voidptr_arg_load1(void *q) {
@@ -104,17 +78,6 @@ char voidptr_arg_load1(void *q) {
 void voidptr_arg_store1(void *q) {
   char *s = (char*)q; 
   *s = 42;
-}
-
-char fp_malloc() {
-  void *q = malloc(100);
-  char *s = (char*)q; // no warning
-  return *s;
-}
-
-char fp_init_str(void) {
-  char s[] = "String literal"; // no warning
-  return s[3];
 }
 
 // =====     Part of capability representation used as argument in binary operator     =====
@@ -131,7 +94,7 @@ int hash(void *key0, size_t len) {
   char *k = key0;
   int h = 0;
   while (len--)
-    h = (h << 5) + *k++;  // expected-warning{{Part of capability representation used as argument in binary operator}}
+    h = (h << 5) + *k++;  
   return h; 
 }
 
@@ -155,8 +118,8 @@ int memcmp_impl(const void* m1, const void *m2, size_t len) {
   const char *s2 = m2;
 
     while (len--)
-      if (*s1 != *s2) // expected-warning{{Part of capability representation used as argument in binary operator}} 
-          return *s1 - *s2; // expected-warning{{Part of capability representation used as argument in binary operator}}  
+      if (*s1 != *s2) 
+          return *s1 - *s2; 
     return 0;
 }
 

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy-hybrid.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy-hybrid.c
@@ -12,6 +12,8 @@ extern void * malloc(size_t);
 extern void *memmove(void *dest, const void *src, size_t n);
 extern void free(void *ptr);
 
+typedef unsigned long uintptr_t;
+
 static int x;
 
 // =====     Tag-stripping copy     =====
@@ -30,7 +32,7 @@ void copy_intptr_byte2(int *px, int **ppy) {
   *(char*)ppy = *s; 
 }
 
-static void swapfunc(void *a, void *b, int n) {
+void swapfunc(void *a, void *b, int n) {
   long i = n;
   char *pi = (char *)(a);
   char *pj = (char *)(b);
@@ -57,7 +59,9 @@ void memcpy_impl_unaligned(void* src0, void *dst0, size_t len) {
   char *src = src0;
   char *dst = dst0;
 
-  if ((len < sizeof(BLOCK_TYPE)) || ((long)src & (BLOCK_SIZE - 1)) || ((long)dst & (BLOCK_SIZE - 1)))
+  if ((len < sizeof(BLOCK_TYPE)) ||
+        ((uintptr_t)src & (BLOCK_SIZE - 1)) ||
+        ((uintptr_t)dst & (BLOCK_SIZE - 1)))
     while (len--)
       *dst++ = *src++; 
 }
@@ -81,7 +85,7 @@ void voidptr_arg_store1(void *q) {
   *s = 42;
 }
 
-// =====     Part of capability representation used as argument in binary operator     =====
+// === Part of capability representation used as argument in binary operator ===
 
 int hash_no_call(void *key0, size_t len) {
   char *k = key0;
@@ -124,7 +128,7 @@ int memcmp_impl(const void* m1, const void *m2, size_t len) {
     return 0;
 }
 
-int ptr_cmp(int *x, int *y) {
-    return memcmp_impl(&x, &y, sizeof(int*));
+int ptr_cmp(int *px, int *py) {
+    return memcmp_impl(&px, &py, sizeof(int*));
 }
 

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy-hybrid.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy-hybrid.c
@@ -1,6 +1,7 @@
-// RUN: %cheri_cc1 -analyze -analyzer-checker=core,alpha.cheri.CapabilityCopyChecker -verify %s
+// RUN: %cheri_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,cheri.CapabilityCopy
 
-// Don't emit anywarnings fot hybrid mode
+// Don't emit any warnings in hybrid mode
 // expected-no-diagnostics
 
 #define BLOCK_TYPE long

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy-purecap.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy-purecap.c
@@ -1,0 +1,164 @@
+// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.CapabilityCopyChecker -verify %s
+
+typedef __intcap_t intptr_t;
+typedef __uintcap_t uintptr_t;
+
+#define BLOCK_TYPE uintptr_t
+#define BLOCK_SIZE sizeof(BLOCK_TYPE)
+
+typedef __typeof__(sizeof(int)) size_t;
+extern void * malloc(size_t);
+extern void *memmove(void *dest, const void *src, size_t n);
+extern void free(void *ptr);
+
+static int x;
+
+// =====     Tag-stripping copy     =====
+void copy_intptr_byte(int **ppy) {
+  int *px = &x;
+  int **ppx = &px;
+  void *q = ppx;
+  char *s = (char*)q; 
+  *(char*)ppy = *s; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+void copy_intptr_byte2(int *px, int **ppy) {
+  int **ppx = &px;
+  void *q = ppx;
+  char *s = (char*)q; 
+  *(char*)ppy = *s; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+void copy_int_byte(int *py) {
+  int *px = &x;
+  void *q = px;
+  char *s = (char*)q;
+  *(char*)py = *s;  // no-warning: copying int value
+}
+
+void copy_intptr(int **ppy) {
+  int *px = &x;
+  int **ppx = &px;
+  void *q = ppx;
+  int **v = (int**)q;
+  *ppy = *v; // no-warning: copy as int*
+}
+
+static void swapfunc(void *a, void *b, int n) {
+  long i = n;
+  char *pi = (char *)(a);
+  char *pj = (char *)(b);
+  do {
+    char t = *pi;
+    *pi++ = *pj; // expected-warning{{Tag-stripping store of a capability}}
+    *pj++ = t; // expected-warning{{Tag-stripping store of a capability}}
+  } while (--i > 0);
+}
+
+void *realloc_impl(void *ptr, size_t size) {
+  void *dst = malloc(size);
+  if (size <= sizeof(size)) {
+    size_t *mcsrc = (size_t *)(ptr);
+    size_t *mcdst = (size_t *)(dst);
+    *mcdst = *mcsrc; // expected-warning{{Tag-stripping store of a capability}}
+  } else
+    memmove(dst, ptr, size);
+  free(ptr);
+  return dst;
+}
+
+void memcpy_impl_good(void* src0, void *dst0, size_t len) {
+  char *src = src0;
+  char *dst = dst0;
+
+  if ((len < sizeof(BLOCK_TYPE)))
+    while (len--)
+      *dst++ = *src++; // no-warn
+}
+
+void memcpy_impl_unaligned(void* src0, void *dst0, size_t len) {
+  char *src = src0;
+  char *dst = dst0;
+
+  if ((len < sizeof(BLOCK_TYPE)) || ((long)src & (BLOCK_SIZE - 1)) || ((long)dst & (BLOCK_SIZE - 1)))
+    while (len--)
+      *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+void memcpy_impl_bad(void* src0, void *dst0, size_t len) {
+  char *src = src0;
+  char *dst = dst0;
+
+  if (len < sizeof(BLOCK_TYPE)+1)
+    while (len--)
+      *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+char voidptr_arg_load1(void *q) {
+  char *s = (char*)q; 
+  return *s; 
+}
+
+void voidptr_arg_store1(void *q) {
+  char *s = (char*)q; 
+  *s = 42;
+}
+
+char fp_malloc() {
+  void *q = malloc(100);
+  char *s = (char*)q; // no warning
+  return *s;
+}
+
+char fp_init_str(void) {
+  char s[] = "String literal"; // no warning
+  return s[3];
+}
+
+// =====     Part of capability representation used as argument in binary operator     =====
+
+int hash_no_call(void *key0, size_t len) {
+  char *k = key0;
+  int h = 0;
+  while (len--)
+    h = (h << 5) + *k++;
+  return h;
+}
+
+int hash(void *key0, size_t len) {
+  char *k = key0;
+  int h = 0;
+  while (len--)
+    h = (h << 5) + *k++;  // expected-warning{{Part of capability representation used as argument in binary operator}}
+  return h; 
+}
+
+int ptr_hash(void) {
+  int *p = &x;
+  return hash(&p, sizeof(int*));
+}
+
+int memcmp_impl_no_call(const void* m1, const void *m2, size_t len) {
+  const char *s1 = m1;
+  const char *s2 = m2;
+
+  while (len--)
+    if (*s1 != *s2)  
+      return *s1 - *s2;  
+  return 0;
+}
+
+int memcmp_impl(const void* m1, const void *m2, size_t len) {
+  const char *s1 = m1;
+  const char *s2 = m2;
+
+    while (len--)
+      if (*s1 != *s2) // expected-warning{{Part of capability representation used as argument in binary operator}} 
+          return *s1 - *s2; // expected-warning{{Part of capability representation used as argument in binary operator}}  
+    return 0;
+}
+
+int ptr_cmp(int *x, int *y) {
+    return memcmp_impl(&x, &y, sizeof(int*));
+}
+

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy-purecap.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy-purecap.c
@@ -1,4 +1,5 @@
-// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.CapabilityCopyChecker -verify %s
+// RUN: %cheri_purecap_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,cheri.CapabilityCopy
 
 typedef __intcap_t intptr_t;
 typedef __uintcap_t uintptr_t;

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy.c
@@ -1,0 +1,148 @@
+// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.CapabilityCopyChecker -verify %s
+
+// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.ProvenanceSourceChecker,alpha.cheri.CapabilityCopyChecker -verify %s
+
+typedef __intcap_t intptr_t;
+typedef __uintcap_t uintptr_t;
+
+#define BLOCK_TYPE uintptr_t
+#define BLOCK_SIZE sizeof(BLOCK_TYPE)
+
+typedef __typeof__(sizeof(int)) size_t;
+extern void * malloc(size_t);
+extern void *memmove(void *dest, const void *src, size_t n);
+extern void free(void *ptr);
+
+static int x;
+
+// =====     Tag-stripping copy     =====
+void copy_intptr_byte(int **ppy) {
+  int *px = &x;
+  int **ppx = &px;
+  void *q = ppx;
+  char *s = (char*)q; 
+  *(char*)ppy = *s; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+void copy_intptr_byte2(int *px, int **ppy) {
+  int **ppx = &px;
+  void *q = ppx;
+  char *s = (char*)q; 
+  *(char*)ppy = *s; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+void copy_int_byte(int *py) {
+  int *px = &x;
+  void *q = px;
+  char *s = (char*)q;
+  *(char*)py = *s;  // no-warning: copying int value
+}
+
+void copy_intptr(int **ppy) {
+  int *px = &x;
+  int **ppx = &px;
+  void *q = ppx;
+  int **v = (int**)q;
+  *ppy = *v; // no-warning: copy as int*
+}
+
+void swapfunc(void *a, void *b, int n) {
+  long i = (n);
+  char *pi = (char *)(a);
+  char *pj = (char *)(b);
+  do {
+    char t = *pi;
+    *pi++ = *pj; // expected-warning{{Tag-stripping store of a capability}}
+    *pj++ = t; // expected-warning{{Tag-stripping store of a capability}}
+  } while (--i > 0);
+}
+
+void *realloc_impl(void *ptr, size_t size) {
+  void *dst = malloc(size);
+  if (size <= sizeof(size)) {
+    size_t *mcsrc = (size_t *)(ptr);
+    size_t *mcdst = (size_t *)(dst);
+    *mcdst = *mcsrc; // expected-warning{{Tag-stripping store of a capability}}
+  } else
+    memmove(dst, ptr, size);
+  free(ptr);
+  return dst;
+}
+
+void memcpy_impl(void* src0, void *dst0, size_t len) {
+  char *src = src0;
+  char *dst = dst0;
+
+  if (len < sizeof(BLOCK_TYPE))
+    while (len--)
+      *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
+}
+
+char voidptr_arg_load1(void *q) {
+  char *s = (char*)q; 
+  return *s; 
+}
+
+void voidptr_arg_store1(void *q) {
+  char *s = (char*)q; 
+  *s = 42;
+}
+
+char fp_malloc() {
+  void *q = malloc(100);
+  char *s = (char*)q; // no warning
+  return *s;
+}
+
+char fp_init_str(void) {
+  char s[] = "String literal"; // no warning
+  return s[3];
+}
+
+// =====     Part of capability representation used as argument in binary operator     =====
+
+int hash_no_call(void *key0, size_t len) {
+  char *k = key0;
+  int h = 0;
+  while (len--)
+    h = (h << 5) + *k++;
+  return h;
+}
+
+int hash(void *key0, size_t len) {
+  char *k = key0;
+  int h = 0;
+  while (len--)
+    h = (h << 5) + *k++;  // expected-warning{{Part of capability representation used as argument in binary operator}}
+  return h; 
+}
+
+int ptr_hash(void) {
+  int *p = &x;
+  return hash(&p, sizeof(int*));
+}
+
+int memcmp_impl_no_call(const void* m1, const void *m2, size_t len) {
+  const char *s1 = m1;
+  const char *s2 = m2;
+
+  while (len--)
+    if (*s1 != *s2)  
+      return *s1 - *s2;  
+  return 0;
+}
+
+int memcmp_impl(const void* m1, const void *m2, size_t len) {
+  const char *s1 = m1;
+  const char *s2 = m2;
+
+    while (len--)
+      if (*s1 != *s2) // expected-warning{{Part of capability representation used as argument in binary operator}} 
+          return *s1 - *s2; // expected-warning{{Part of capability representation used as argument in binary operator}}  
+    return 0;
+}
+
+int ptr_cmp(int *x, int *y) {
+    return memcmp_impl(&x, &y, sizeof(int*));
+}
+

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy.c
@@ -46,8 +46,8 @@ void copy_intptr(int **ppy) {
   *ppy = *v; // no-warning: copy as int*
 }
 
-void swapfunc(void *a, void *b, int n) {
-  long i = (n);
+static void swapfunc(void *a, void *b, int n) {
+  long i = n;
   char *pi = (char *)(a);
   char *pj = (char *)(b);
   do {
@@ -69,11 +69,20 @@ void *realloc_impl(void *ptr, size_t size) {
   return dst;
 }
 
-void memcpy_impl(void* src0, void *dst0, size_t len) {
+void memcpy_impl_good(void* src0, void *dst0, size_t len) {
   char *src = src0;
   char *dst = dst0;
 
-  if (len < sizeof(BLOCK_TYPE))
+  if ((len < sizeof(BLOCK_TYPE)) || ((long)src & (BLOCK_SIZE - 1)) || ((long)dst & (BLOCK_SIZE - 1)))
+    while (len--)
+      *dst++ = *src++; // no-warning
+}
+
+void memcpy_impl_bad(void* src0, void *dst0, size_t len) {
+  char *src = src0;
+  char *dst = dst0;
+
+  if (len < sizeof(BLOCK_TYPE)+1)
     while (len--)
       *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
 }

--- a/clang/test/Analysis/Checkers/CHERI/capability-copy.c
+++ b/clang/test/Analysis/Checkers/CHERI/capability-copy.c
@@ -73,9 +73,18 @@ void memcpy_impl_good(void* src0, void *dst0, size_t len) {
   char *src = src0;
   char *dst = dst0;
 
+  if ((len < sizeof(BLOCK_TYPE)))
+    while (len--)
+      *dst++ = *src++; // no-warn
+}
+
+void memcpy_impl_unaligned(void* src0, void *dst0, size_t len) {
+  char *src = src0;
+  char *dst = dst0;
+
   if ((len < sizeof(BLOCK_TYPE)) || ((long)src & (BLOCK_SIZE - 1)) || ((long)dst & (BLOCK_SIZE - 1)))
     while (len--)
-      *dst++ = *src++; // no-warning
+      *dst++ = *src++; // expected-warning{{Tag-stripping store of a capability}}
 }
 
 void memcpy_impl_bad(void* src0, void *dst0, size_t len) {

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -1,4 +1,5 @@
-// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.ProvenanceSourceChecker -verify %s
+// RUN: %cheri_purecap_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,cheri.ProvenanceSource
 
 typedef __intcap_t intptr_t;
 typedef __uintcap_t uintptr_t;

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -132,7 +132,7 @@ uintptr_t align_down(void *p, size_t alignment) {
 char* ptr_diff(char *s1, char *s2) {
   intptr_t a = (intptr_t)s1;
   intptr_t b = (intptr_t)s2;
-  intptr_t d = a - b; // expected-warning{{Pointer difference as capability}}
+  intptr_t d = a - b;
   return (char*)d; // expected-warning{{NULL-derived capability used as pointer}}
 }
 

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -185,8 +185,14 @@ int fp5(char *a, unsigned x) {
   return (char*)p - (char*)q;
 }
 
-char* const2ptr(int *p, int x) {
+char* const2ptr(void) {
   return (char*)(-1);
+}
+
+void *fn3(size_t x, int y) {
+  intptr_t a = (intptr_t)x;
+  a += y;
+  return (void*)a; // expected-warning{{NULL-derived capability used as pointer}}
 }
 
 //------------------- Inter-procedural warnings ---------------------

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -107,7 +107,7 @@ char add_var(int *p, int x, int c) {
 
 int * null_derived(int x) {
   intptr_t u = (intptr_t)x;
-  return (int*)u; // expected-warning{{Invalid capability is used as pointer}}
+  return (int*)u; // expected-warning{{NULL-derived capability used as pointer}}
 }
 
 uintptr_t fn1(char *str, int f) {
@@ -133,14 +133,14 @@ char* ptr_diff(char *s1, char *s2) {
   intptr_t a = (intptr_t)s1;
   intptr_t b = (intptr_t)s2;
   intptr_t d = a - b; // expected-warning{{Pointer difference as capability}}
-  return (char*)d; // expected-warning{{Invalid capability is used as pointer}}
+  return (char*)d; // expected-warning{{NULL-derived capability used as pointer}}
 }
 
 char* ptr_diff2(int x, char *s) {
   intptr_t a = (intptr_t)x;
   intptr_t b = (intptr_t)s;
   intptr_t d = a - b;
-  return (char*)d; // expected-warning{{Invalid capability is used as pointer}}
+  return (char*)d; // expected-warning{{NULL-derived capability used as pointer}}
 }
 
 void *fp2(char *p) {
@@ -175,13 +175,13 @@ uintptr_t fn2(char *a, char *b) {
 
 char *ptrdiff(char *a, unsigned x) {
   intptr_t ip = ((ptrdiff_t)a | (intptr_t)x);
-  char *p = (char*) ip; // expected-warning{{Invalid capability is used as pointer}}
+  char *p = (char*) ip; // expected-warning{{NULL-derived capability used as pointer}}
   return p;
 }
 
 int fp5(char *a, unsigned x) {
   void *p = (void*)(uintptr_t)a;
-  void *q = (void*)(uintptr_t)x; // common pattern, don't fire warning
+  void *q = (void*)(uintptr_t)x; // expected-warning{{cheri_no_provenance capability used as pointer}}
   return (char*)p - (char*)q;
 }
 

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -27,7 +27,7 @@ char right_prov(unsigned d, char *p) {
   uintptr_t a = d;
   uintptr_t b = (uintptr_t)p;
 
-  uintptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
+  uintptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance. Note: along this path, LHS was derived from NULL, RHS was derived from pointer. Currently, provenance is inherited from LHS, therefore result capability will be invalid}}
                       // expected-warning@-1{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 
   // CHECK-FIXES:      intptr_t s = (ptrdiff_t)(a) + b;
@@ -39,7 +39,7 @@ char both_prov(int* d, char *p) {
   intptr_t a = (intptr_t)d;
   intptr_t b = (intptr_t)p;
 
-  intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from pointers}}
+  intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance. Note: along this path, LHS and RHS were derived from pointers. Result capability will be derived from LHS by default. This code may need to be rewritten for CHERI}}
                       // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
   return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
@@ -64,7 +64,7 @@ char right_prov_cond(int d, char *p, int x) {
     b = x;
 
   intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from NULL}}
-                      // expected-warning@-1{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
+                      // expected-warning@-1{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance. Note: along this path, LHS was derived from NULL, RHS was derived from pointer. Currently, provenance is inherited from LHS, therefore result capability will be invalid}}
                       // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 
   return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
@@ -152,7 +152,7 @@ intptr_t fp3(char *s1, char *s2) {
   intptr_t a __attribute__((cheri_no_provenance));
   a = (intptr_t)s1;
   intptr_t b = (intptr_t)s2;
-  return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from pointers}} FIXME: expect no warning
+  return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance. Note: along this path, LHS and RHS were derived from pointers. Result capability will be derived from LHS by default. This code may need to be rewritten for CHERI}} FIXME: expect no warning
 }
 
 uintptr_t fp4(char *str, int f) {
@@ -163,7 +163,7 @@ uintptr_t fn2(char *a, char *b) {
   uintptr_t msk = sizeof (long) - 1;
 
   uintptr_t x = (uintptr_t)a | (uintptr_t)b;
-  // expected-warning@-1{{Result of '|' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS and RHS were derived from pointers}}
+  // expected-warning@-1{{Result of '|' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance. Note: along this path, LHS and RHS were derived from pointers. Result capability will be derived from LHS by default. This code may need to be rewritten for CHERI}}
   // expected-warning@-2{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 
   int ma = x & msk;
@@ -209,7 +209,7 @@ intptr_t foo(int d) {
 }
 
 intptr_t add(intptr_t a, intptr_t b) {
-  return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
+  return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance. Note: along this path, LHS was derived from NULL, RHS was derived from pointer. Currently, provenance is inherited from LHS, therefore result capability will be invalid}}
                 // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 
   // CHECK-FIXES:     return (ptrdiff_t)(a) + b;

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -38,7 +38,7 @@ char no_prov(int d, char p) {
   intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from NULL}}
                       // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 
-  return *(char*)s; // expected-warning{{NULL-derived capability is used as pointer}}
+  return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
 
 char right_prov_cond(int d, char *p, int x) {
@@ -54,7 +54,6 @@ char right_prov_cond(int d, char *p, int x) {
                       // expected-warning@-1{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
                       // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
   return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
-                   // expected-warning@-1{{NULL-derived capability is used as pointer}}
 }
 
 intptr_t no_bug(int *p, intptr_t *u) {
@@ -88,7 +87,7 @@ char add_var(int *p, int x, int c) {
 
 int * null_derived(int x) {
   intptr_t u = (intptr_t)x;
-  return (int*)u; // expected-warning{{NULL-derived capability is used as pointer}}
+  return (int*)u; // expected-warning{{Invalid capability is used as pointer}}
 }
 
 uintptr_t fn1(char *str, int f) {
@@ -99,10 +98,18 @@ uintptr_t fn1(char *str, int f) {
     // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 }
 
-int fp1(char *s1, char *s2) {
+char* ptr_diff(char *s1, char *s2) {
   intptr_t a = (intptr_t)s1;
   intptr_t b = (intptr_t)s2;
-  return a - b;
+  intptr_t d = a - b; // expected-warning{{Pointer difference as capability}}
+  return (char*)d; // expected-warning{{Invalid capability is used as pointer}}
+}
+
+char* ptr_diff2(int x, char *s) {
+  intptr_t a = (intptr_t)x;
+  intptr_t b = (intptr_t)s;
+  intptr_t d = a - b;
+  return (char*)d; // expected-warning{{Invalid capability is used as pointer}}
 }
 
 void *fp2(char *p) {
@@ -137,7 +144,7 @@ uintptr_t fn2(char *a, char *b) {
 
 char *ptrdiff(char *a, unsigned x) {
   intptr_t ip = ((ptrdiff_t)a | (intptr_t)x);
-  char *p = (char*) ip; // expected-warning{{NULL-derived capability is used as pointer}}
+  char *p = (char*) ip; // expected-warning{{Invalid capability is used as pointer}}
   return p;
 }
 

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -4,6 +4,7 @@
 typedef __intcap_t intptr_t;
 typedef __uintcap_t uintptr_t;
 typedef long int ptrdiff_t;
+typedef __typeof__(sizeof(int)) size_t;
 
 char left_prov(int d, char *p) {
   intptr_t a = d;
@@ -97,6 +98,13 @@ uintptr_t fn1(char *str, int f) {
     return ((intptr_t)str & x);
     // expected-warning@-1{{Result of '&' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
     // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+}
+
+uintptr_t align_down(void *p, size_t alignment) {
+    uintptr_t sz = (uintptr_t)p;
+    uintptr_t mask = alignment - 1;
+    return (sz & ~mask); // expected-warning{{Result of '&' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
+    // expected-warning@-1{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
 }
 
 char* ptr_diff(char *s1, char *s2) {

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -1,5 +1,10 @@
 // RUN: %cheri_purecap_cc1 -analyze -verify %s \
 // RUN:   -analyzer-checker=core,cheri.ProvenanceSource
+// RUN: %check_analyzer_fixit %s %t \
+// RUN:   -triple mips64-unknown-freebsd -target-abi purecap -target-cpu cheri128 -cheri-size 128 \
+// RUN:   -analyzer-checker=core,cheri.ProvenanceSource \
+// RUN:   -analyzer-config cheri.ProvenanceSource:ShowFixIts=true \
+// RUN:   -verify=non-nested,nested
 
 typedef __intcap_t intptr_t;
 typedef __uintcap_t uintptr_t;
@@ -12,6 +17,9 @@ char left_prov(int d, char *p) {
 
   intptr_t s = b + a; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
                       // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  // CHECK-FIXES:      intptr_t s = b + (ptrdiff_t)(a);
+
   return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
 
@@ -21,6 +29,9 @@ char right_prov(unsigned d, char *p) {
 
   uintptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
                       // expected-warning@-1{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  // CHECK-FIXES:      intptr_t s = (ptrdiff_t)(a) + b;
+
   return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
 
@@ -55,6 +66,7 @@ char right_prov_cond(int d, char *p, int x) {
   intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from NULL}}
                       // expected-warning@-1{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
                       // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
   return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
 
@@ -75,6 +87,9 @@ char add_const(int *p, int x) {
 
   intptr_t s =  a | b; // expected-warning{{Result of '|' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
                        // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  // CHECK-FIXES:      intptr_t s =  a | (ptrdiff_t)(b);
+
   return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
 
@@ -84,6 +99,9 @@ char add_var(int *p, int x, int c) {
 
   intptr_t s =  a | b; // expected-warning{{Result of '|' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
                        // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  // CHECK-FIXES:      intptr_t s =  a | (ptrdiff_t)(b);
+
   return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
 }
 
@@ -98,6 +116,8 @@ uintptr_t fn1(char *str, int f) {
     return ((intptr_t)str & x);
     // expected-warning@-1{{Result of '&' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
     // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+    // CHECK-FIXES:     return ((intptr_t)str & (ptrdiff_t)(x));
 }
 
 uintptr_t align_down(void *p, size_t alignment) {
@@ -105,6 +125,8 @@ uintptr_t align_down(void *p, size_t alignment) {
     uintptr_t mask = alignment - 1;
     return (sz & ~mask); // expected-warning{{Result of '&' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
     // expected-warning@-1{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+    // CHECK-FIXES:      return (sz & (size_t)(~mask));
 }
 
 char* ptr_diff(char *s1, char *s2) {
@@ -182,11 +204,15 @@ intptr_t foo(int d) {
 
   return b + a; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
                 // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  // CHECK-FIXES:     return b + (ptrdiff_t)(a);
 }
 
 intptr_t add(intptr_t a, intptr_t b) {
   return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
                 // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  // CHECK-FIXES:     return (ptrdiff_t)(a) + b;
 }
 
 intptr_t bar(int d) {

--- a/clang/test/Analysis/Checkers/CHERI/provenance-source.c
+++ b/clang/test/Analysis/Checkers/CHERI/provenance-source.c
@@ -1,0 +1,181 @@
+// RUN: %cheri_purecap_cc1 -analyze -analyzer-checker=core,alpha.cheri.ProvenanceSourceChecker -verify %s
+
+typedef __intcap_t intptr_t;
+typedef __uintcap_t uintptr_t;
+typedef long int ptrdiff_t;
+
+char left_prov(int d, char *p) {
+  intptr_t a = d;
+  intptr_t b = (intptr_t)p;
+
+  intptr_t s = b + a; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
+                      // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+  return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
+}
+
+char right_prov(unsigned d, char *p) {
+  uintptr_t a = d;
+  uintptr_t b = (uintptr_t)p;
+
+  uintptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
+                      // expected-warning@-1{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+  return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
+}
+
+char both_prov(int* d, char *p) {
+  intptr_t a = (intptr_t)d;
+  intptr_t b = (intptr_t)p;
+
+  intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from pointers}}
+                      // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+  return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
+}
+
+char no_prov(int d, char p) {
+  intptr_t a = (intptr_t)d;
+  intptr_t b = (intptr_t)p;
+
+  intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from NULL}}
+                      // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  return *(char*)s; // expected-warning{{NULL-derived capability is used as pointer}}
+}
+
+char right_prov_cond(int d, char *p, int x) {
+  intptr_t a = d;
+
+  intptr_t b;
+  if (d > 42)
+    b = (intptr_t)p;
+  else
+    b = x;
+
+  intptr_t s = a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from NULL}}
+                      // expected-warning@-1{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
+                      // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+  return *(char*)s;// expected-warning{{Capability with ambiguous provenance is used as pointer}}
+                   // expected-warning@-1{{NULL-derived capability is used as pointer}}
+}
+
+intptr_t no_bug(int *p, intptr_t *u) {
+  int *d = p + 20;
+
+  intptr_t a = (intptr_t)d;
+  *u = a;
+  intptr_t b = (intptr_t)p;
+
+  a = b;
+  return a;
+}
+
+char add_const(int *p, int x) {
+  intptr_t a = (intptr_t)p + 42;
+  intptr_t b = (intptr_t)x;
+
+  intptr_t s =  a | b; // expected-warning{{Result of '|' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
+                       // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+  return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
+}
+
+char add_var(int *p, int x, int c) {
+  intptr_t a = (intptr_t)p + c;
+  intptr_t b = (intptr_t)x;
+
+  intptr_t s =  a | b; // expected-warning{{Result of '|' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
+                       // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+  return *(char*)s; // expected-warning{{Capability with ambiguous provenance is used as pointer}}
+}
+
+int * null_derived(int x) {
+  intptr_t u = (intptr_t)x;
+  return (int*)u; // expected-warning{{NULL-derived capability is used as pointer}}
+}
+
+uintptr_t fn1(char *str, int f) {
+    str++;
+    intptr_t x = f;
+    return ((intptr_t)str & x);
+    // expected-warning@-1{{Result of '&' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
+    // expected-warning@-2{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+}
+
+int fp1(char *s1, char *s2) {
+  intptr_t a = (intptr_t)s1;
+  intptr_t b = (intptr_t)s2;
+  return a - b;
+}
+
+void *fp2(char *p) {
+  void *a = (void*)(uintptr_t)p;
+  return a;
+}
+
+intptr_t fp3(char *s1, char *s2) {
+  intptr_t a __attribute__((cheri_no_provenance));
+  a = (intptr_t)s1;
+  intptr_t b = (intptr_t)s2;
+  return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS and RHS were derived from pointers}} FIXME: expect no warning
+}
+
+uintptr_t fp4(char *str, int f) {
+  return ((intptr_t)str & (intptr_t)(f));
+}
+
+uintptr_t fn2(char *a, char *b) {
+  uintptr_t msk = sizeof (long) - 1;
+
+  uintptr_t x = (uintptr_t)a | (uintptr_t)b;
+  // expected-warning@-1{{Result of '|' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, LHS and RHS were derived from pointers}}
+  // expected-warning@-2{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  int ma = x & msk;
+  // expected-warning@-1{{Result of '&' on capability type 'uintptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'size_t'. Note: along this path, RHS was derived from NULL}}
+  // expected-warning@-2{{binary expression on capability types 'uintptr_t' (aka 'unsigned __intcap') and 'uintptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+
+  return ma;
+}
+
+char *ptrdiff(char *a, unsigned x) {
+  intptr_t ip = ((ptrdiff_t)a | (intptr_t)x);
+  char *p = (char*) ip; // expected-warning{{NULL-derived capability is used as pointer}}
+  return p;
+}
+
+int fp5(char *a, unsigned x) {
+  void *p = (void*)(uintptr_t)a;
+  void *q = (void*)(uintptr_t)x; // common pattern, don't fire warning
+  return (char*)p - (char*)q;
+}
+
+char* const2ptr(int *p, int x) {
+  return (char*)(-1);
+}
+
+//------------------- Inter-procedural warnings ---------------------
+
+static int *p;
+
+intptr_t get_ptr(void) {
+  return (intptr_t)p;
+
+}
+
+intptr_t foo(int d) {
+  intptr_t a = d;
+  intptr_t b = get_ptr();
+
+  return b + a; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from pointer, RHS was derived from NULL}}
+                // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+}
+
+intptr_t add(intptr_t a, intptr_t b) {
+  return a + b; // expected-warning{{Result of '+' on capability type 'intptr_t'; it is unclear which side should be used as the source of provenance; consider indicating the provenance-carrying argument explicitly by casting the other argument to 'ptrdiff_t'. Note: along this path, LHS was derived from NULL, RHS was derived from pointer}}
+                // expected-warning@-1{{binary expression on capability types 'intptr_t' (aka '__intcap') and 'intptr_t'; it is not clear which should be used as the source of provenance; currently provenance is inherited from the left-hand side}}
+}
+
+intptr_t bar(int d) {
+  intptr_t a = d;
+  intptr_t b = get_ptr();
+
+  return add(a, b);
+}

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-mips64.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-mips64.c
@@ -1,0 +1,32 @@
+// RUN: %cheri_purecap_cc1 -analyze -verify %s \
+// RUN:   -analyzer-checker=core,cheri.SubObjectRepresentability
+
+struct R1 {
+  struct {
+    struct {
+      char c;
+      char a[0x9FF]; // no warn
+    } f1good;
+    struct {
+      char c; // expected-note{{}}
+      char a[0x1000]; // expected-warning{{Field 'a' of type 'char[4096]' (size 4096) requires 8 byte alignment for precise bounds; field offset is 1}}
+    } f2bad;
+    struct {
+      int c[2];
+      char a[0x1000]; // no warn
+    } f3good __attribute__((aligned(8)));
+  } s2;
+} s1;
+
+struct S2 {
+  int x[3];
+  int *px;
+};
+
+struct R2 {
+  char x[0x50]; // expected-note{{16/80}}
+  struct S2 s2; // expected-note{{32/32 bytes exposed (may expose capability!)}}
+  char c; // expected-note{{1}}
+  char a[0x8000]; // expected-warning{{Field 'a' of type 'char[32768]' (size 32768) requires 64 byte alignment for precise bounds; field offset is 113 (aligned to 1); Current bounds: 64-32896}}
+  char y[32]; // expected-note{{15/32}}
+};

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
@@ -11,7 +11,7 @@ struct R1 {
       char a[0x3FFF]; // no warn
     } f1good;
     struct {
-      char c; // expected-note{{}}
+      char c;
       char a[0x4000]; // expected-warning{{Field 'a' of type 'char[16384]' (size 16384) requires 8 byte alignment for precise bounds; field offset is 1}}
     } f2bad;
     struct {
@@ -27,9 +27,9 @@ struct S2 {
 };
 
 struct R2 {
-  char x[0x50]; // expected-note{{16/80}}
-  struct S2 s2; // expected-note{{32/32 bytes exposed (may expose capability!)}}
-  char c; // expected-note{{1}}
+  char x[0x50];
+  struct S2 s2;
+  char c;
   char a[0x8000]; // expected-warning{{Field 'a' of type 'char[32768]'}}
-  char y[32]; // expected-note{{15/32}}
+  char y[32];
 };

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
@@ -11,7 +11,7 @@ struct R1 {
       char a[0x3FFF]; // no warn
     } f1good;
     struct {
-      char c;
+      char c; // expected-note{{}}
       char a[0x4000]; // expected-warning{{Field 'a' of type 'char[16384]' (size 16384) requires 8 byte alignment for precise bounds; field offset is 1}}
     } f2bad;
     struct {
@@ -20,3 +20,16 @@ struct R1 {
     } f3good __attribute__((aligned(8)));
   } s2;
 } s1;
+
+struct S2 {
+  int x[3];
+  int *px;
+};
+
+struct R2 {
+  char x[0x50]; // expected-note{{16/80}}
+  struct S2 s2; // expected-note{{32/32 bytes exposed (may expose capability!)}}
+  char c; // expected-note{{1}}
+  char a[0x8000]; // expected-warning{{Field 'a' of type 'char[32768]'}}
+  char y[32]; // expected-note{{15/32}}
+};

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
@@ -11,7 +11,7 @@ struct R1 {
       char a[0x3FFF]; // no warn
     } f1good;
     struct {
-      char c;
+      char c; // expected-note{{}}
       char a[0x4000]; // expected-warning{{Field 'a' of type 'char[16384]' (size 16384) requires 8 byte alignment for precise bounds; field offset is 1}}
     } f2bad;
     struct {
@@ -27,9 +27,9 @@ struct S2 {
 };
 
 struct R2 {
-  char x[0x50];
-  struct S2 s2;
-  char c;
-  char a[0x8000]; // expected-warning{{Field 'a' of type 'char[32768]'}}
-  char y[32];
+  char x[0x50]; // expected-note{{16/80}}
+  struct S2 s2; // expected-note{{32/32 bytes exposed (may expose capability!)}}
+  char c; // expected-note{{1}}
+  char a[0x20000]; // expected-warning{{Field 'a' of type 'char[131072]' (size 131072) requires 64 byte alignment for precise bounds; field offset is 113 (aligned to 1); Current bounds: 64-131200}}
+  char y[32]; // expected-note{{15/32}}
 };

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
@@ -2,7 +2,7 @@
 
 // XFAIL: *
 // RUN: %clang_cc1 -triple aarch64-none-elf -target-feature +morello -target-feature +c64 -target-abi purecap \
-// RUN:            -analyze -analyzer-checker=core,alpha.cheri.SubObjectRepresentability -verify %s
+// RUN:            -analyze -analyzer-checker=core,cheri.SubObjectRepresentability -verify %s
 
 struct R1 {
   struct {

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-morello.c
@@ -1,0 +1,22 @@
+// Test for Morello
+
+// XFAIL: *
+// RUN: %clang_cc1 -triple aarch64-none-elf -target-feature +morello -target-feature +c64 -target-abi purecap \
+// RUN:            -analyze -analyzer-checker=core,alpha.cheri.SubObjectRepresentability -verify %s
+
+struct R1 {
+  struct {
+    struct {
+      char c;
+      char a[0x3FFF]; // no warn
+    } f1good;
+    struct {
+      char c;
+      char a[0x4000]; // expected-warning{{Field 'a' of type 'char[16384]' (size 16384) requires 8 byte alignment for precise bounds; field offset is 1}}
+    } f2bad;
+    struct {
+      int c[2];
+      char a[0x4000]; // no warn
+    } f3good __attribute__((aligned(8)));
+  } s2;
+} s1;

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -4,6 +4,7 @@
 // CHECK:      [config]
 // CHECK-NEXT: add-pop-up-notes = true
 // CHECK-NEXT: aggressive-binary-operation-simplification = false
+// CHECK-NEXT: alpha.cheri.Allocation:ReportForUnknownAllocations = true
 // CHECK-NEXT: alpha.clone.CloneChecker:IgnoredFilesPattern = ""
 // CHECK-NEXT: alpha.clone.CloneChecker:MinimumCloneComplexity = 50
 // CHECK-NEXT: alpha.clone.CloneChecker:ReportNormalClones = true

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -27,6 +27,7 @@
 // CHECK-NEXT: cfg-rich-constructors = true
 // CHECK-NEXT: cfg-scopes = false
 // CHECK-NEXT: cfg-temporary-dtors = true
+// CHECK-NEXT: cheri.ProvenanceSource:ShowFixIts = false
 // CHECK-NEXT: core.BitwiseShift:Pedantic = false
 // CHECK-NEXT: core.CallAndMessage:ArgInitializedness = true
 // CHECK-NEXT: core.CallAndMessage:ArgPointeeInitializedness = false

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -27,7 +27,7 @@
 // CHECK-NEXT: cfg-rich-constructors = true
 // CHECK-NEXT: cfg-scopes = false
 // CHECK-NEXT: cfg-temporary-dtors = true
-// CHECK-NEXT: cheri.CapabilityCopy:ReportForCharPtr = true
+// CHECK-NEXT: cheri.CapabilityCopy:ReportForCharPtr = false
 // CHECK-NEXT: cheri.ProvenanceSource:ReportForAmbiguousProvenance = true
 // CHECK-NEXT: cheri.ProvenanceSource:ShowFixIts = false
 // CHECK-NEXT: core.BitwiseShift:Pedantic = false

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -27,6 +27,7 @@
 // CHECK-NEXT: cfg-rich-constructors = true
 // CHECK-NEXT: cfg-scopes = false
 // CHECK-NEXT: cfg-temporary-dtors = true
+// CHECK-NEXT: cheri.CapabilityCopy:ReportForCharPtr = true
 // CHECK-NEXT: cheri.ProvenanceSource:ShowFixIts = false
 // CHECK-NEXT: core.BitwiseShift:Pedantic = false
 // CHECK-NEXT: core.CallAndMessage:ArgInitializedness = true

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -28,6 +28,7 @@
 // CHECK-NEXT: cfg-scopes = false
 // CHECK-NEXT: cfg-temporary-dtors = true
 // CHECK-NEXT: cheri.CapabilityCopy:ReportForCharPtr = true
+// CHECK-NEXT: cheri.ProvenanceSource:ReportForAmbiguousProvenance = true
 // CHECK-NEXT: cheri.ProvenanceSource:ShowFixIts = false
 // CHECK-NEXT: core.BitwiseShift:Pedantic = false
 // CHECK-NEXT: core.CallAndMessage:ArgInitializedness = true

--- a/clang/test/Analysis/html_diagnostics/notes-links.cpp
+++ b/clang/test/Analysis/html_diagnostics/notes-links.cpp
@@ -18,5 +18,5 @@ void f() {
 
 //CHECK:      <tr><td class="rowname">Note:</td>
 //CHECK-NOT:  <a href="#Note0">
-//CHECK-SAME: <a href="#Note1">line 9, column 7</a>
-//CHECK-SAME: <a href="#Note2">line 10, column 7</a>
+//CHECK-SAME: <a href="#Note2">line 9, column 7</a>
+//CHECK-SAME: <a href="#Note3">line 10, column 7</a>

--- a/clang/test/Analysis/out-of-bounds-notes.c
+++ b/clang/test/Analysis/out-of-bounds-notes.c
@@ -29,11 +29,7 @@ int assumingBothPointerToMiddle(int arg) {
   // will speak about the "byte offset" measured from the beginning of the TenElements.
   int *p = TenElements + 2;
   int a = p[arg];
-  // FIXME: The following note does not appear:
-  //  {{Assuming byte offset is non-negative and less than 40, the extent of 'TenElements'}}
-  // It seems that the analyzer "gives up" modeling this pointer arithmetics
-  // and says that `p[arg]` is just an UnknownVal (instead of calculating that
-  // it's equivalent to `TenElements[2+arg]`).
+  // expected-note@-1 {{Assuming byte offset is non-negative and less than 40, the extent of 'TenElements'}}
 
   int b = TenElements[arg]; // This is normal access, and only the lower bound is new.
   // expected-note@-1 {{Assuming index is non-negative}}

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -112,6 +112,12 @@ void copy_through_unaligned(intptr_t *src, void *dst, size_t n) {
   // expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
 }
 
+void after_cap_data(int n, int D) {
+  int **p = malloc(100);
+  p[0] = &((int*)&p[D])[0];  // 2D matrix
+  memcpy(c_buf, p[0], n); // no warn
+}
+
 // ----
 char a1[100], a2[100], a3[100], a4[100]; // expected-note{{Original allocation}} expected-note{{}} expected-note{{}}
 
@@ -150,4 +156,3 @@ void test(void) {
   intptr_t *cp; // expected-note{{Capabilities stored}}
   alloc((void**)&cp);
 }
-

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -178,7 +178,7 @@ void test_assign(struct T *pT) {
   pT->pVoid = (void*)"string"; // no warning
 }
 
-
+// ----
 #define offsetof(T,F) __builtin_offsetof(T, F)
 
 struct S2 {
@@ -192,4 +192,13 @@ int test_offsetof(char *pC, short *pSh, struct S2 *pS2) {
   struct S2 *q2 = (struct S2*)((char*)pSh2 - offsetof(struct S2, sh));
   struct S2 *q3 = (struct S2*)((char*)pC - offsetof(struct S2, c)); // no-warn
   return q->x + q2->x + q3->x;
+}
+
+// ----
+void cast_and_assign(void) {
+  char x[100]; // expected-note{{Original allocation}}
+  intptr_t *i;
+  i = (intptr_t*)x; // expected-warning{{Pointer value aligned to a 1 byte boundary cast}}
+                     // no duplicate assign warn
+  *i = 42;
 }

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -119,7 +119,7 @@ void after_cap_data(int n, int D) {
 }
 
 // ----
-char a1[100], a2[100], a3[100], a4[100]; // expected-note{{Original allocation}} expected-note{{}} expected-note{{}}
+char a1[100], a2[100], a3[100], a4[100], a5[100], a6[100]; // expected-note{{Original allocation}} expected-note{{}} expected-note{{}} expected-note{{}} expected-note{{}}
 
 struct T {
   void *pVoid;
@@ -140,9 +140,15 @@ void gen_storage(struct T *pT, void *p, size_t n) {
   memcpy(a3, mT->pVoid, n);
   //expected-warning@-1{{Copied memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
 
+  memcpy(mT->pCap, a4, n);
+  //expected-warning@-1{{Destination memory object pointed by 'intptr_t * __capability' pointer is supposed to contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
+
+  memcpy(gS->pCap, a5, n);
+  //expected-warning@-1{{Destination memory object pointed by 'intptr_t * __capability' pointer is supposed to contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
+
   void *m = malloc(n);
-  memcpy(a4, m, n); // no-warn
-  copy(a4, m, n);
+  memcpy(a6, m, n); // no-warn
+  copy(a6, m, n);
 }
 
 // ----

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -98,7 +98,7 @@ B* flex(size_t n) {
 char c_buf[100]; // expected-note{{Original allocation}} expected-note{{Original allocation}} expected-note{{Original allocation}}
 void implicit_cap_storage(void **impl_cap_ptr) {
   *impl_cap_ptr = &c_buf[0];
-  // expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as type 'void * __capability'. Memory pointed by it may be used to hold capabilities, for which 16-byte capability alignment will be required}}
+  // expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as value of type 'void * __capability'. Memory pointed by it may be used to hold capabilities, for which 16-byte capability alignment will be required}}
 }
 
 char c_buf_aligned[100] __attribute__((aligned(_Alignof(void*)))); // expected-note{{Capabilities stored in 'char[100]'}}
@@ -109,7 +109,7 @@ void copy_through_unaligned(intptr_t *src, void *dst, size_t n) {
   memcpy(c_buf, c_buf_aligned, n * sizeof(intptr_t));
   // expected-warning@-1{{Copied memory object of type 'char[100]' contains capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
   memcpy(d, c_buf, n * sizeof(intptr_t));
-  // expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
+  // expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may be supposed to contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
 }
 
 void after_cap_data(int n, int D) {
@@ -122,8 +122,9 @@ void after_cap_data(int n, int D) {
 char a1[100], a2[100], a3[100], a4[100]; // expected-note{{Original allocation}} expected-note{{}} expected-note{{}}
 
 struct T {
-  void *p;
-} gS;
+  void *pVoid;
+  intptr_t *pCap;
+} *gS;
 
 void copy(void *dst, void* src, size_t n) {
   memcpy(dst, src, n); // no-warn
@@ -132,11 +133,11 @@ void copy(void *dst, void* src, size_t n) {
 void gen_storage(struct T *pT, void *p, size_t n) {
   memcpy(a1, p, n);
   //expected-warning@-1{{Copied memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
-  memcpy(pT->p, a2, n);
-  //expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
+  memcpy(pT->pVoid, a2, n);
+  //expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may be supposed to contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
 
   struct T *mT = malloc(sizeof(struct T));
-  memcpy(a3, mT->p, n);
+  memcpy(a3, mT->pVoid, n);
   //expected-warning@-1{{Copied memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
 
   void *m = malloc(n);
@@ -145,12 +146,12 @@ void gen_storage(struct T *pT, void *p, size_t n) {
 }
 
 // ----
-char extra[100]; // expected-note{{Original allocation}}
+char extra[100]; // expected-note{{Original allocation of type 'char[100]' has an alignment requirement 1 byte}}
 void *gP;
 
 void alloc(void** p) {
   *p = extra;
-  //expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as type 'void * __capability'. Memory pointed by it is supposed to hold capabilities, for which 16-byte capability alignment will be required}}
+  //expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as value of type 'intptr_t * __capability'. Memory pointed by it is supposed to hold capabilities, for which 16-byte capability alignment will be required}}
 }
 
 void test_assign(struct T *pT) {
@@ -158,5 +159,5 @@ void test_assign(struct T *pT) {
   alloc((void**)&cp);
   gP = cp; // no duplicate warning
 
-  pT->p = (void*)"string"; // no warning
+  pT->pVoid = (void*)"string"; // no warning
 }

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -1,5 +1,5 @@
 // RUN: %cheri_purecap_cc1 -analyze -verify %s \
-// RUN:   -analyzer-checker=core,cheri.CapabilityAlignmentChecker
+// RUN:   -analyzer-checker=core,optin.portability.PointerAlignment
 
 typedef __uintcap_t uintptr_t;
 typedef __intcap_t intptr_t;

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -153,7 +153,7 @@ void alloc(void** p) {
 }
 
 void test_assign(struct T *pT) {
-  intptr_t *cp; // expected-note{{Capabilities stored}}
+  intptr_t *cp; // expected-note{{Memory pointed by '__intcap * __capability' value is supposed to hold capabilities}}
   alloc((void**)&cp);
 
   pT->p = (void*)"string"; // no warning

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -17,15 +17,15 @@ uintptr_t *u;
 
 void foo(void *v, int *pi, void *pv) {
   char *p0 = (char*)a;
-  *(void**)p0 = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
+  *(void**)p0 = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with 16-byte capability alignment}}
   char *p1 = (char*)roundup2((uintptr_t)p0, sizeof(void*));
   *(void**)p1 = v; // no warning
   char *p2 = p1 + 5*sizeof(double);
-  *(void**)p2 = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
+  *(void**)p2 = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with 16-byte capability alignment}}
 
-  *(void**)pi = v; // expected-warning{{Pointer value aligned to a 4 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
+  *(void**)pi = v; // expected-warning{{Pointer value aligned to a 4 byte boundary cast to type 'void * __capability * __capability' with 16-byte capability alignment}}
   *(void**)pv = v; // no warning
-  *(void**)next = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with required capability alignment 16 bytes}}
+  *(void**)next = v; // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'void * __capability * __capability' with 16-byte capability alignment}}
 
   if (u == NULL || u == MINUS_ONE) // no warning
     return;
@@ -49,8 +49,8 @@ struct S {
 };
 int struct_field(struct S *s) {
   uintptr_t* p1 = (uintptr_t*)&s->u[3];  // no warning
-  uintptr_t* p2 = (uintptr_t*)&s->i[8];  // expected-warning{{Pointer value aligned to a 4 byte boundary cast to type 'uintptr_t * __capability' with required capability alignment 16 bytes}}
-  uintptr_t* p3 = (uintptr_t*)&s->i_aligned[6];  // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'uintptr_t * __capability' with required capability alignment 16 bytes}}
+  uintptr_t* p2 = (uintptr_t*)&s->i[8];  // expected-warning{{Pointer value aligned to a 4 byte boundary cast to type 'uintptr_t * __capability' with 16-byte capability alignment}}
+  uintptr_t* p3 = (uintptr_t*)&s->i_aligned[6];  // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'uintptr_t * __capability' with 16-byte capability alignment}}
   uintptr_t* p4 = (uintptr_t*)&s->i_aligned[4];  // no warning
   return (p4 - p3) + (p2 - p1);
 }
@@ -59,21 +59,21 @@ void local_var(void) {
   char buf[4]; // expected-note{{Original allocation}}
   char buf_underaligned[4] __attribute__((aligned(2))); // expected-note{{Original allocation}}
   char buf_aligned[4] __attribute__((aligned(4)));
-  *(int*)buf = 42; // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
-  *(int*)buf_underaligned = 42; // expected-warning{{Pointer value aligned to a 2 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
+  *(int*)buf = 42; // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with 4-byte alignment}}
+  *(int*)buf_underaligned = 42; // expected-warning{{Pointer value aligned to a 2 byte boundary cast to type 'int * __capability' with 4-byte alignment}}
   *(int*)buf_aligned = 42; // no warning
 }
 
 char st_buf[4]; // expected-note{{Original allocation}}
 char st_buf_aligned[4] __attribute__((aligned(_Alignof(int*))));
 void static_var(void) {
-  *(int*)st_buf = 42; // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
+  *(int*)st_buf = 42; // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with 4-byte alignment}}
   *(int*)st_buf_aligned = 42; // no warning
 }
 
 int voidptr_cast(int *ip1, int *ip2) {
   intptr_t w = (intptr_t)(ip2) | 1;
-  int b1 = (ip1 == (int*)w);  // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with required alignment 4 bytes}}
+  int b1 = (ip1 == (int*)w);  // expected-warning{{Pointer value aligned to a 1 byte boundary cast to type 'int * __capability' with 4-byte alignment}}
   int b2 = (ip1 == (void*)w); // no-warn
   return b1 || b2;
 }
@@ -87,12 +87,67 @@ B* blob(size_t n) {
   size_t s = sizeof(B) + n * sizeof(long) + n * sizeof(B);
   B *p = malloc(s);
   p->ptr = (long*)&p[1];
-  return (B*)(&p->ptr[n]); // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'B * __capability' with required capability alignment 16 bytes}}
+  return (B*)(&p->ptr[n]); // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'B * __capability' with 16-byte capability alignment}}
 }
 B* flex(size_t n) {
   size_t s = sizeof(B) + (n-1) * sizeof(long) + n * sizeof(B);
   B *p = malloc(s);
-  return (B*)(&p->flex[n]); // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'B * __capability' with required capability alignment 16 bytes}}
+  return (B*)(&p->flex[n]); // expected-warning{{Pointer value aligned to a 8 byte boundary cast to type 'B * __capability' with 16-byte capability alignment}}
 }
 
+char c_buf[100]; // expected-note{{Original allocation}} expected-note{{Original allocation}} expected-note{{Original allocation}}
+void implicit_cap_storage(void **impl_cap_ptr) {
+  *impl_cap_ptr = &c_buf[0];
+  // expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as type 'void * __capability'. Memory pointed by it may be used to hold capabilities, for which 16-byte capability alignment will be required}}
+}
+
+char c_buf_aligned[100] __attribute__((aligned(_Alignof(void*)))); // expected-note{{Capabilities stored in 'char[100]'}}
+extern void *memcpy(void *dest, const void *src, size_t n);
+void copy_through_unaligned(intptr_t *src, void *dst, size_t n) {
+  void *s = src, *d = dst;
+  memcpy(c_buf_aligned, s, n * sizeof(intptr_t)); // no warn
+  memcpy(c_buf, c_buf_aligned, n * sizeof(intptr_t));
+  // expected-warning@-1{{Copied memory object of type 'char[100]' contains capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
+  memcpy(d, c_buf, n * sizeof(intptr_t));
+  // expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
+}
+
+// ----
+char a1[100], a2[100], a3[100], a4[100]; // expected-note{{Original allocation}} expected-note{{}} expected-note{{}}
+
+struct T {
+  void *p;
+} gS;
+
+void copy(void *dst, void* src, size_t n) {
+  memcpy(dst, src, n); // no-warn
+}
+
+void gen_storage(struct T *pT, void *p, size_t n) {
+  memcpy(a1, p, n);
+  //expected-warning@-1{{Copied memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
+  memcpy(pT->p, a2, n);
+  //expected-warning@-1{{Destination memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Source address alignment is 1, which means that copied object may have its capabilities tags stripped earlier due to underaligned storage}}
+
+  struct T *mT = malloc(sizeof(struct T));
+  memcpy(a3, mT->p, n);
+  //expected-warning@-1{{Copied memory object pointed by 'void * __capability' pointer may contain capabilities that require 16-byte capability alignment. Destination address alignment is 1. Storing a capability at an underaligned address leads to tag stripping}}
+
+  void *m = malloc(n);
+  memcpy(a4, m, n); // no-warn
+  copy(a4, m, n);
+}
+
+// ----
+char extra[100]; // expected-note{{Original allocation}}
+
+void alloc(void** p) {
+  *p = extra;
+  //expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as type 'void * __capability'. Memory pointed by it is supposed to hold capabilities, for which 16-byte capability alignment will be required}}
+}
+
+void test(void) {
+  intptr_t *cp; // expected-note{{Capabilities stored}}
+  alloc((void**)&cp);
+}
 

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -146,6 +146,7 @@ void gen_storage(struct T *pT, void *p, size_t n) {
 
 // ----
 char extra[100]; // expected-note{{Original allocation}}
+void *gP;
 
 void alloc(void** p) {
   *p = extra;
@@ -155,6 +156,7 @@ void alloc(void** p) {
 void test_assign(struct T *pT) {
   intptr_t *cp; // expected-note{{Memory pointed by '__intcap * __capability' value is supposed to hold capabilities}}
   alloc((void**)&cp);
+  gP = cp; // no duplicate warning
 
   pT->p = (void*)"string"; // no warning
 }

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -152,7 +152,9 @@ void alloc(void** p) {
   //expected-warning@-1{{Pointer value aligned to a 1 byte boundary stored as type 'void * __capability'. Memory pointed by it is supposed to hold capabilities, for which 16-byte capability alignment will be required}}
 }
 
-void test(void) {
+void test_assign(struct T *pT) {
   intptr_t *cp; // expected-note{{Capabilities stored}}
   alloc((void**)&cp);
+
+  pT->p = (void*)"string"; // no warning
 }

--- a/clang/tools/scan-build/libexec/ccc-analyzer
+++ b/clang/tools/scan-build/libexec/ccc-analyzer
@@ -362,6 +362,7 @@ sub Analyze {
 my %CompileOptionMap = (
   '-nostdinc' => 0,
   '-nostdlibinc' => 0,
+  '-nostdinc++' => 0,
   '-include' => 1,
   '-idirafter' => 1,
   '-imacros' => 1,


### PR DESCRIPTION
- **[CHERI-CSA] Allow ASTContext::getIntWidth() for reference type**
- **[CHERI-CSA] Use type IntWidth instead of TypeSize for NULL ptr SVal**
- **[CHERI-CSA] Improve LocAsInt arithmetic support**
- **[CHERI-CSA] Add provenance bit to LocAsInteger**
- **[analyzer] scan-build: Retain -nostdinc++ option**
- **[CHERI-CSA] Add alpha.cheri.ProvenanceSourceChecker**
- **[CHERI-CSA] ProvenanceSourceChecker: add subtraction**
- **[CHERI-CSA] Add CapabilityCopyChecker**
- **[CHERI_CSA] CapabilityCopyChecker: suppress for short loops**
- **[CHERI_CSA] CapabilityCopyChecker: suppress for unaligned ptr**
- **[CHERI_CSA] CapabilityCopyChecker: silence for hybrid mode**
- **[CHERI-CSA] CapabilityCopyChecker: char* as universal pointer**
- **[CHERI-CSA] CapabilityCopyChecker: suppress FP for short copies**
- **[CHERI-CSA] CapabilityCopyChecker: improve bug trace**
- **[CHERI_CSA] ProvenanceSourceChecker: silence for hybrid mode**
- **[CHERI_CSA] CHERIUtils**
- **[CHERI_CSA] Add Capability Alignment Checker**
- **[CHERI_CSA] CapabilityAlignmentChecker: assume align on parameters and globals**
- **[CHERI_CSA] CapabilityAlignmentChecker: support align check**
- **[CHERI_CSA] CapabilityAlignmentChecker: array element alignment**
- **[CHERI_CSA] CapabilityAlignmentChecker: attribute __aligned__**
- **[CHERI_CSA] CapabilityAlignmentChecker: BugReporterVisitor**
- **[CHERI_CSA] CapabilityAlignmentChecker: fix FP for comparison with void***
- **[CHERI_CSA] CapabilityAlignmentChecker: refactoring of MemRegion alignment**
- **[CHERI_CSA] CapabilityAlignmentChecker: add allocation source location to warning**
- **[CHERI_CSA] CapabilityAlignmentChecker: improve warning message**
- **[CHERI_CSA] CapabilityAlignmentChecker: removing dead symbols**
- **[CHERI_CSA] move 3 checkers from CHERIAlpha to CHERI section**
- **[CHERI_CSA] ProvenanceSourceChecker: propagate InvalidCap through UnaryOperator**
- **[CHERI_CSA] Enable cheri.* checkers by default on purecap**
- **[CHERI_CSA] ProvenanceSourceChecker: add FixIts**
- **[CHERI_CSA] Move cheri.CapabilityAlignmentChecker -> optin.portability.PointerAlignment**
- **[CHERI_CSA] CapabilityCopyChecker: add ReportForCharPtr option**
- **[CHERI_CSA] Enable alpha.core.PointerSub by default for CHERI**
- **[CHERI_CSA] Support non-constant offsets to ElementRegion**
- **[CHERI_CSA] PointerAlignmentChecker: improve alignment tracking**
- **[CHERI_CSA] PointerAlignmentChecker: use declaration as uniquing location**
- **[CHERI_CSA] CapabilityCopyChecker: fix infinite recursion**
- **[CHERI_CSA] PointerSizeAssumptionsChecker: new checker**
- **[CHERI_CSA] ProvenanceSourceChecker: divide bugs into subtypes**
- **[CHERI_CSA] ProvenanceSource: suppress with -Wno-cheri-provenance**
- **[CHERI_CSA] Fix note links in reports HTML**
- **[CHERI_CSA] Fix crash with FieldDecl as UniqLoc**
- **[CHERI_CSA] PointerAlignmentChecker: report implicit assignment amd memcpy**
- **[CHERI_CSA] PointerAlignmentChecker: fix FP for adjacent objects**
- **[CHERI_CSA] PointerAlignmentChecker: fix FP for void* assignment**
- **[CHERI_CSA] PointerAlignmentChecker: improve warning notes**
- **[CHERI_CSA] PointerAlignmentChecker: suppress duplicate reports**
- **[CHERI_CSA] PointerAlignmentChecker: improve messages & traces**
- **[CHERI_CSA] PointerAlignmentChecker: rework handling symbolic addresses**
- **[CHERI_CSA] PointerAlignmentChecker: false warnings suppression**
- **[CHERI_CSA] CapabilityCopyChecker: ReportForCharPtr=false by default**
- **[CHERI_CSA] PointerAlignmentChecker: refine warning types**
- **[CHERI_CSA] ProvenanceSourceChecker: refine warning types**
- **[CHERI_CSA] PointerAlignmentChecker: support bcopy**
- **[CHERI_CSA] ProvenanceSourceChecker: delete ptrdiff as capability warning**
- **[CHERI_CSA] ProvenanceSourceChecker: Fix for CompoundAssignmentOp**
- **[CHERI_CSA] CapabilityCopyChecker: fix for BugType**
- **[CHERI_CSA] ProvenanceSourceChecker: refine warning types**
- **[CHERI_CSA] New alpha.cheri.SubObjectRepresentability checker**
- **[CHERI_CSA] SubObjectRepresentability: detailed message**
- **[CHERI_CSA] SubObjectRepresentability: disable notes for now**
- **[CHERI_CSA] SubObjectRepresentability: enable notes with updated cheri-compressed-cap**
- **[CHERI_CSA] SubObjectRepresentability: move alpha.cheri -> cheri**
- **[CHERI_CSA] New cheri.Allocation checker**
- **[CHERI_CSA] AllocationChecker: move static and heap allocation to new BugType**
- **[CHERI_CSA] AllocationChecker: suppress for ptr to first field**
- **[CHERI_CSA] CHERIUtils: Print aka type in messages**
- **[CHERI_CSA] AllocationChecker: suppress for flexible array**
- **[CHERI_CSA] AllocationChecker: rework**
- **[CHERI_CSA] AllocationChecker: suppress for free**
- **[CHERI_CSA] CHERI API Modelling**
- **[CHERI_CSA] AllocationChecker: suppress for bounded suballocations**
- **[CHERI_CSA] AllocationChecker: add ReportForUnknownAllocations option**
- **[CHERI_CSA] AllocationChecker: disable for non-purecap**
- **[CHERI_CSA] Refactoring state cleanup for dead symbols & regions**
- **[CHERI_CSA] SubObjectRepresentability: support other CHERI targets**
