### PR TITLE
Fix layering violation

### DIFF
--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -514,9 +514,6 @@ namespace llvm {
   /// This pass performs merging similar functions globally.
   ModulePass *createGlobalMergeFuncPass();
 
-  /// This pass logs information on generated CSetBounds calls
-  FunctionPass *createLogCheriSetBoundsPass();
-
   /// This pass performs outlining on machine instructions directly before
   /// printing assembly.
   ModulePass *createMachineOutlinerPass(bool RunOnAllFunctions = true);

--- a/llvm/include/llvm/Transforms/Utils.h
+++ b/llvm/include/llvm/Transforms/Utils.h
@@ -21,6 +21,13 @@ class FunctionPass;
 class Pass;
 
 //===----------------------------------------------------------------------===//
+// LogCheriSetBounds - This pass logs information on generated CSetBounds
+// calls.
+//
+FunctionPass *createLogCheriSetBoundsPass();
+extern char &LogCheriSetBoundsID;
+
+//===----------------------------------------------------------------------===//
 //
 // LowerInvoke - This pass removes invoke instructions, converting them to call
 // instructions.

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -97,7 +97,6 @@ add_llvm_component_library(LLVMTransformUtils
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Transforms/Utils
 
   DEPENDS
-  vt_gen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/llvm/lib/Transforms/Utils/CheriLogSetBoundsPass.cpp
+++ b/llvm/lib/Transforms/Utils/CheriLogSetBoundsPass.cpp
@@ -7,13 +7,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Transforms/Utils/CheriLogSetBounds.h"
-
 #include "llvm/Analysis/AssumptionCache.h"
-#include "llvm/CodeGen/MachineFunctionPass.h"
-#include "llvm/CodeGen/MachineModuleInfo.h"
-#include "llvm/CodeGen/Passes.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Transforms/Utils.h"
+#include "llvm/Transforms/Utils/CheriLogSetBounds.h"
 #include "llvm/Transforms/Utils/CheriSetBounds.h"
 #include "llvm/Transforms/Utils/Local.h"
 
@@ -137,12 +134,16 @@ public:
 
 char CheriLogSetBoundsLegacyPass::ID;
 
-FunctionPass *llvm::createLogCheriSetBoundsPass() {
+namespace llvm {
+char &LogCheriSetBoundsID = CheriLogSetBoundsLegacyPass::ID;
+
+FunctionPass *createLogCheriSetBoundsPass() {
   static bool created = false;
   assert(!created && "Should only be created once");
   created = true;
   return new CheriLogSetBoundsLegacyPass();
 }
+} // namespace llvm
 
 PreservedAnalyses CheriLogSetBoundsPass::run(Function &F,
                                              FunctionAnalysisManager &AM) {


### PR DESCRIPTION
Port over two fixes for a layering violation introduced during the LLVM 17 merge.

- **[Transforms] Move createLogCheriSetBoundsPass to Transforms/Utils.h**
- **Revert "Utils: add missing dep for llvm/CodeGen/GenVT.inc"**
