### PR TITLE
[CHERI] Prefer to lower subobject bounds calculations as cap_top - cap_addr.

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -755,13 +755,15 @@ tightenCHERIBounds(CodeGenFunction &CGF, SubObjectBoundsKind Kind,
     SizeStr = TBR.Size ? ("min(" + Twine(*TBR.Size) + ", remaining)").str()
                        : "remaining";
     auto SrcAsI8 = CGF.Builder.CreateBitCast(ValueToBound, CGF.Int8CheriCapTy);
-    auto Offset = CGF.Builder.CreateIntrinsic(
-        llvm::Intrinsic::cheri_cap_offset_get, CGF.PtrDiffTy, SrcAsI8, nullptr,
-        "cur_offset");
-    SrcLength =
-        CGF.Builder.CreateIntrinsic(llvm::Intrinsic::cheri_cap_length_get,
-                                    CGF.PtrDiffTy, SrcAsI8, nullptr, "cur_len");
-    SetBoundsSize = CGF.Builder.CreateSub(SrcLength, Offset, "remaining_bytes");
+    // CHERIoT does not directly implement cheri_cap_offset_get, so it's better
+    // to lower the bounds in terms of cheri_cap_top_get / cheri_cap_addr_get.
+    auto Top =
+        CGF.Builder.CreateIntrinsic(llvm::Intrinsic::cheri_cap_top_get,
+                                    CGF.PtrDiffTy, SrcAsI8, nullptr, "cur_top");
+    auto Addr = CGF.Builder.CreateIntrinsic(
+        llvm::Intrinsic::cheri_cap_address_get, CGF.PtrDiffTy, SrcAsI8, nullptr,
+        "cur_addr");
+    SetBoundsSize = CGF.Builder.CreateSub(Top, Addr, "remaining_bytes");
     if (TBR.Size) {
       auto MaxConst = llvm::ConstantInt::get(CGF.PtrDiffTy, *TBR.Size);
       auto LessThanMax = CGF.Builder.CreateICmpULT(SetBoundsSize, MaxConst,

--- a/clang/test/CodeGen/cheri/subobject-bounds-addrof-array.c
+++ b/clang/test/CodeGen/cheri/subobject-bounds-addrof-array.c
@@ -436,23 +436,23 @@ extern int bhnd_sprom_layouts[];
 
 // AGGRESSIVE-OR-LESS-LABEL: @test_unsized_global_array(
 // AGGRESSIVE-OR-LESS-NEXT:  entry:
-// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_OFFSET:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
-// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_LEN:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
-// AGGRESSIVE-OR-LESS-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_TOP:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
+// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_ADDR:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
+// AGGRESSIVE-OR-LESS-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // AGGRESSIVE-OR-LESS-NEXT:    [[TMP0:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) @bhnd_sprom_layouts, i64 [[REMAINING_BYTES]])
 // AGGRESSIVE-OR-LESS-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [0 x i32], ptr addrspace(200) [[TMP0]], i64 0, i64 0
-// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_OFFSET1:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[ARRAYIDX]])
-// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_LEN2:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[ARRAYIDX]])
-// AGGRESSIVE-OR-LESS-NEXT:    [[REMAINING_BYTES3:%.*]] = sub i64 [[CUR_LEN2]], [[CUR_OFFSET1]]
+// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_TOP1:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[ARRAYIDX]])
+// AGGRESSIVE-OR-LESS-NEXT:    [[CUR_ADDR1:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[ARRAYIDX]])
+// AGGRESSIVE-OR-LESS-NEXT:    [[REMAINING_BYTES3:%.*]] = sub i64 [[CUR_TOP1]], [[CUR_ADDR1]]
 // AGGRESSIVE-OR-LESS-NEXT:    [[TMP1:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[ARRAYIDX]], i64 [[REMAINING_BYTES3]])
 // AGGRESSIVE-OR-LESS-NEXT:    call void @do_stuff_untyped(ptr addrspace(200) noundef [[TMP1]])
 // AGGRESSIVE-OR-LESS-NEXT:    ret void
 //
 // VERY-AGGRESSIVE-LABEL: @test_unsized_global_array(
 // VERY-AGGRESSIVE-NEXT:  entry:
-// VERY-AGGRESSIVE-NEXT:    [[CUR_OFFSET:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
-// VERY-AGGRESSIVE-NEXT:    [[CUR_LEN:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
-// VERY-AGGRESSIVE-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// VERY-AGGRESSIVE-NEXT:    [[CUR_TOP:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
+// VERY-AGGRESSIVE-NEXT:    [[CUR_ADDR:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) @bhnd_sprom_layouts)
+// VERY-AGGRESSIVE-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // VERY-AGGRESSIVE-NEXT:    [[TMP0:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) @bhnd_sprom_layouts, i64 [[REMAINING_BYTES]])
 // VERY-AGGRESSIVE-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [0 x i32], ptr addrspace(200) [[TMP0]], i64 0, i64 0
 // VERY-AGGRESSIVE-NEXT:    [[TMP1:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[ARRAYIDX]], i64 4)

--- a/clang/test/CodeGen/cheri/subobject-bounds-array-to-pointer-decay.c
+++ b/clang/test/CodeGen/cheri/subobject-bounds-array-to-pointer-decay.c
@@ -93,9 +93,9 @@ void test_global_struct_array_decay(struct_with_array *s, long index) {
 // CHECK-SAME: (ptr addrspace(200) nocapture noundef readnone [[S:%.*]], i64 noundef signext [[SIZE:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VLA:%.*]] = alloca i32, i64 [[SIZE]], align 4, addrspace(200)
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[VLA]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    call void @overflow_buffer(ptr addrspace(200) noundef [[TMP0]]) #[[ATTR5]]
 // CHECK-NEXT:    ret void
@@ -115,9 +115,9 @@ struct vla_struct {
 // CHECK-SAME: (ptr addrspace(200) noundef [[S:%.*]], i64 noundef signext [[INDEX:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VLA:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[S]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[VLA]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    tail call void @overflow_buffer(ptr addrspace(200) noundef [[TMP0]]) #[[ATTR5]]
 // CHECK-NEXT:    ret void
@@ -135,9 +135,9 @@ struct fake_vla_struct {
 // CHECK-SAME: (ptr addrspace(200) noundef [[S:%.*]], i64 noundef signext [[INDEX:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[FAKE_VLA:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[S]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[FAKE_VLA]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    tail call void @overflow_buffer(ptr addrspace(200) noundef [[TMP0]]) #[[ATTR5]]
 // CHECK-NEXT:    ret void
@@ -155,9 +155,9 @@ struct fake_vla_struct2 {
 // CHECK-SAME: (ptr addrspace(200) noundef [[S:%.*]], i64 noundef signext [[INDEX:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[FAKE_VLA2:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[S]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA2]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA2]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA2]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[FAKE_VLA2]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[FAKE_VLA2]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    tail call void @overflow_buffer(ptr addrspace(200) noundef [[TMP0]]) #[[ATTR5]]
 // CHECK-NEXT:    ret void
@@ -171,9 +171,9 @@ extern int bhnd_sprom_layouts[];
 // CHECK-LABEL: define {{[^@]+}}@test_unsized_global_decay
 // CHECK-SAME: () local_unnamed_addr addrspace(200) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull @bhnd_sprom_layouts)
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull @bhnd_sprom_layouts)
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull @bhnd_sprom_layouts)
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull @bhnd_sprom_layouts)
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull @bhnd_sprom_layouts, i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    tail call void @overflow_buffer(ptr addrspace(200) noundef [[TMP0]]) #[[ATTR5]]
 // CHECK-NEXT:    ret void

--- a/clang/test/CodeGen/cheri/subobject-bounds-pointer-container.c
+++ b/clang/test/CodeGen/cheri/subobject-bounds-pointer-container.c
@@ -59,14 +59,14 @@ char *test_SA(struct SA *sa) {
 // CHECK-LABEL: @test_TA(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[A:%.*]] = getelementptr inbounds nuw [[STRUCT_TA:%.*]], ptr addrspace(200) [[TA:%.*]], i32 0, i32 0
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[A]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[A]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[A]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[A]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[A]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [2 x i8], ptr addrspace(200) [[TMP0]], i64 0, i64 1
-// CHECK-NEXT:    [[CUR_OFFSET1:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[ARRAYIDX]])
-// CHECK-NEXT:    [[CUR_LEN2:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[ARRAYIDX]])
-// CHECK-NEXT:    [[REMAINING_BYTES3:%.*]] = sub i64 [[CUR_LEN2]], [[CUR_OFFSET1]]
+// CHECK-NEXT:    [[CUR_TOP1:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[ARRAYIDX]])
+// CHECK-NEXT:    [[CUR_ADDR1:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[ARRAYIDX]])
+// CHECK-NEXT:    [[REMAINING_BYTES3:%.*]] = sub i64 [[CUR_TOP1]], [[CUR_ADDR1]]
 // CHECK-NEXT:    [[TMP1:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[ARRAYIDX]], i64 [[REMAINING_BYTES3]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[TMP1]]
 //

--- a/clang/test/CodeGen/cheri/subobject-bounds-remaining-size-attribute.c
+++ b/clang/test/CodeGen/cheri/subobject-bounds-remaining-size-attribute.c
@@ -38,9 +38,9 @@ void *test_opt_out(void *data, long index) {
 // CHECK-LABEL: @test_remaining_size(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[DATA1:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[DATA:%.*]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[DATA1]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[DATA1]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[DATA1]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[DATA1]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[DATA1]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[TMP0]]
 //
@@ -56,9 +56,9 @@ void *test_remaining_size(void *data, long index) {
 // CHECK-LABEL: @test_remaining_size_not_array(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[F:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[DATA:%.*]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[F]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[F]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[F]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[F]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[F]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[TMP0]]
 //
@@ -79,9 +79,9 @@ void *test_remaining_size_not_array(void *data, long index) {
 // CHECK-LABEL: @test_remaining_size_on_type(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[DATA1:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[DATA:%.*]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[DATA1]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[DATA1]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[DATA1]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[DATA1]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[BOUNDED_REMAINING_SIZE:%.*]] = tail call i64 @llvm.umin.i64(i64 [[REMAINING_BYTES]], i64 16)
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[DATA1]], i64 [[BOUNDED_REMAINING_SIZE]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[TMP0]]
@@ -124,9 +124,9 @@ void *test_remaining_size_ignored_on_typedef(void *data, long index) {
 // CHECK-LABEL: @test_remaining_size_maximum(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[DATA1:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[DATA:%.*]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[DATA1]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[DATA1]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[DATA1]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[DATA1]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[BOUNDED_REMAINING_SIZE:%.*]] = tail call i64 @llvm.umin.i64(i64 [[REMAINING_BYTES]], i64 127)
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[DATA1]], i64 [[BOUNDED_REMAINING_SIZE]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[TMP0]]
@@ -143,9 +143,9 @@ void *test_remaining_size_maximum(void *data, long index) {
 // CHECK-LABEL: @test_vla(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[VLA:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[DATA:%.*]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[VLA]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[TMP0]]
 //

--- a/clang/test/CodeGen/cheri/subobject-bounds-structure-array.c
+++ b/clang/test/CodeGen/cheri/subobject-bounds-structure-array.c
@@ -78,9 +78,9 @@ typedef struct {
 // CHECK-SAME: (ptr addrspace(200) noundef [[S:%.*]], i64 noundef signext [[INDEX:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR5:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[BUF:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[S]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[CUR_ADDRESS:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDRESS]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[BUF]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [0 x i8], ptr addrspace(200) [[TMP0]], i64 0, i64 [[INDEX]]
 // CHECK-NEXT:    store i8 65, ptr addrspace(200) [[ARRAYIDX]], align 1, !tbaa [[TBAA9:![0-9]+]]
@@ -96,9 +96,9 @@ int test_vla_a(struct_vla *s, long index) {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[RETVAL:%.*]] = alloca [[STRUCT_STRUCT_VLA:%.*]], align 4, addrspace(200)
 // CHECK-NEXT:    [[BUF:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[RETVAL]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[CUR_ADDRESS:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDRESS]]
 // CHECK-NEXT:    [[TMP0:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[BUF]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [0 x i8], ptr addrspace(200) [[TMP0]], i64 0, i64 [[INDEX]]
 // CHECK-NEXT:    store i8 65, ptr addrspace(200) [[ARRAYIDX]], align 1, !tbaa [[TBAA9]]
@@ -120,9 +120,9 @@ typedef struct {
 // CHECK-SAME: (ptr addrspace(200) noundef [[S:%.*]], i64 noundef signext [[INDEX:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR5]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[BUF:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[S]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[BUF]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [0 x i8], ptr addrspace(200) [[TMP0]], i64 0, i64 [[INDEX]]
 // CHECK-NEXT:    store i8 65, ptr addrspace(200) [[ARRAYIDX]], align 1, !tbaa [[TBAA9]]
@@ -142,9 +142,9 @@ typedef struct {
 // CHECK-SAME: (ptr addrspace(200) noundef [[S:%.*]], i64 noundef signext [[INDEX:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR5]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[BUF:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(200) [[S]], i64 4
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[BUF]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[BUF]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[BUF]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [1 x i8], ptr addrspace(200) [[TMP0]], i64 0, i64 [[INDEX]]
 // CHECK-NEXT:    store i8 65, ptr addrspace(200) [[ARRAYIDX]], align 1, !tbaa [[TBAA9]]
@@ -161,14 +161,14 @@ int test_fake_vla2(struct_fake_vla2 *s, long index) {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = zext i32 [[LEN]] to i64
 // CHECK-NEXT:    [[VLA:%.*]] = alloca i32, i64 [[TMP0]], align 4, addrspace(200)
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) nonnull [[VLA]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) nonnull [[VLA]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP1:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) nonnull [[VLA]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    call void @use_buf(ptr addrspace(200) noundef [[TMP1]]) #[[ATTR12:[0-9]+]]
-// CHECK-NEXT:    [[CUR_OFFSET4:%.*]] = call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[TMP1]])
-// CHECK-NEXT:    [[CUR_LEN5:%.*]] = call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[TMP1]])
-// CHECK-NEXT:    [[REMAINING_BYTES6:%.*]] = sub i64 [[CUR_LEN5]], [[CUR_OFFSET4]]
+// CHECK-NEXT:    [[CUR_TOP1:%.*]] = call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[TMP1]])
+// CHECK-NEXT:    [[CUR_ADDR1:%.*]] = call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[TMP1]])
+// CHECK-NEXT:    [[REMAINING_BYTES6:%.*]] = sub i64 [[CUR_TOP1]], [[CUR_ADDR1]]
 // CHECK-NEXT:    [[TMP2:%.*]] = call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[TMP1]], i64 [[REMAINING_BYTES6]])
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds i32, ptr addrspace(200) [[TMP2]], i64 [[INDEX]]
 // CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(200) [[ARRAYIDX]], align 4, !tbaa [[TBAA2]]

--- a/clang/test/CodeGen/cheri/subobject-bounds-union.c
+++ b/clang/test/CodeGen/cheri/subobject-bounds-union.c
@@ -149,19 +149,19 @@ union WithVLA3 {
 // CHECK-LABEL: define {{[^@]+}}@test3
 // CHECK-SAME: (ptr addrspace(200) noundef [[UN1:%.*]], ptr addrspace(200) noundef [[UN2:%.*]], ptr addrspace(200) noundef [[UN3:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CUR_OFFSET:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[UN1]])
-// CHECK-NEXT:    [[CUR_LEN:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[UN1]])
-// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_LEN]], [[CUR_OFFSET]]
+// CHECK-NEXT:    [[CUR_TOP:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[UN1]])
+// CHECK-NEXT:    [[CUR_ADDR:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[UN1]])
+// CHECK-NEXT:    [[REMAINING_BYTES:%.*]] = sub i64 [[CUR_TOP]], [[CUR_ADDR]]
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[UN1]], i64 [[REMAINING_BYTES]])
 // CHECK-NEXT:    tail call void @call(ptr addrspace(200) noundef [[TMP0]]) #[[ATTR3]]
-// CHECK-NEXT:    [[CUR_OFFSET1:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[UN2]])
-// CHECK-NEXT:    [[CUR_LEN2:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[UN2]])
-// CHECK-NEXT:    [[REMAINING_BYTES3:%.*]] = sub i64 [[CUR_LEN2]], [[CUR_OFFSET1]]
+// CHECK-NEXT:    [[CUR_TOP1:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[UN2]])
+// CHECK-NEXT:    [[CUR_ADDR1:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[UN2]])
+// CHECK-NEXT:    [[REMAINING_BYTES3:%.*]] = sub i64 [[CUR_TOP1]], [[CUR_ADDR1]]
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[UN2]], i64 [[REMAINING_BYTES3]])
 // CHECK-NEXT:    tail call void @call(ptr addrspace(200) noundef [[TMP1]]) #[[ATTR3]]
-// CHECK-NEXT:    [[CUR_OFFSET4:%.*]] = tail call i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200) [[UN3]])
-// CHECK-NEXT:    [[CUR_LEN5:%.*]] = tail call i64 @llvm.cheri.cap.length.get.i64(ptr addrspace(200) [[UN3]])
-// CHECK-NEXT:    [[REMAINING_BYTES6:%.*]] = sub i64 [[CUR_LEN5]], [[CUR_OFFSET4]]
+// CHECK-NEXT:    [[CUR_TOP2:%.*]] = tail call i64 @llvm.cheri.cap.top.get.i64(ptr addrspace(200) [[UN3]])
+// CHECK-NEXT:    [[CUR_ADDR2:%.*]] = tail call i64 @llvm.cheri.cap.address.get.i64(ptr addrspace(200) [[UN3]])
+// CHECK-NEXT:    [[REMAINING_BYTES6:%.*]] = sub i64 [[CUR_TOP2]], [[CUR_ADDR2]]
 // CHECK-NEXT:    [[TMP2:%.*]] = tail call ptr addrspace(200) @llvm.cheri.cap.bounds.set.i64(ptr addrspace(200) [[UN3]], i64 [[REMAINING_BYTES6]])
 // CHECK-NEXT:    tail call void @call(ptr addrspace(200) noundef [[TMP2]]) #[[ATTR3]]
 // CHECK-NEXT:    ret void

--- a/clang/test/CodeGenCXX/cheri/csetbounds-stats-all.cpp
+++ b/clang/test/CodeGenCXX/cheri/csetbounds-stats-all.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -f %t-hybrid.csv %t-purecap.csv
-// RUN: %cheri128_purecap_cc1 %s -mllvm -cheri-cap-table-abi=pcrel -cheri-bounds=aggressive \
+// RUN: %riscv64_cheri_purecap_cc1 %s -mllvm -cheri-cap-table-abi=pcrel -cheri-bounds=aggressive \
 // RUN:   -mllvm -collect-csetbounds-stats=csv -cheri-stats-file=%t-purecap.csv -S -o /dev/null -O1
 // RUN: FileCheck -input-file %t-purecap.csv %s -check-prefixes CSV
 
@@ -74,9 +74,6 @@ int test(void) {
 // CSV-NEXT: 0,<unknown>,s,"<somewhere in _Z23test_varlen_stack_arrayi>","CHERI bound stack allocations","set bounds on AllocaInst vla"
 // CSV-NEXT: 0,<unknown>,s,"<somewhere in _Z11test_allocai>","ExpandDYNAMIC_STACKALLOC",""
 // CSV-NEXT: 0,<unknown>,s,"<somewhere in _Z23test_varlen_stack_arrayi>","ExpandDYNAMIC_STACKALLOC",""
-// CSV-NEXT: 2,12,g,"<somewhere in _Z20load_global_variablev>","MipsTargetLowering::lowerGlobalAddress","load of global global_foo (alloc size=12)"
-// CSV-NEXT: 0,32,s,"<somewhere in _Z4testv>","MIPS variadic call lowering","setting varargs bounds for call to _Z3fooiz"
-
 
 // CSV-EMPTY:
 


### PR DESCRIPTION
This is more efficient on CHERIoT, and is the direction big CHERI is heading as well.
