### PR TITLE
[CHERI CSA] Disable subobject-representability diagnostics on packed structs.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/SubObjectRepresentabilityChecker.cpp
@@ -102,6 +102,11 @@ std::unique_ptr<BugReport> checkFieldImpl(const FieldDecl *D, BugReporter &BR,
                                           const BugType &BT) {
   QualType T = D->getType();
 
+  // If the parent struct is explicitly marked as packed, then don't emit a
+  // diagnostic, as this layout is likely intentional.
+  if (D->getParent()->hasAttr<PackedAttr>())
+    return nullptr;
+
   ASTContext &ASTCtx = BR.getContext();
   uint64_t Offset = ASTCtx.getFieldOffset(D) / 8;
   if (Offset > 0) {

--- a/clang/test/Analysis/Checkers/CHERI/subobject-representability-mips64.c
+++ b/clang/test/Analysis/Checkers/CHERI/subobject-representability-mips64.c
@@ -15,6 +15,10 @@ struct R1 {
       int c[2];
       char a[0x1000]; // no warn
     } f3good __attribute__((aligned(8)));
+    struct __attribute__((packed)) {
+      char c;
+      char a[0x1000]; // no warn
+    } f4good;
   } s2;
 } s1;
 


### PR DESCRIPTION
On a packed struct, the layout is likely to have been intentionally chosen, often to
conform with some external definition, so diagnostics here are very likely to be noise.
