### PR TITLE
[TableGen] Look up registers directly in the CodeGenRegBank in CompressInstEmitter, rather than indirecting via the name. (#161853)

### DIFF
--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -161,7 +161,7 @@ bool CompressInstEmitter::validateRegister(const Record *Reg,
   assert(RegClass->isSubClassOf("RegisterClass") &&
          "RegClass record should be a RegisterClass");
   const CodeGenRegisterClass &RC = Target.getRegisterClass(RegClass);
-  const CodeGenRegister *R = Target.getRegisterByName(Reg->getName().lower());
+  const CodeGenRegister *R = Target.getRegBank().getReg(Reg);
   assert(R != nullptr && "Register not defined!!");
   return RC.contains(R);
 }


### PR DESCRIPTION
The previous code was subtly incorrect, as it indexed the RegistersByName map using the tblgen Def name of the register, rather than the AsmName with which the table was initialized. But all of this indirection via the name was unnecessary.