### PR TITLE
[CHERI CSA] Disable pointer alignment checker for sealed capabilities.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/PointerAlignmentChecker.cpp
@@ -259,6 +259,11 @@ int getTrailingZerosCount(const SVal &V, ProgramStateRef State,
   if (V.isUnknownOrUndef())
     return -1;
 
+  // Sealed capabilities cannot be dereferenced, and any type-punning
+  // will be dynamically checked during unsealing.
+  if (V.getType(ASTCtx)->isCHERISealedCapabilityType(ASTCtx))
+    return -1;
+
   if (V.isConstant()) {
     if (auto LV = V.getAs<loc::ConcreteInt>())
       return LV->getValue()->countTrailingZeros();

--- a/clang/test/Analysis/pointer-alignment.c
+++ b/clang/test/Analysis/pointer-alignment.c
@@ -214,3 +214,9 @@ void write_to_first_member(struct AlignedParentStruct *chunk) {
   *(long long*)(&chunk->a) = 0;
 }
 
+// ----
+long long * __sealed_capability sealed_cast(int * __sealed_capability in) {
+  // No warnings for sealed capabilities, since they will be effectively dynamically
+  // verified when unsealed.
+  return (long long * __sealed_capability)in;
+}


### PR DESCRIPTION
Sealed capabilities can't be dereferenced without unsealing, which
effectively verifies that the type was dynamically correct.
