### PR TITLE
Merge further changes from CTSRD main up to 7385a57cdd2b819aa1b9e608cf479e18e7eb70b6

### DIFF
--- a/clang/lib/Headers/cheri_init_globals.h
+++ b/clang/lib/Headers/cheri_init_globals.h
@@ -171,15 +171,16 @@ cheri_init_globals_impl(const struct capreloc *start_relocs,
             data_cap, reloc->capability_location + base_addr);
     const void *__capability base_cap;
     bool can_set_bounds = true;
-    if ((reloc->permissions & function_reloc_flag) == function_reloc_flag) {
+    if (reloc->permissions == function_reloc_flag) {
       base_cap = code_cap; /* code pointer */
       /* Do not set tight bounds for functions (unless we are in the plt ABI) */
       can_set_bounds = tight_code_bounds;
-    } else if ((reloc->permissions & constant_reloc_flag) ==
-               constant_reloc_flag) {
+    } else if (reloc->permissions == constant_reloc_flag) {
       base_cap = rodata_cap; /* read-only data pointer */
-    } else {
+    } else if (reloc->permissions == 0) {
       base_cap = data_cap; /* read-write data */
+    } else {
+      __builtin_trap(); /* unknown permissions */
     }
     const void *__capability src =
         cheri_address_or_offset_set(base_cap, reloc->object + base_addr);

--- a/clang/lib/Headers/cheri_init_globals.h
+++ b/clang/lib/Headers/cheri_init_globals.h
@@ -65,11 +65,11 @@ static const __SIZE_TYPE__ global_pointer_permissions_mask =
     ~(__SIZE_TYPE__)(__CHERI_CAP_PERMISSION_PERMIT_SEAL__ |
                      __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__);
 
-__attribute__((weak)) extern struct capreloc __start___cap_relocs;
-__attribute__((weak)) extern struct capreloc __stop___cap_relocs;
+__attribute__((weak)) extern struct capreloc __start___cap_relocs[];
+__attribute__((weak)) extern struct capreloc __stop___cap_relocs[];
 
-__attribute__((weak)) extern void *__capability __cap_table_start;
-__attribute__((weak)) extern void *__capability __cap_table_end;
+__attribute__((weak)) extern void *__capability __cap_table_start[];
+__attribute__((weak)) extern void *__capability __cap_table_end[];
 
 /*
  * Sandbox data segments are relocated by moving DDC, since they're compiled as

--- a/clang/lib/Headers/cheri_init_globals.h
+++ b/clang/lib/Headers/cheri_init_globals.h
@@ -67,6 +67,8 @@ static const __SIZE_TYPE__ global_pointer_permissions_mask =
                      __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__);
 static const __SIZE_TYPE__ indirect_reloc_flag = (__SIZE_TYPE__)1
                                                  << (__SIZE_WIDTH__ - 3);
+static const __SIZE_TYPE__ code_reloc_flag = (__SIZE_TYPE__)1
+                                             << (__SIZE_WIDTH__ - 4);
 
 __attribute__((weak)) extern struct capreloc __start___cap_relocs[];
 __attribute__((weak)) extern struct capreloc __stop___cap_relocs[];
@@ -186,7 +188,8 @@ cheri_init_globals_impl(const struct capreloc *start_relocs,
       __builtin_trap();
 #endif
     }
-    if (reloc->permissions == function_reloc_flag) {
+    if (reloc->permissions == function_reloc_flag ||
+        reloc->permissions == (function_reloc_flag | code_reloc_flag)) {
       base_cap = code_cap; /* code pointer */
       /* Do not set tight bounds for functions (unless we are in the plt ABI) */
       can_set_bounds = tight_code_bounds;

--- a/clang/lib/Headers/cheri_init_globals.h
+++ b/clang/lib/Headers/cheri_init_globals.h
@@ -39,6 +39,7 @@ extern "C" {
 #define CHERI_INIT_GLOBALS_VERSION 5
 #define CHERI_INIT_GLOBALS_NUM_ARGS 7
 #define CHERI_INIT_GLOBALS_SUPPORTS_CONSTANT_FLAG 1
+#define CHERI_INIT_GLOBALS_SUPPORTS_INDIRECT_FLAG 1
 
 struct capreloc {
   __SIZE_TYPE__ capability_location;
@@ -64,6 +65,8 @@ static const __SIZE_TYPE__ constant_pointer_permissions_mask =
 static const __SIZE_TYPE__ global_pointer_permissions_mask =
     ~(__SIZE_TYPE__)(__CHERI_CAP_PERMISSION_PERMIT_SEAL__ |
                      __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__);
+static const __SIZE_TYPE__ indirect_reloc_flag = (__SIZE_TYPE__)1
+                                                 << (__SIZE_WIDTH__ - 3);
 
 __attribute__((weak)) extern struct capreloc __start___cap_relocs[];
 __attribute__((weak)) extern struct capreloc __stop___cap_relocs[];
@@ -171,6 +174,18 @@ cheri_init_globals_impl(const struct capreloc *start_relocs,
             data_cap, reloc->capability_location + base_addr);
     const void *__capability base_cap;
     bool can_set_bounds = true;
+    if (reloc->permissions == (function_reloc_flag | indirect_reloc_flag)) {
+      /*
+       * IRELATIVE-like caprelocs require deferred processing, with a
+       * target-specific set of parameters. Trap if the caller doesn't
+       * support that, as we can't do anything here, otherwise skip.
+       */
+#ifdef CHERI_INIT_GLOBALS_ALLOW_IFUNCS
+      continue;
+#else
+      __builtin_trap();
+#endif
+    }
     if (reloc->permissions == function_reloc_flag) {
       base_cap = code_cap; /* code pointer */
       /* Do not set tight bounds for functions (unless we are in the plt ABI) */

--- a/compiler-rt/lib/builtins/riscv/int_mul_impl.inc
+++ b/compiler-rt/lib/builtins/riscv/int_mul_impl.inc
@@ -14,24 +14,20 @@
 #error "__mulxi3 must be defined to use this generic implementation"
 #endif
 
-	.text
-	.align 2
+.text
+    .align 2
 
-	.globl __mulxi3
-	.type  __mulxi3, @function
-__mulxi3:
-	mv     a2, a0
-	mv     a0, zero
-.L1:
-	andi   a3, a1, 1
-	beqz   a3, .L2
-	add    a0, a0, a2
-.L2:
-	srli   a1, a1, 1
-	slli   a2, a2, 1
-	bnez   a1, .L1
-#ifdef __CHERI_PURE_CAPABILITY__
-	cret
-#else
-	ret
-#endif
+    .globl __mulxi3.type __mulxi3,
+    @function __mulxi3 : mv a2,
+                         a0 mv a0,
+                         zero.L1 : andi a3,
+                         a1,
+                         1 beqz a3,
+                         .L2 add a0,
+                         a0,
+                         a2.L2 : srli a1,
+                         a1,
+                         1 slli a2,
+                         a2,
+                         1 bnez a1,
+                         .L1 ret

--- a/libunwind/src/UnwindRegistersRestore.S
+++ b/libunwind/src/UnwindRegistersRestore.S
@@ -1329,7 +1329,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_sparc6jumptoEv)
 
 .macro restore_fpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  cfld   f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
+  fld    f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
 #else
   FLOAD  f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(\ctxreg)
 #endif
@@ -1337,7 +1337,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_sparc6jumptoEv)
 
 .macro restore_gpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  clc   c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
+  lc    c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
 #else
   ILOAD x\num, (RISCV_ISIZE * \num)(\ctxreg)
 #endif
@@ -1359,7 +1359,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
 
   // x0 is zero
 #ifdef __CHERI_PURE_CAPABILITY__
-  clc   c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // restore pc into ra
+  lc       c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // restore pc into ra
 #else
   ILOAD    x1, (RISCV_ISIZE * 0)(a0) // restore pc into ra
 #endif
@@ -1376,11 +1376,7 @@ DEFINE_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
   .endr
   restore_gpr 10, a0  // restore a0
 
-#ifdef __CHERI_PURE_CAPABILITY__
-  cret          // jump to cra
-#else
   ret           // jump to ra
-#endif
 END_LIBUNWIND_FUNCTION(_ZN9libunwind15Registers_riscv6jumptoEv)
 
 #elif defined(__s390x__)

--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -1318,7 +1318,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 .macro save_fpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  cfsd   f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
+  fsd    f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(c\ctxreg)
 #else
   FSTORE f\num, (RISCV_FOFFSET + RISCV_FSIZE * \num)(\ctxreg)
 #endif
@@ -1326,7 +1326,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 .macro save_gpr num, ctxreg
 #ifdef __CHERI_PURE_CAPABILITY__
-  csc   c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
+  sc     c\num, (__SIZEOF_CHERI_CAPABILITY__ * \num)(c\ctxreg)
 #else
   ISTORE x\num, (RISCV_ISIZE * \num)(\ctxreg)
 #endif
@@ -1340,7 +1340,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 #
 DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 #ifdef __CHERI_PURE_CAPABILITY__
-  csc   c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // store ra as pc
+  sc        c1, (__SIZEOF_CHERI_CAPABILITY__ * 0)(ca0) // store ra as pc
 #else
   ISTORE    x1, (RISCV_ISIZE * 0)(a0) // store ra as pc
 #if defined(__riscv_32e)
@@ -1358,11 +1358,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 # endif
 
   li     a0, 0  // return UNW_ESUCCESS
-#ifdef __CHERI_PURE_CAPABILITY__
-  cret          // jump to cra
-#else
-  ret           // jump to ra
-#endif
+  ret          // jump to ra
 END_LIBUNWIND_FUNCTION(__unw_getcontext)
 
 #elif defined(__s390x__)

--- a/lld/ELF/AArch64ErrataFix.cpp
+++ b/lld/ELF/AArch64ErrataFix.cpp
@@ -562,10 +562,10 @@ static void implementPatch(Ctx &ctx, uint64_t adrpAddr, uint64_t patcheeOffset,
   };
 
   if (relIt != isec->relocs().end()) {
-    ps->addReloc({relIt->expr, relIt->type, 0, relIt->addend, relIt->sym});
+    ps->addReloc(ctx, {relIt->expr, relIt->type, 0, relIt->addend, relIt->sym});
     *relIt = makeRelToPatch(patcheeOffset, ps->patchSym);
   } else
-    isec->addReloc(makeRelToPatch(patcheeOffset, ps->patchSym));
+    isec->addReloc(ctx, makeRelToPatch(patcheeOffset, ps->patchSym));
 }
 
 // Scan all the instructions in InputSectionDescription, for each instance of

--- a/lld/ELF/ARMErrataFix.cpp
+++ b/lld/ELF/ARMErrataFix.cpp
@@ -457,8 +457,8 @@ static void implementPatch(ScanResult sr, InputSection *isec,
       patchRelType = R_ARM_JUMP24;
       patchRelAddend -= 4;
     }
-    psec->addReloc(
-        Relocation{sr.rel->expr, patchRelType, 0, patchRelAddend, sr.rel->sym});
+    psec->addReloc(ctx, Relocation{sr.rel->expr, patchRelType, 0,
+                                   patchRelAddend, sr.rel->sym});
     // Redirect the existing branch relocation to the patch.
     sr.rel->expr = R_PC;
     sr.rel->addend = -4;
@@ -477,7 +477,7 @@ static void implementPatch(ScanResult sr, InputSection *isec,
       type = R_ARM_THM_JUMP24;
     else
       type = R_ARM_THM_CALL;
-    isec->addReloc(Relocation{R_PC, type, sr.off, -4, psec->patchSym});
+    isec->addReloc(ctx, Relocation{R_PC, type, sr.off, -4, psec->patchSym});
   }
   patches.push_back(psec);
 }

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -968,34 +968,6 @@ void addRelativeCapabilityRelocation(
   ctx.in.capRelocs->addCapReloc({&isec, offsetInSec}, {symOrSec, 0u}, addend);
 }
 
-void addCapabilityRelocation(
-    Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
-    RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,
-    int64_t addend, llvm::function_ref<std::string()> referencedBy,
-    RelocationBaseSection *dynRelSec) {
-  Symbol *sym = dyn_cast<Symbol *>(symOrSec);
-  assert(expr == R_ABS_CAP);
-
-  // Non-preemptible undef weak symbols are link-time constants and should use
-  // addNullDerivedCapability
-  if (sym)
-    assert(sym->isPreemptible || !sym->isUndefWeak());
-
-  // Emit either the legacy __cap_relocs section or a R_*_CHERI_CAPABILITY
-  // reloc
-  // For local symbols we can also emit the untagged capability bits and
-  // instruct csu/rtld to run CBuildCap
-  if (!sym || !sym->isPreemptible) {
-    addRelativeCapabilityRelocation(ctx, *sec, offset, symOrSec, addend, expr,
-                                    type);
-    return;
-  }
-
-  if (!dynRelSec)
-    dynRelSec = ctx.mainPart->relaDyn.get();
-  dynRelSec->addSymbolReloc(type, *sec, offset, *sym, addend, type);
-}
-
 void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,
                               uint64_t offset, int64_t addend) {
   // Only non-preemptible undef weak symbols are link-time constants

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -700,7 +700,7 @@ uint64_t MipsCheriCapTableSection::assignIndices(uint64_t startIndex,
     if (targetSym->isPreemptible)
       dynRelSec.addSymbolReloc(elfCapabilityReloc, *this, off, *targetSym);
     else if (targetSym->isUndefWeak())
-      addNullDerivedCapability(ctx, *targetSym, *this, off, 0);
+      addConstant(ctx, {R_ABS_CAP, elfCapabilityReloc, off, 0, targetSym});
     else
       addRelativeCapabilityRelocation(ctx, *this, off, targetSym, 0, R_ABS_CAP,
                                       elfCapabilityReloc);
@@ -749,7 +749,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
     uint64_t offset = *cti.index * ctx.arg.wordsize;
     if (s == nullptr) {
       if (!ctx.arg.shared)
-        addConstant({R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
+        addConstant(ctx, {R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
       else
         ctx.mainPart->relaDyn->addReloc(
             {ctx.target->tlsModuleIndexRel, this, offset});
@@ -759,7 +759,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
       // s->isPreemptible is not sufficient (this happens e.g. for
       // thread-locals that have been marked as local through a linker script)
       if (!s->isPreemptible && !ctx.arg.shared)
-        addConstant({R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
+        addConstant(ctx, {R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
       else
         ctx.mainPart->relaDyn->addSymbolReloc(ctx.target->tlsModuleIndexRel,
                                               *this, offset, *s);
@@ -769,7 +769,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
       // However, we can skip writing the TLS offset reloc for non-preemptible
       // symbols since it is known even in shared libraries
       if (!s->isPreemptible)
-        addConstant({R_ABS, ctx.target->tlsOffsetRel, offset, 0, s});
+        addConstant(ctx, {R_ABS, ctx.target->tlsOffsetRel, offset, 0, s});
       else
         ctx.mainPart->relaDyn->addSymbolReloc(ctx.target->tlsOffsetRel, *this,
                                               offset, *s);
@@ -786,7 +786,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
     // for the TP-relative offset as we don't know how much other data will
     // be allocated before us in the static TLS block.
     if (!s->isPreemptible && !ctx.arg.shared)
-      addConstant({R_TPREL, ctx.target->symbolicRel, offset, 0, s});
+      addConstant(ctx, {R_TPREL, ctx.target->symbolicRel, offset, 0, s});
     else
       ctx.mainPart->relaDyn->addAddendOnlyRelocIfNonPreemptible(
           ctx.target->tlsGotRel, *this, offset, *s, ctx.target->symbolicRel);
@@ -962,28 +962,6 @@ void addRelativeCapabilityRelocation(
   assert(!ctx.arg.useRelativeElfCheriRelocs &&
          "relative ELF capability relocations not currently implemented");
   ctx.in.capRelocs->addCapReloc({&isec, offsetInSec}, {symOrSec, 0u}, addend);
-}
-
-void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,
-                              uint64_t offset, int64_t addend) {
-  // Only non-preemptible undef weak symbols are link-time constants
-  assert(!sym.isPreemptible && sym.isUndefWeak());
-  if (ctx.arg.isLE) {
-    sec.addReloc({R_ABS, ctx.target->symbolicRel, offset, addend, &sym});
-    sec.addReloc({R_ADDEND, ctx.target->symbolicRel, offset + ctx.arg.wordsize,
-                  0, &sym});
-  } else {
-    sec.addReloc({R_ADDEND, ctx.target->symbolicRel, offset, 0, &sym});
-    sec.addReloc({R_ABS, ctx.target->symbolicRel, offset + ctx.arg.wordsize,
-                  addend, &sym});
-  }
-  // Handle deprecated CHERI-256
-  if (ctx.target->getCapabilitySize() == ctx.arg.wordsize * 4) {
-    sec.addReloc({R_ADDEND, ctx.target->symbolicRel,
-                  offset + 2 * ctx.arg.wordsize, 0, &sym});
-    sec.addReloc({R_ADDEND, ctx.target->symbolicRel,
-                  offset + 3 * ctx.arg.wordsize, 0, &sym});
-  }
 }
 
 } // namespace elf

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -936,6 +936,21 @@ static bool needsCheriMipsTrampoline(Ctx &ctx, RelType type,
   return true;
 }
 
+void addRelativeCapabilityRelocation(
+    Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
+    llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
+    RelExpr expr, RelType type) {
+  Symbol *sym = dyn_cast<Symbol *>(symOrSec);
+  assert(expr == R_ABS_CAP);
+  if (sym) {
+    assert(!needsCheriMipsTrampoline(ctx, type, *sym));
+    assert(!sym->isPreemptible);
+  }
+  assert(!ctx.arg.useRelativeCheriRelocs &&
+         "relative ELF capability relocations not currently implemented");
+  ctx.in.capRelocs->addCapReloc({&isec, offsetInSec}, {symOrSec, 0u}, addend);
+}
+
 void addCapabilityRelocation(
     Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
     RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,
@@ -956,9 +971,8 @@ void addCapabilityRelocation(
   // For local symbols we can also emit the untagged capability bits and
   // instruct csu/rtld to run CBuildCap
   if ((!sym || !sym->isPreemptible) && !needTrampoline) {
-    assert(!ctx.arg.useRelativeCheriRelocs &&
-           "relative ELF capability relocations not currently implemented");
-    ctx.in.capRelocs->addCapReloc({sec, offset}, {symOrSec, 0u}, addend);
+    addRelativeCapabilityRelocation(ctx, *sec, offset, symOrSec, addend, expr,
+                                    type);
     return;
   }
 

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -946,7 +946,7 @@ void addRelativeCapabilityRelocation(
     assert(!needsCheriMipsTrampoline(ctx, type, *sym));
     assert(!sym->isPreemptible);
   }
-  assert(!ctx.arg.useRelativeCheriRelocs &&
+  assert(!ctx.arg.useRelativeElfCheriRelocs &&
          "relative ELF capability relocations not currently implemented");
   ctx.in.capRelocs->addCapReloc({&isec, offsetInSec}, {symOrSec, 0u}, addend);
 }

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -903,6 +903,39 @@ static void getMipsCheriAbiVariant(std::optional<unsigned> &abi,
   abi = static_cast<MipsAbiFlagsSection<ELFT> &>(sec).getCheriAbiVariant();
 }
 
+static bool needsCheriMipsTrampoline(Ctx &ctx, RelType type,
+                                     const Symbol &sym) {
+  // In the PLT ABI (and fndesc?) we have to use an elf relocation for function
+  // pointers to ensure that the runtime linker adds the required trampolines
+  // that sets $cgp:
+
+  if (ctx.arg.emachine != EM_MIPS)
+    return false;
+
+  if (!sym.isFunc() || type == *ctx.target->cheriCapCallRel)
+    return false;
+
+  // In static binaries we do not need PLT stubs for function pointers since
+  // all functions share the same $cgp
+  // TODO: this is no longer true if we were to support dlopen() in static
+  // binaries
+  if (!lld::elf::hasDynamicLinker(ctx))
+    return false;
+
+  if (!ctx.in.mipsAbiFlags)
+    return false;
+
+  std::optional<unsigned> abi;
+  invokeELFT(getMipsCheriAbiVariant, abi, *ctx.in.mipsAbiFlags);
+  if (!abi)
+    return false;
+
+  if (*abi != DF_MIPS_CHERI_ABI_PLT && *abi != DF_MIPS_CHERI_ABI_FNDESC)
+    return false;
+
+  return true;
+}
+
 void addCapabilityRelocation(
     Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
     RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,
@@ -911,33 +944,12 @@ void addCapabilityRelocation(
   Symbol *sym = dyn_cast<Symbol *>(symOrSec);
   assert(expr == R_ABS_CAP);
 
-  bool needTrampoline = false;
-  // In the PLT ABI (and fndesc?) we have to use an elf relocation for function
-  // pointers to ensure that the runtime linker adds the required trampolines
-  // that sets $cgp:
-  if (ctx.arg.emachine == llvm::ELF::EM_MIPS && sym && sym->isFunc() &&
-      type != *ctx.target->cheriCapCallRel) {
-    // In static binaries we do not need PLT stubs for function pointers since
-    // all functions share the same $cgp
-    // TODO: this is no longer true if we were to support dlopen() in static
-    // binaries
-    if (lld::elf::hasDynamicLinker(ctx) && ctx.in.mipsAbiFlags) {
-      std::optional<unsigned> abi;
-      invokeELFT(getMipsCheriAbiVariant, abi, *ctx.in.mipsAbiFlags);
-      if (abi && (*abi == llvm::ELF::DF_MIPS_CHERI_ABI_PLT ||
-                  *abi == llvm::ELF::DF_MIPS_CHERI_ABI_FNDESC))
-        needTrampoline = true;
-    }
-
-    if (needTrampoline && ctx.arg.verboseCapRelocs)
-      message("Using trampoline for function pointer against " +
-              verboseToString(ctx, sym));
-  }
-
   // Non-preemptible undef weak symbols are link-time constants and should use
   // addNullDerivedCapability
   if (sym)
     assert(sym->isPreemptible || !sym->isUndefWeak());
+
+  bool needTrampoline = sym && needsCheriMipsTrampoline(ctx, type, *sym);
 
   // Emit either the legacy __cap_relocs section or a R_*_CHERI_CAPABILITY
   // reloc
@@ -964,6 +976,9 @@ void addCapabilityRelocation(
   // the offset addend
   if (!dynRelSec)
     dynRelSec = ctx.mainPart->relaDyn.get();
+  if (needTrampoline && ctx.arg.verboseCapRelocs)
+    message("Using trampoline for function pointer against " +
+            verboseToString(ctx, sym));
   if (needTrampoline && !isSymIncludedInDynsym(ctx, *sym)) {
     // Hack: Add a new global symbol with a unique name so that we can use
     // a dynamic relocation against it.

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -956,10 +956,18 @@ void addRelativeCapabilityRelocation(
     RelExpr expr, RelType type) {
   Symbol *sym = dyn_cast<Symbol *>(symOrSec);
   assert(expr == R_ABS_CAP);
-  if (sym) {
-    assert(!needsCheriMipsTrampoline(ctx, type, *sym));
-    assert(!sym->isPreemptible);
+  if (sym && needsCheriMipsTrampoline(ctx, type, *sym)) {
+    if (ctx.arg.verboseCapRelocs)
+      message("Forcing symbolic relocation for non-preemptible "
+              "trampoline-using function pointer against " +
+              verboseToString(ctx, sym));
+
+    sym = &getCheriMipsTrampolineSym(ctx, type, *sym);
+    ctx.mainPart->relaDyn->addSymbolReloc(type, isec, offsetInSec, *sym, addend,
+                                          type);
+    return;
   }
+  assert(!sym || !sym->isPreemptible);
   assert(!ctx.arg.useRelativeElfCheriRelocs &&
          "relative ELF capability relocations not currently implemented");
   ctx.in.capRelocs->addCapReloc({&isec, offsetInSec}, {symOrSec, 0u}, addend);
@@ -978,23 +986,14 @@ void addCapabilityRelocation(
   if (sym)
     assert(sym->isPreemptible || !sym->isUndefWeak());
 
-  bool needTrampoline = sym && needsCheriMipsTrampoline(ctx, type, *sym);
-
   // Emit either the legacy __cap_relocs section or a R_*_CHERI_CAPABILITY
   // reloc
   // For local symbols we can also emit the untagged capability bits and
   // instruct csu/rtld to run CBuildCap
-  if ((!sym || !sym->isPreemptible) && !needTrampoline) {
+  if (!sym || !sym->isPreemptible) {
     addRelativeCapabilityRelocation(ctx, *sec, offset, symOrSec, addend, expr,
                                     type);
     return;
-  }
-
-  if (needTrampoline) {
-    if (ctx.arg.verboseCapRelocs)
-      message("Using trampoline for function pointer against " +
-              verboseToString(ctx, sym));
-    sym = &getCheriMipsTrampolineSym(ctx, type, *sym);
   }
 
   if (!dynRelSec)

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -917,15 +917,11 @@ void addCapabilityRelocation(
   // that sets $cgp:
   if (ctx.arg.emachine == llvm::ELF::EM_MIPS && sym && sym->isFunc() &&
       type != *ctx.target->cheriCapCallRel) {
-    if (!lld::elf::hasDynamicLinker(ctx)) {
-      // In static binaries we do not need PLT stubs for function pointers since
-      // all functions share the same $cgp
-      // TODO: this is no longer true if we were to support dlopen() in static
-      // binaries
-      if (ctx.arg.verboseCapRelocs)
-        Msg(ctx) << "Do not need function pointer trampoline for "
-                 << toStr(ctx, *sym) << " in static binary";
-    } else if (ctx.in.mipsAbiFlags) {
+    // In static binaries we do not need PLT stubs for function pointers since
+    // all functions share the same $cgp
+    // TODO: this is no longer true if we were to support dlopen() in static
+    // binaries
+    if (lld::elf::hasDynamicLinker(ctx) && ctx.in.mipsAbiFlags) {
       std::optional<unsigned> abi;
       invokeELFT(getMipsCheriAbiVariant, abi, *ctx.in.mipsAbiFlags);
       if (abi && (*abi == llvm::ELF::DF_MIPS_CHERI_ABI_PLT ||

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -954,6 +954,15 @@ void addCapabilityRelocation(
     return;
   }
 
+  if (sym->isFunc() && addend != 0) {
+    auto diag = Warn(ctx);
+    diag << "capability relocation with non-zero addend (0x"
+         << llvm::utohexstr(addend) << ") against preemptible function "
+         << toStr(ctx, *sym)
+         << "; this may not be supported by the runtime linker.";
+    printLocationMessage(diag, *sec, *sym, offset);
+  }
+
   // We don't use a R_MIPS_CHERI_CAPABILITY relocation for the input but
   // instead need to use an absolute pointer size relocation to write
   // the offset addend

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -702,7 +702,7 @@ uint64_t MipsCheriCapTableSection::assignIndices(uint64_t startIndex,
       addNullDerivedCapability(ctx, *targetSym, *this, off, 0);
     else
       addCapabilityRelocation(
-          ctx, targetSym, elfCapabilityReloc, this, off, R_CHERI_CAPABILITY, 0,
+          ctx, targetSym, elfCapabilityReloc, this, off, R_ABS_CAP, 0,
           it.second.usedInCallExpr,
           [&]() {
             return ("\n>>> referenced by " + refName + "\n>>> first used in " +
@@ -911,7 +911,7 @@ void addCapabilityRelocation(
     llvm::function_ref<std::string()> referencedBy,
     RelocationBaseSection *dynRelSec) {
   Symbol *sym = dyn_cast<Symbol *>(symOrSec);
-  assert(expr == R_CHERI_CAPABILITY);
+  assert(expr == R_ABS_CAP);
 
   bool needTrampoline = false;
   // In the PLT ABI (and fndesc?) we have to use an elf relocation for function

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -351,6 +351,12 @@ void CheriCapRelocsSection::writeToImpl(uint8_t *buf) {
     bool isFunc, isTls;
     OutputSection *os;
     if (Symbol *s = dyn_cast<Symbol *>(realTarget.symOrSec)) {
+      if (s->isGnuIFunc())
+        error("cannot reference non-preemptible IFUNC as a capability, "
+              "needed for symbol " +
+              verboseToString(ctx, s) + "\n>>> referenced by " +
+              location.toString(ctx));
+
       targetVA = realTarget.sym()->getVA(ctx, 0);
       isFunc = s->isFunc();
       isTls = s->isTls();

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -695,20 +695,15 @@ uint64_t MipsCheriCapTableSection::assignIndices(uint64_t startIndex,
     // All capability call relocations should end up in the pltrel section
     // rather than the normal relocation section to make processing of PLT
     // relocations in RTLD more efficient.
-    RelocationBaseSection *dynRelSec = it.second.usedInCallExpr
-                                           ? ctx.in.relaPlt.get()
-                                           : ctx.mainPart->relaDyn.get();
-    if (!targetSym->isPreemptible && targetSym->isUndefWeak())
+    RelocationBaseSection &dynRelSec =
+        it.second.usedInCallExpr ? *ctx.in.relaPlt : *ctx.mainPart->relaDyn;
+    if (targetSym->isPreemptible)
+      dynRelSec.addSymbolReloc(elfCapabilityReloc, *this, off, *targetSym);
+    else if (targetSym->isUndefWeak())
       addNullDerivedCapability(ctx, *targetSym, *this, off, 0);
     else
-      addCapabilityRelocation(
-          ctx, targetSym, elfCapabilityReloc, this, off, R_ABS_CAP, 0,
-          [&]() {
-            return ("\n>>> referenced by " + refName + "\n>>> first used in " +
-                    it.second.firstUse->verboseToString(ctx))
-                .str();
-          },
-          dynRelSec);
+      addRelativeCapabilityRelocation(ctx, *this, off, targetSym, 0, R_ABS_CAP,
+                                      elfCapabilityReloc);
   }
   assert(assignedSmallIndexes + assignedLargeIndexes == entries.size());
   return assignedSmallIndexes + assignedLargeIndexes;

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -979,9 +979,12 @@ void addCapabilityRelocation(
     assert(newSym->visibility() == llvm::ELF::STV_HIDDEN);
     sym = newSym; // Make the relocation point to the newly added symbol
   }
+  // .chericap initialises the memory to 0xcacacaca not 0, so if writing
+  // addends we still need to write even it if zero.
+  // TODO: Stop doing this in the assembler and drop this hack
   dynRelSec->addReloc(
-      DynamicReloc::AgainstSymbol, type, *sec, offset, *sym, addend, expr,
-      /* Relocation type for the addend = */ ctx.target->symbolicRel);
+      DynamicReloc::AgainstSymbol, type, *sec, offset, *sym, addend, R_ADDEND,
+      /*addendRelType=*/ctx.target->symbolicRel, /*writeZero=*/true);
 }
 
 void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -749,8 +749,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
     uint64_t offset = *cti.index * ctx.arg.wordsize;
     if (s == nullptr) {
       if (!ctx.arg.shared)
-        this->relocations.push_back(
-            {R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
+        addConstant({R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
       else
         ctx.mainPart->relaDyn->addReloc(
             {ctx.target->tlsModuleIndexRel, this, offset});
@@ -760,8 +759,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
       // s->isPreemptible is not sufficient (this happens e.g. for
       // thread-locals that have been marked as local through a linker script)
       if (!s->isPreemptible && !ctx.arg.shared)
-        this->relocations.push_back(
-            {R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
+        addConstant({R_ADDEND, ctx.target->symbolicRel, offset, 1, s});
       else
         ctx.mainPart->relaDyn->addSymbolReloc(ctx.target->tlsModuleIndexRel,
                                               *this, offset, *s);
@@ -771,8 +769,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
       // However, we can skip writing the TLS offset reloc for non-preemptible
       // symbols since it is known even in shared libraries
       if (!s->isPreemptible)
-        this->relocations.push_back(
-            {R_ABS, ctx.target->tlsOffsetRel, offset, 0, s});
+        addConstant({R_ABS, ctx.target->tlsOffsetRel, offset, 0, s});
       else
         ctx.mainPart->relaDyn->addSymbolReloc(ctx.target->tlsOffsetRel, *this,
                                               offset, *s);
@@ -789,8 +786,7 @@ void MipsCheriCapTableSection::assignValuesAndAddCapTableSymbols() {
     // for the TP-relative offset as we don't know how much other data will
     // be allocated before us in the static TLS block.
     if (!s->isPreemptible && !ctx.arg.shared)
-      this->relocations.push_back(
-          {R_TPREL, ctx.target->symbolicRel, offset, 0, s});
+      addConstant({R_TPREL, ctx.target->symbolicRel, offset, 0, s});
     else
       ctx.mainPart->relaDyn->addAddendOnlyRelocIfNonPreemptible(
           ctx.target->tlsGotRel, *this, offset, *s, ctx.target->symbolicRel);

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -703,7 +703,6 @@ uint64_t MipsCheriCapTableSection::assignIndices(uint64_t startIndex,
     else
       addCapabilityRelocation(
           ctx, targetSym, elfCapabilityReloc, this, off, R_ABS_CAP, 0,
-          it.second.usedInCallExpr,
           [&]() {
             return ("\n>>> referenced by " + refName + "\n>>> first used in " +
                     it.second.firstUse->verboseToString(ctx))
@@ -907,8 +906,7 @@ static void getMipsCheriAbiVariant(std::optional<unsigned> &abi,
 void addCapabilityRelocation(
     Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
     RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,
-    int64_t addend, bool isCallExpr,
-    llvm::function_ref<std::string()> referencedBy,
+    int64_t addend, llvm::function_ref<std::string()> referencedBy,
     RelocationBaseSection *dynRelSec) {
   Symbol *sym = dyn_cast<Symbol *>(symOrSec);
   assert(expr == R_ABS_CAP);
@@ -917,8 +915,8 @@ void addCapabilityRelocation(
   // In the PLT ABI (and fndesc?) we have to use an elf relocation for function
   // pointers to ensure that the runtime linker adds the required trampolines
   // that sets $cgp:
-  if (!isCallExpr && ctx.arg.emachine == llvm::ELF::EM_MIPS && sym &&
-      sym->isFunc()) {
+  if (ctx.arg.emachine == llvm::ELF::EM_MIPS && sym && sym->isFunc() &&
+      type != *ctx.target->cheriCapCallRel) {
     if (!lld::elf::hasDynamicLinker(ctx)) {
       // In static binaries we do not need PLT stubs for function pointers since
       // all functions share the same $cgp

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -86,8 +86,9 @@ SymbolAndOffset SymbolAndOffset::fromSectionWithOffset(
     }
   }
   // When using the legacy __cap_relocs style (where clang emits __cap_relocs
-  // instead of R_CHERI_CAPABILITY) the local symbols might not exist so we
+  // instead of R_*_CHERI_CAPABILITY) the local symbols might not exist so we
   // may have fall back to the section.
+  // TODO: Revisit this now we no longer support __cap_relocs input.
   if (!fallbackResult) {
     // worst case we fall back to the section + offset
     // Don't warn if the relocation is against an anonymous string constant
@@ -944,7 +945,8 @@ void addCapabilityRelocation(
   if (sym)
     assert(sym->isPreemptible || !sym->isUndefWeak());
 
-  // Emit either the legacy __cap_relocs section or a R_CHERI_CAPABILITY reloc
+  // Emit either the legacy __cap_relocs section or a R_*_CHERI_CAPABILITY
+  // reloc
   // For local symbols we can also emit the untagged capability bits and
   // instruct csu/rtld to run CBuildCap
   if ((!sym || !sym->isPreemptible) && !needTrampoline) {
@@ -963,7 +965,7 @@ void addCapabilityRelocation(
     printLocationMessage(diag, *sec, *sym, offset);
   }
 
-  // We don't use a R_MIPS_CHERI_CAPABILITY relocation for the input but
+  // We don't use a R_*_CHERI_CAPABILITY relocation for the input but
   // instead need to use an absolute pointer size relocation to write
   // the offset addend
   if (!dynRelSec)

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -318,6 +318,8 @@ struct CaptablePermissions {
                                    << ((sizeof(typename ELFT::uint) * 8) - 1);
   static const uint64_t readOnly = UINT64_C(1)
                                    << ((sizeof(typename ELFT::uint) * 8) - 2);
+  static const uint64_t indirect = UINT64_C(1)
+                                   << ((sizeof(typename ELFT::uint) * 8) - 3);
 };
 
 template <class ELFT>
@@ -349,23 +351,19 @@ void CheriCapRelocsSection::writeToImpl(uint8_t *buf) {
 
     // The target VA is the base address of the capability, so symbol + 0
     uint64_t targetVA;
-    bool isFunc, isTls;
+    bool isFunc, isGnuIFunc, isTls;
     OutputSection *os;
     if (Symbol *s = dyn_cast<Symbol *>(realTarget.symOrSec)) {
-      if (s->isGnuIFunc())
-        error("cannot reference non-preemptible IFUNC as a capability, "
-              "needed for symbol " +
-              verboseToString(ctx, s) + "\n>>> referenced by " +
-              location.toString(ctx));
-
       targetVA = realTarget.sym()->getVA(ctx, 0);
       isFunc = s->isFunc();
+      isGnuIFunc = s->isGnuIFunc();
       isTls = s->isTls();
       os = s->getOutputSection();
     } else {
       InputSectionBase *isec = cast<InputSectionBase *>(realTarget.symOrSec);
       targetVA = isec->getVA(0);
       isFunc = (isec->flags & SHF_EXECINSTR) != 0;
+      isGnuIFunc = false;
       isTls = isec->type == STT_TLS;
       os = isec->getOutputSection();
     }
@@ -373,8 +371,10 @@ void CheriCapRelocsSection::writeToImpl(uint8_t *buf) {
     uint64_t targetOffset = reloc.capabilityOffset + realTarget.offset;
     uint64_t permissions = 0;
     // Fow now Function implies ReadOnly so don't add the flag
-    if (isFunc) {
+    if (isFunc || isGnuIFunc) {
       permissions |= CaptablePermissions<ELFT>::function;
+      if (isGnuIFunc)
+        permissions |= CaptablePermissions<ELFT>::indirect;
     } else if (os) {
       assert(!isTls);
       // if ((OS->getPhdrFlags() & PF_W) == 0) {

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -985,9 +985,6 @@ void addCapabilityRelocation(
     printLocationMessage(diag, *sec, *sym, offset);
   }
 
-  // We don't use a R_*_CHERI_CAPABILITY relocation for the input but
-  // instead need to use an absolute pointer size relocation to write
-  // the offset addend
   if (!dynRelSec)
     dynRelSec = ctx.mainPart->relaDyn.get();
   if (needTrampoline && ctx.arg.verboseCapRelocs)
@@ -1007,9 +1004,9 @@ void addCapabilityRelocation(
   // .chericap initialises the memory to 0xcacacaca not 0, so if writing
   // addends we still need to write even it if zero.
   // TODO: Stop doing this in the assembler and drop this hack
-  dynRelSec->addReloc(
-      DynamicReloc::AgainstSymbol, type, *sec, offset, *sym, addend, R_ADDEND,
-      /*addendRelType=*/ctx.target->symbolicRel, /*writeZero=*/true);
+  dynRelSec->addReloc(DynamicReloc::AgainstSymbol, type, *sec, offset, *sym,
+                      addend, R_ADDEND,
+                      /*addendRelType=*/type, /*writeZero=*/true);
 }
 
 void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -976,17 +976,6 @@ void addCapabilityRelocation(
     return;
   }
 
-  if (sym->isFunc() && addend != 0) {
-    auto diag = Warn(ctx);
-    diag << "capability relocation with non-zero addend (0x"
-         << llvm::utohexstr(addend) << ") against preemptible function "
-         << toStr(ctx, *sym)
-         << "; this may not be supported by the runtime linker.";
-    printLocationMessage(diag, *sec, *sym, offset);
-  }
-
-  if (!dynRelSec)
-    dynRelSec = ctx.mainPart->relaDyn.get();
   if (needTrampoline && ctx.arg.verboseCapRelocs)
     message("Using trampoline for function pointer against " +
             verboseToString(ctx, sym));
@@ -1001,12 +990,9 @@ void addCapabilityRelocation(
     assert(newSym->visibility() == llvm::ELF::STV_HIDDEN);
     sym = newSym; // Make the relocation point to the newly added symbol
   }
-  // .chericap initialises the memory to 0xcacacaca not 0, so if writing
-  // addends we still need to write even it if zero.
-  // TODO: Stop doing this in the assembler and drop this hack
-  dynRelSec->addReloc(DynamicReloc::AgainstSymbol, type, *sec, offset, *sym,
-                      addend, R_ADDEND,
-                      /*addendRelType=*/type, /*writeZero=*/true);
+  if (!dynRelSec)
+    dynRelSec = ctx.mainPart->relaDyn.get();
+  dynRelSec->addSymbolReloc(type, *sec, offset, *sym, addend, type);
 }
 
 void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -936,6 +936,20 @@ static bool needsCheriMipsTrampoline(Ctx &ctx, RelType type,
   return true;
 }
 
+static Symbol &getCheriMipsTrampolineSym(Ctx &ctx, RelType type, Symbol &sym) {
+  assert(needsCheriMipsTrampoline(ctx, type, sym));
+
+  if (isSymIncludedInDynsym(ctx, sym))
+    return sym;
+
+  Defined &newSym = *ctx.symtab->ensureSymbolWillBeInDynsym(&sym);
+  assert(newSym.isFunc() && "This should only be used for functions");
+  assert(isSymIncludedInDynsym(ctx, newSym));
+  assert(newSym.binding == llvm::ELF::STB_GLOBAL);
+  assert(newSym.visibility() == llvm::ELF::STV_HIDDEN);
+  return newSym;
+}
+
 void addRelativeCapabilityRelocation(
     Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
     llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
@@ -976,20 +990,13 @@ void addCapabilityRelocation(
     return;
   }
 
-  if (needTrampoline && ctx.arg.verboseCapRelocs)
-    message("Using trampoline for function pointer against " +
-            verboseToString(ctx, sym));
-  if (needTrampoline && !isSymIncludedInDynsym(ctx, *sym)) {
-    // Hack: Add a new global symbol with a unique name so that we can use
-    // a dynamic relocation against it.
-    // TODO: should it be possible to add STB_LOCAL symbols to .dynsymtab?
-    Defined *newSym = ctx.symtab->ensureSymbolWillBeInDynsym(sym);
-    assert(newSym->isFunc() && "This should only be used for functions");
-    assert(isSymIncludedInDynsym(ctx, *newSym));
-    assert(newSym->binding == llvm::ELF::STB_GLOBAL);
-    assert(newSym->visibility() == llvm::ELF::STV_HIDDEN);
-    sym = newSym; // Make the relocation point to the newly added symbol
+  if (needTrampoline) {
+    if (ctx.arg.verboseCapRelocs)
+      message("Using trampoline for function pointer against " +
+              verboseToString(ctx, sym));
+    sym = &getCheriMipsTrampolineSym(ctx, type, *sym);
   }
+
   if (!dynRelSec)
     dynRelSec = ctx.mainPart->relaDyn.get();
   dynRelSec->addSymbolReloc(type, *sec, offset, *sym, addend, type);

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -353,12 +353,6 @@ void addSymbolCapabilityRelocation(RelType dynType, RelocationBaseSection &rel,
                                    InputSectionBase &isec, uint64_t offsetInSec,
                                    Symbol &sym, int64_t addend = 0);
 
-void addCapabilityRelocation(
-    Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> target,
-    RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,
-    int64_t addend, llvm::function_ref<std::string()> referencedBy,
-    RelocationBaseSection *dynRelSec = nullptr);
-
 void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,
                               uint64_t offset, int64_t addend);
 } // namespace elf

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -344,6 +344,11 @@ inline uint64_t getBiasedCGPOffsetLo12(Ctx &ctx, const Symbol &sym)
   return (mask << 11) | (Displacement & ((1L << 11) - 1));
 }
 
+void addRelativeCapabilityRelocation(
+    Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
+    llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
+    RelExpr expr, RelType type);
+
 void addCapabilityRelocation(
     Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> target,
     RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -171,6 +171,7 @@ private:
 class MipsCheriCapTableSection : public SyntheticSection {
 public:
   MipsCheriCapTableSection(Ctx &ctx);
+  void addConstant(const Relocation &r) { addReloc(r); }
   // InputFile and Offset is needed in order to implement per-file/per-function
   // tables
   void addEntry(Symbol &sym, RelExpr expr, InputSectionBase *isec,

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -171,7 +171,7 @@ private:
 class MipsCheriCapTableSection : public SyntheticSection {
 public:
   MipsCheriCapTableSection(Ctx &ctx);
-  void addConstant(const Relocation &r) { addReloc(r); }
+  void addConstant(Ctx &ctx, const Relocation &r) { addReloc(ctx, r); }
   // InputFile and Offset is needed in order to implement per-file/per-function
   // tables
   void addEntry(Symbol &sym, RelExpr expr, InputSectionBase *isec,
@@ -353,9 +353,6 @@ void addRelativeCapabilityRelocation(
 void addSymbolCapabilityRelocation(RelType dynType, RelocationBaseSection &rel,
                                    InputSectionBase &isec, uint64_t offsetInSec,
                                    Symbol &sym, int64_t addend = 0);
-
-void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,
-                              uint64_t offset, int64_t addend);
 } // namespace elf
 } // namespace lld
 

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -349,10 +349,6 @@ void addRelativeCapabilityRelocation(
     Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
     llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
     RelExpr expr, RelType type);
-
-void addSymbolCapabilityRelocation(RelType dynType, RelocationBaseSection &rel,
-                                   InputSectionBase &isec, uint64_t offsetInSec,
-                                   Symbol &sym, int64_t addend = 0);
 } // namespace elf
 } // namespace lld
 

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -347,8 +347,7 @@ inline uint64_t getBiasedCGPOffsetLo12(Ctx &ctx, const Symbol &sym)
 void addCapabilityRelocation(
     Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> target,
     RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,
-    int64_t addend, bool isCallExpr,
-    llvm::function_ref<std::string()> referencedBy,
+    int64_t addend, llvm::function_ref<std::string()> referencedBy,
     RelocationBaseSection *dynRelSec = nullptr);
 
 void addNullDerivedCapability(Ctx &ctx, Symbol &sym, InputSectionBase &sec,

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -349,6 +349,10 @@ void addRelativeCapabilityRelocation(
     llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
     RelExpr expr, RelType type);
 
+void addSymbolCapabilityRelocation(RelType dynType, RelocationBaseSection &rel,
+                                   InputSectionBase &isec, uint64_t offsetInSec,
+                                   Symbol &sym, int64_t addend = 0);
+
 void addCapabilityRelocation(
     Ctx &ctx, llvm::PointerUnion<Symbol *, InputSectionBase *> target,
     RelType type, InputSectionBase *sec, uint64_t offset, RelExpr expr,

--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -207,7 +207,7 @@ RelExpr MIPS<ELFT>::getRelExpr(RelType type, const Symbol &s,
   case R_MIPS_NONE:
     return R_NONE;
   case R_MIPS_CHERI_CAPABILITY:
-    return R_CHERI_CAPABILITY;
+    return R_ABS_CAP;
   case R_MIPS_CHERI_CAPTAB_LO16:
   case R_MIPS_CHERI_CAPTAB_HI16:
     return R_MIPS_CHERI_CAPTAB_INDEX;

--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -237,7 +237,7 @@ RelExpr MIPS<ELFT>::getRelExpr(RelType type, const Symbol &s,
 }
 
 template <class ELFT> RelType MIPS<ELFT>::getDynRel(RelType type) const {
-  if (type == symbolicRel)
+  if (type == symbolicRel || type == cheriCapRel)
     return type;
   return R_MIPS_NONE;
 }

--- a/lld/ELF/Arch/Mips.cpp
+++ b/lld/ELF/Arch/Mips.cpp
@@ -828,7 +828,13 @@ void MIPS<ELFT>::relocate(uint8_t *loc, const Relocation &rel,
     writeShuffle<e>(ctx, loc, val, 23, 2);
     break;
   case R_MIPS_CHERI_CAPABILITY:
-    llvm_unreachable("R_MIPS_CHERI_CAPABILITY should never be handled here!");
+  case R_MIPS_CHERI_CAPABILITY_CALL:
+    // Write a word within the capability
+    if (ctx.arg.is64)
+      write64(ctx, loc, val);
+    else
+      write32(ctx, loc, val);
+    break;
   default:
     llvm_unreachable("unknown relocation");
   }

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -679,6 +679,14 @@ void RISCV::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     break;
   }
 
+  case R_RISCV_CHERI_CAPABILITY:
+    // Write a word within the capability
+    if (ctx.arg.is64)
+      write64le(loc, val);
+    else
+      write32le(loc, val);
+    break;
+
   default:
     llvm_unreachable("unknown relocation");
   }

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -382,7 +382,7 @@ RelExpr RISCV::getRelExpr(const RelType type, const Symbol &s,
   case R_RISCV_SUB_ULEB128:
     return RE_RISCV_LEB128;
     case R_RISCV_CHERI_CAPABILITY:
-    return R_CHERI_CAPABILITY;
+      return R_ABS_CAP;
     // TODO: Deprecate and eventually remove these
     case R_RISCV_CHERI_CAPTAB_PCREL_HI20:
       return R_GOT_PC;

--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -308,8 +308,9 @@ void RISCV::writePlt(uint8_t *buf, const Symbol &sym,
 }
 
 RelType RISCV::getDynRel(RelType type) const {
-  return type == ctx.target->symbolicRel ? type
-                                         : static_cast<RelType>(R_RISCV_NONE);
+  return type == symbolicRel || type == cheriCapRel
+             ? type
+             : static_cast<RelType>(R_RISCV_NONE);
 }
 
 RelExpr RISCV::getRelExpr(const RelType type, const Symbol &s,

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -453,7 +453,7 @@ struct Config {
   UnresolvedPolicy unresolvedSymbolsInShlib;
   Target2Policy target2;
   GcsPolicy zGcs;
-  bool useRelativeCheriRelocs;
+  bool useRelativeElfCheriRelocs;
   CapTableScopePolicy capTableScope;
 
   bool power10Stubs;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -481,7 +481,7 @@ static void checkOptions(Ctx &ctx) {
       ErrAlways(ctx) << "-r and -z nosectionheader may not be used together";
   }
 
-  if (ctx.arg.useRelativeCheriRelocs)
+  if (ctx.arg.useRelativeElfCheriRelocs)
     error("local-cap-relocs=elf is not implemented yet");
 
   if (ctx.arg.executeOnly) {
@@ -1472,7 +1472,7 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
       args.hasArg(OPT_ignore_function_address_equality);
   ctx.arg.init = args.getLastArgValue(OPT_init, "_init");
   // TODO: change default to true
-  ctx.arg.useRelativeCheriRelocs =
+  ctx.arg.useRelativeElfCheriRelocs =
       args.hasFlag(OPT_local_caprelocs_elf, OPT_local_caprelocs_legacy, false);
   ctx.arg.ltoAAPipeline = args.getLastArgValue(OPT_lto_aa_pipeline);
   ctx.arg.ltoCSProfileGenerate = args.hasArg(OPT_lto_cs_profile_generate);

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -554,7 +554,7 @@ void InputSection::copyRelocations(Ctx &ctx, uint8_t *buf,
       // this sec->relocations change.
       else if (ctx.arg.relocatable && (sec->flags & SHF_ALLOC) &&
                type != target.noneRel)
-        sec->addReloc({R_ABS, type, rel.offset, addend, &sym});
+        sec->addReloc(ctx, {R_ABS, type, rel.offset, addend, &sym});
     } else if (ctx.arg.emachine == EM_PPC && type == R_PPC_PLTREL24 &&
                p->r_addend >= 0x8000 && sec->file->ppc32Got2) {
       // Similar to R_MIPS_GPREL{16,32}. If the addend of R_PPC_PLTREL24
@@ -1014,6 +1014,12 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
     return ctx.in.got->getTlsIndexVA() + a - p;
   case R_ABS_CAP:
     llvm_unreachable("R_ABS_CAP should not be handled here!");
+  case R_ABS_CAP_ADDR:
+    return r.sym->getVA(ctx, a);
+  case R_ABS_CAP_META:
+    assert(r.sym->isUndefined() &&
+           "cannot encode non-null derived capability yet");
+    return 0;
   case R_MIPS_CHERI_CAPTAB_INDEX:
   case R_MIPS_CHERI_CAPTAB_INDEX_SMALL_IMMEDIATE:
   case R_MIPS_CHERI_CAPTAB_INDEX_CALL:
@@ -1065,6 +1071,28 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
   default:
     llvm_unreachable("invalid expression");
   }
+}
+
+void InputSectionBase::addRelocCap(Ctx &ctx, const Relocation &r) {
+  assert(r.expr == R_ABS_CAP);
+
+  RelExpr exprLo = R_ABS_CAP_ADDR, exprHi = R_ABS_CAP_META;
+  if (!ctx.arg.isLE)
+    std::swap(exprLo, exprHi);
+
+  addReloc(ctx, {exprLo, r.type, r.offset, r.addend, r.sym});
+  addReloc(ctx, {exprHi, r.type, r.offset + ctx.arg.wordsize, r.addend, r.sym});
+
+  // Handle deprecated CHERI-256
+  if (ctx.arg.capabilitySize == ctx.arg.wordsize * 4) {
+    assert(r.sym->isUndefined() &&
+           "can encode only null-derived capabilities for CHERI-256");
+    addReloc(ctx, {R_ABS_CAP_META, r.type, r.offset + 2 * ctx.arg.wordsize,
+                   r.addend, r.sym});
+    addReloc(ctx, {R_ABS_CAP_META, r.type, r.offset + 3 * ctx.arg.wordsize,
+                   r.addend, r.sym});
+  } else
+    assert(ctx.arg.capabilitySize == ctx.arg.wordsize * 2);
 }
 
 // This function applies relocations to sections without SHF_ALLOC bit.

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -1012,8 +1012,8 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
     return ctx.in.got->getTlsIndexOff() + a;
   case R_TLSLD_PC:
     return ctx.in.got->getTlsIndexVA() + a - p;
-  case R_CHERI_CAPABILITY:
-    llvm_unreachable("R_CHERI_CAPABILITY should not be handled here!");
+  case R_ABS_CAP:
+    llvm_unreachable("R_ABS_CAP should not be handled here!");
   case R_MIPS_CHERI_CAPTAB_INDEX:
   case R_MIPS_CHERI_CAPTAB_INDEX_SMALL_IMMEDIATE:
   case R_MIPS_CHERI_CAPTAB_INDEX_CALL:

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -276,7 +276,12 @@ public:
   // This vector contains such "cooked" relocations.
   SmallVector<Relocation, 0> relocations;
 
-  void addReloc(const Relocation &r) { relocations.push_back(r); }
+  void addReloc(Ctx &ctx, const Relocation &r) {
+    if (r.expr == R_ABS_CAP)
+      addRelocCap(ctx, r);
+    else
+      relocations.push_back(r);
+  }
   MutableArrayRef<Relocation> relocs() { return relocations; }
   ArrayRef<Relocation> relocs() const { return relocations; }
 
@@ -312,6 +317,9 @@ public:
 protected:
   template <typename ELFT> void parseCompressedHeader(Ctx &);
   void decompress() const;
+
+private:
+  void addRelocCap(Ctx &ctx, const Relocation &r);
 };
 
 // SectionPiece represents a piece of splittable section contents.

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -931,7 +931,7 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
   plt.addEntry(sym);
   gotPlt.addEntry(sym);
 
-  if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeCheriRelocs) {
+  if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeElfCheriRelocs) {
     if (!sym.isPreemptible) {
       addRelativeCapabilityRelocation(ctx, gotPlt, sym.getGotPltOffset(ctx),
                                       &sym, 0, R_ABS_CAP,

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -884,6 +884,13 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
                              RelExpr expr, RelType type) {
   Partition &part = isec.getPartition(ctx);
 
+  if (expr == R_CHERI_CAPABILITY) {
+    assert(!sym.isPreemptible);
+    addCapabilityRelocation(ctx, &sym, type, &isec, offsetInSec, expr, addend,
+                            false, [] { return ""; });
+    return;
+  }
+
   if (sym.isTagged()) {
     part.relaDyn->addRelativeReloc<shard>(ctx.target->relativeRel, isec,
                                           offsetInSec, sym, addend, type, expr);
@@ -947,29 +954,28 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
 void elf::addGotEntry(Ctx &ctx, Symbol &sym) {
   ctx.in.got->addEntry(sym);
   uint64_t off = sym.getGotOffset(ctx);
+  RelExpr expr = ctx.arg.isCheriAbi ? R_CHERI_CAPABILITY : R_ABS;
 
   // If preemptible, emit a GLOB_DAT relocation.
   if (sym.isPreemptible) {
     ctx.mainPart->relaDyn->addReloc({ctx.target->gotRel, ctx.in.got.get(), off,
                                      DynamicReloc::AgainstSymbol, sym, 0,
-                                     R_ABS});
+                                     expr});
     return;
   }
+
+  RelType type =
+      ctx.arg.isCheriAbi ? *ctx.target->cheriCapRel : ctx.target->symbolicRel;
 
   // Otherwise, the value is either a link-time constant or the load base
   // plus a constant. For CHERI it always requires run-time initialisation,
   // with the exception of undef weak symbols.
   if (ctx.arg.isCheriAbi && sym.isUndefWeak())
     addNullDerivedCapability(ctx, sym, *ctx.in.got, off, 0);
-  else if (ctx.arg.isCheriAbi) {
-    addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel,
-                            ctx.in.got.get(), off, R_CHERI_CAPABILITY, 0, false,
-                            [] { return ""; });
-  } else if (!ctx.arg.isPic || isAbsolute(sym))
-    ctx.in.got->addConstant({R_ABS, ctx.target->symbolicRel, off, 0, &sym});
+  else if (!ctx.arg.isCheriAbi && (!ctx.arg.isPic || isAbsolute(sym)))
+    ctx.in.got->addConstant({expr, type, off, 0, &sym});
   else
-    addRelativeReloc(ctx, *ctx.in.got, off, sym, 0, R_ABS,
-                     ctx.target->symbolicRel);
+    addRelativeReloc(ctx, *ctx.in.got, off, sym, 0, expr, type);
 }
 
 static void addGotAuthEntry(Ctx &ctx, Symbol &sym) {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1952,7 +1952,10 @@ static bool handleNonPreemptibleIfunc(Ctx &ctx, Symbol &sym, uint16_t flags) {
     auto &d = cast<Defined>(sym);
     d.section = ctx.in.iplt.get();
     d.value = d.getPltIdx(ctx) * ctx.target->ipltEntrySize;
-    d.setSize(0);
+    if (ctx.arg.isCheriAbi)
+      d.setSize(ctx.target->ipltEntrySize);
+    else
+      d.setSize(0);
     // It's important to set the symbol type here so that dynamic loaders
     // don't try to call the PLT as if it were an ifunc resolver.
     d.type = STT_FUNC;

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -887,7 +887,7 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
   if (expr == R_ABS_CAP) {
     assert(!sym.isPreemptible);
     addCapabilityRelocation(ctx, &sym, type, &isec, offsetInSec, expr, addend,
-                            false, [] { return ""; });
+                            [] { return ""; });
     return;
   }
 
@@ -935,13 +935,13 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
   if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeCheriRelocs) {
     if (!sym.isPreemptible) {
       addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
-                              sym.getGotPltOffset(ctx), R_ABS_CAP, 0, false,
+                              sym.getGotPltOffset(ctx), R_ABS_CAP, 0,
                               [] { return ""; });
       return;
     }
 
     addCapabilityRelocation(ctx, &plt, *ctx.target->cheriCapRel, &gotPlt,
-                            sym.getGotPltOffset(ctx), R_ABS_CAP, 0, false,
+                            sym.getGotPltOffset(ctx), R_ABS_CAP, 0,
                             [] { return ""; });
   }
 
@@ -1253,7 +1253,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
       return;
     }
     addCapabilityRelocation(ctx, &sym, type, sec, offset, expr, addend,
-                            /* isCallExpr=*/false, getRelocTargetLocation);
+                            getRelocTargetLocation);
     // TODO: check if it is a call and needs a plt stub
     return;
   }

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -928,7 +928,7 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
   // don't store the addend values, so we must write it to the relocated
   // address.
   if (part.relrDyn && isec.addralign >= 2 && offsetInSec % 2 == 0) {
-    isec.addReloc({expr, type, offsetInSec, addend, &sym});
+    isec.addReloc(ctx, {expr, type, offsetInSec, addend, &sym});
     if (shard)
       part.relrDyn->relocsVec[parallel::getThreadIndex()].push_back(
           {&isec, isec.relocs().size() - 1});
@@ -983,10 +983,9 @@ void elf::addGotEntry(Ctx &ctx, Symbol &sym) {
   // Otherwise, the value is either a link-time constant or the load base
   // plus a constant. For CHERI it always requires run-time initialisation,
   // with the exception of undef weak symbols.
-  if (ctx.arg.isCheriAbi && sym.isUndefWeak())
-    addNullDerivedCapability(ctx, sym, *ctx.in.got, off, 0);
-  else if (!ctx.arg.isCheriAbi && (!ctx.arg.isPic || isAbsolute(sym)))
-    ctx.in.got->addConstant({expr, type, off, 0, &sym});
+  if ((ctx.arg.isCheriAbi && sym.isUndefWeak()) ||
+      (!ctx.arg.isCheriAbi && (!ctx.arg.isPic || isAbsolute(sym))))
+    ctx.in.got->addConstant(ctx, {expr, type, off, 0, &sym});
   else
     addRelativeReloc(ctx, *ctx.in.got, off, sym, 0, expr, type);
 }
@@ -1014,7 +1013,8 @@ static void addTpOffsetGotEntry(Ctx &ctx, Symbol &sym) {
   ctx.in.got->addEntry(sym);
   uint64_t off = sym.getGotOffset(ctx);
   if (!sym.isPreemptible && !ctx.arg.shared) {
-    ctx.in.got->addConstant({R_TPREL, ctx.target->symbolicRel, off, 0, &sym});
+    ctx.in.got->addConstant(ctx,
+                            {R_TPREL, ctx.target->symbolicRel, off, 0, &sym});
     return;
   }
   ctx.mainPart->relaDyn->addAddendOnlyRelocIfNonPreemptible(
@@ -1228,10 +1228,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
   // handling of GOT-generating relocations.
   if (isStaticLinkTimeConstant(expr, type, sym, offset) ||
       (!ctx.arg.isPic && sym.isUndefWeak())) {
-    if (expr == R_ABS_CAP)
-      addNullDerivedCapability(ctx, sym, *sec, offset, addend);
-    else
-      sec->addReloc({expr, type, offset, addend, &sym});
+    sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     return;
   }
 
@@ -1267,7 +1264,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
           // When symbol values are determined in
           // finalizeAddressDependentContent, some .relr.auth.dyn relocations
           // may be moved to .rela.dyn.
-          sec->addReloc({expr, type, offset, addend, &sym});
+          sec->addReloc(ctx, {expr, type, offset, addend, &sym});
           part.relrAuthDyn->relocs.push_back({sec, sec->relocs().size() - 1});
         } else {
           part.relaDyn->addReloc({R_AARCH64_AUTH_RELATIVE, sec, offset,
@@ -1333,7 +1330,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
         }
         sym.setFlags(NEEDS_COPY);
       }
-      sec->addReloc({expr, type, offset, addend, &sym});
+      sec->addReloc(ctx, {expr, type, offset, addend, &sym});
       return;
     }
 
@@ -1372,7 +1369,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
         printLocation(diag, *sec, sym, offset);
       }
       sym.setFlags(NEEDS_COPY | NEEDS_PLT);
-      sec->addReloc({expr, type, offset, addend, &sym});
+      sec->addReloc(ctx, {expr, type, offset, addend, &sym});
       return;
     }
   }
@@ -1398,33 +1395,33 @@ static unsigned handleMipsTlsRelocation(Ctx &ctx, RelType type, Symbol &sym,
                                         int64_t addend, RelExpr expr) {
   if (expr == RE_MIPS_TLSLD) {
     ctx.in.mipsGot->addTlsIndex(*c.file);
-    c.addReloc({expr, type, offset, addend, &sym});
+    c.addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
   if (expr == RE_MIPS_TLSGD) {
     ctx.in.mipsGot->addDynTlsEntry(*c.file, sym);
-    c.addReloc({expr, type, offset, addend, &sym});
+    c.addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
   if (expr == R_MIPS_CHERI_CAPTAB_TLSLD) {
     ctx.in.mipsCheriCapTable->addTlsIndex();
-    c.addReloc({expr, type, offset, addend, &sym});
+    c.addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
   if (expr == R_MIPS_CHERI_CAPTAB_TLSGD) {
     ctx.in.mipsCheriCapTable->addDynTlsEntry(sym);
-    c.addReloc({expr, type, offset, addend, &sym});
+    c.addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
   if (expr == R_MIPS_CHERI_CAPTAB_TPREL) {
     ctx.in.mipsCheriCapTable->addTlsEntry(sym);
-    c.addReloc({expr, type, offset, addend, &sym});
+    c.addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
   return 0;
 }
 
-static unsigned handleAArch64PAuthTlsRelocation(InputSectionBase *sec,
+static unsigned handleAArch64PAuthTlsRelocation(Ctx &ctx, InputSectionBase *sec,
                                                 RelExpr expr, RelType type,
                                                 uint64_t offset, Symbol &sym,
                                                 int64_t addend) {
@@ -1433,7 +1430,7 @@ static unsigned handleAArch64PAuthTlsRelocation(InputSectionBase *sec,
   // > PAUTHELF64 only supports the descriptor based TLS (TLSDESC).
   if (oneof<RE_AARCH64_AUTH_TLSDESC_PAGE, RE_AARCH64_AUTH_TLSDESC>(expr)) {
     sym.setFlags(NEEDS_TLSDESC | NEEDS_TLSDESC_AUTH);
-    sec->addReloc({expr, type, offset, addend, &sym});
+    sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
 
@@ -1459,7 +1456,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
 
   if (isAArch64)
     if (unsigned processed = handleAArch64PAuthTlsRelocation(
-            sec, expr, type, offset, sym, addend))
+            ctx, sec, expr, type, offset, sym, addend))
       return processed;
 
   if (expr == R_TPREL || expr == R_TPREL_NEG) {
@@ -1488,7 +1485,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
         sym.setFlags(NEEDS_TLSDESC | NEEDS_TLSDESC_NONAUTH);
       else if (!isRISCV || type == R_RISCV_TLSDESC_HI20)
         sym.setFlags(NEEDS_TLSDESC);
-      sec->addReloc({expr, type, offset, addend, &sym});
+      sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     }
     return 1;
   }
@@ -1531,14 +1528,14 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
   if (oneof<R_TLSLD_GOT, R_TLSLD_GOTPLT, R_TLSLD_PC, R_TLSLD_HINT>(expr)) {
     // Local-Dynamic relocs can be optimized to Local-Exesec->
     if (execOptimize) {
-      sec->addReloc({ctx.target->adjustTlsExpr(type, R_RELAX_TLS_LD_TO_LE),
-                     type, offset, addend, &sym});
+      sec->addReloc(ctx, {ctx.target->adjustTlsExpr(type, R_RELAX_TLS_LD_TO_LE),
+                          type, offset, addend, &sym});
       return ctx.target->getTlsGdRelaxSkip(type);
     }
     if (expr == R_TLSLD_HINT)
       return 1;
     ctx.needsTlsLd.store(true, std::memory_order_relaxed);
-    sec->addReloc({expr, type, offset, addend, &sym});
+    sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
 
@@ -1546,7 +1543,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
   if (expr == R_DTPREL) {
     if (execOptimize)
       expr = ctx.target->adjustTlsExpr(type, R_RELAX_TLS_LD_TO_LE);
-    sec->addReloc({expr, type, offset, addend, &sym});
+    sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
 
@@ -1555,7 +1552,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
   // Local-Exesec->
   if (expr == R_TLSLD_GOT_OFF) {
     sym.setFlags(NEEDS_GOT_DTPREL);
-    sec->addReloc({expr, type, offset, addend, &sym});
+    sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     return 1;
   }
 
@@ -1568,7 +1565,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
       !execOptimize) {
     if (expr != R_TLSDESC_CALL) {
       sym.setFlags(NEEDS_TLSDESC);
-      sec->addReloc({expr, type, offset, addend, &sym});
+      sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     }
     return 1;
   }
@@ -1578,7 +1575,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
             RE_LOONGARCH_TLSGD_PAGE_PC, RE_LOONGARCH_TLSDESC_PAGE_PC>(expr)) {
     if (!execOptimize) {
       sym.setFlags(NEEDS_TLSGD);
-      sec->addReloc({expr, type, offset, addend, &sym});
+      sec->addReloc(ctx, {expr, type, offset, addend, &sym});
       return 1;
     }
 
@@ -1590,11 +1587,11 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
     // the categorization in RISCV::relocateAllosec->
     if (sym.isPreemptible) {
       sym.setFlags(NEEDS_TLSGD_TO_IE);
-      sec->addReloc({ctx.target->adjustTlsExpr(type, R_RELAX_TLS_GD_TO_IE),
-                     type, offset, addend, &sym});
+      sec->addReloc(ctx, {ctx.target->adjustTlsExpr(type, R_RELAX_TLS_GD_TO_IE),
+                          type, offset, addend, &sym});
     } else {
-      sec->addReloc({ctx.target->adjustTlsExpr(type, R_RELAX_TLS_GD_TO_LE),
-                     type, offset, addend, &sym});
+      sec->addReloc(ctx, {ctx.target->adjustTlsExpr(type, R_RELAX_TLS_GD_TO_LE),
+                          type, offset, addend, &sym});
     }
     return ctx.target->getTlsGdRelaxSkip(type);
   }
@@ -1605,7 +1602,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
     // Initial-Exec relocs can be optimized to Local-Exec if the symbol is
     // locally defined.  This is not supported on SystemZ.
     if (execOptimize && isLocalInExecutable && ctx.arg.emachine != EM_S390) {
-      sec->addReloc({R_RELAX_TLS_IE_TO_LE, type, offset, addend, &sym});
+      sec->addReloc(ctx, {R_RELAX_TLS_IE_TO_LE, type, offset, addend, &sym});
     } else if (expr != R_TLSIE_HINT) {
       sym.setFlags(NEEDS_TLSIE);
       // R_GOT needs a relative relocation for PIC on i386 and Hexagon.
@@ -1613,7 +1610,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
           !ctx.target->usesOnlyLowPageBits(type))
         addRelativeReloc<true>(ctx, *sec, offset, sym, addend, expr, type);
       else
-        sec->addReloc({expr, type, offset, addend, &sym});
+        sec->addReloc(ctx, {expr, type, offset, addend, &sym});
     }
     return 1;
   }
@@ -1623,7 +1620,7 @@ unsigned RelocationScanner::handleTlsRelocation(RelExpr expr, RelType type,
   if (ctx.arg.emachine == EM_LOONGARCH && expr == RE_LOONGARCH_GOT &&
       execOptimize && isLocalInExecutable) {
     ctx.hasTlsIe.store(true, std::memory_order_relaxed);
-    sec->addReloc({R_RELAX_TLS_IE_TO_LE, type, offset, addend, &sym});
+    sec->addReloc(ctx, {R_RELAX_TLS_IE_TO_LE, type, offset, addend, &sym});
     return 1;
   }
 
@@ -2052,7 +2049,8 @@ void elf::postScanRelocations(Ctx &ctx) {
       uint64_t off = got->getGlobalDynOffset(sym);
       if (isLocalInExecutable)
         // Write one to the GOT slot.
-        got->addConstant({R_ADDEND, ctx.target->symbolicRel, off, 1, &sym});
+        got->addConstant(ctx,
+                         {R_ADDEND, ctx.target->symbolicRel, off, 1, &sym});
       else
         ctx.mainPart->relaDyn->addSymbolReloc(ctx.target->tlsModuleIndexRel,
                                               *got, off, sym);
@@ -2064,7 +2062,8 @@ void elf::postScanRelocations(Ctx &ctx) {
         ctx.mainPart->relaDyn->addSymbolReloc(ctx.target->tlsOffsetRel, *got,
                                               offsetOff, sym);
       else
-        got->addConstant({R_ABS, ctx.target->tlsOffsetRel, offsetOff, 0, &sym});
+        got->addConstant(ctx,
+                         {R_ABS, ctx.target->tlsOffsetRel, offsetOff, 0, &sym});
     }
     if (flags & NEEDS_TLSGD_TO_IE) {
       got->addEntry(sym);
@@ -2073,8 +2072,8 @@ void elf::postScanRelocations(Ctx &ctx) {
     }
     if (flags & NEEDS_GOT_DTPREL) {
       got->addEntry(sym);
-      got->addConstant(
-          {R_ABS, ctx.target->tlsOffsetRel, sym.getGotOffset(ctx), 0, &sym});
+      got->addConstant(ctx, {R_ABS, ctx.target->tlsOffsetRel,
+                             sym.getGotOffset(ctx), 0, &sym});
     }
 
     if ((flags & NEEDS_TLSIE) && !(flags & NEEDS_TLSGD_TO_IE))
@@ -2088,8 +2087,8 @@ void elf::postScanRelocations(Ctx &ctx) {
       ctx.mainPart->relaDyn->addReloc(
           {ctx.target->tlsModuleIndexRel, got, got->getTlsIndexOff()});
     else
-      got->addConstant({R_ADDEND, ctx.target->symbolicRel,
-                        got->getTlsIndexOff(), 1, &dummy});
+      got->addConstant(ctx, {R_ADDEND, ctx.target->symbolicRel,
+                             got->getTlsIndexOff(), 1, &dummy});
   }
 
   assert(ctx.symAux.size() == 1);

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -473,7 +473,6 @@ private:
   int64_t computeMipsAddend(const RelTy &rel, RelExpr expr, bool isLocal) const;
   bool isStaticLinkTimeConstant(RelExpr e, RelType type, const Symbol &sym,
                                 uint64_t relOff) const;
-  template <typename ELFT>
   void processAux(RelExpr expr, RelType type, uint64_t offset, Symbol &sym,
                   int64_t addend) const;
   unsigned handleTlsRelocation(RelExpr expr, RelType type, uint64_t offset,
@@ -1137,7 +1136,6 @@ bool RelocationScanner::isStaticLinkTimeConstant(RelExpr e, RelType type,
 // sections. Given that it is ro, we will need an extra PT_LOAD. This
 // complicates things for the dynamic linker and means we would have to reserve
 // space for the extra PT_LOAD even if we end up not using it.
-template <typename ELFT>
 void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
                                    Symbol &sym, int64_t addend) const {
   // If non-ifunc non-preemptible, change PLT to direct call and optimize GOT
@@ -1739,7 +1737,7 @@ void RelocationScanner::scanOne(typename Relocs<RelTy>::const_iterator &i) {
     }
   }
 
-  processAux<ELFT>(expr, type, offset, sym, addend);
+  processAux(expr, type, offset, sym, addend);
 }
 
 // R_PPC64_TLSGD/R_PPC64_TLSLD is required to mark `bl __tls_get_addr` for

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1243,7 +1243,6 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
   bool canWrite = (sec->flags & SHF_WRITE) ||
                   !(ctx.arg.zText ||
                     (isa<EhInputSection>(sec) && ctx.arg.emachine != EM_MIPS));
-
   if (canWrite) {
     RelType rel = ctx.target->getDynRel(type);
     if (oneof<R_GOT, RE_LOONGARCH_GOT>(expr) ||

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1246,26 +1246,11 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
                   !(ctx.arg.zText ||
                     (isa<EhInputSection>(sec) && ctx.arg.emachine != EM_MIPS));
 
-  if (expr == R_ABS_CAP) {
-    std::lock_guard<std::mutex> lock(ctx.relocMutex);
-    static auto getRelocTargetLocation = [&]() -> std::string {
-      return "\n>>> referenced by " +
-             SymbolAndOffset(sec, offset).verboseToString(ctx);
-    };
-    if (!canWrite) {
-      readOnlyCapRelocsError(ctx, sym, getRelocTargetLocation());
-      return;
-    }
-    addCapabilityRelocation(ctx, &sym, type, sec, offset, expr, addend,
-                            getRelocTargetLocation);
-    // TODO: check if it is a call and needs a plt stub
-    return;
-  }
-
   if (canWrite) {
     RelType rel = ctx.target->getDynRel(type);
     if (oneof<R_GOT, RE_LOONGARCH_GOT>(expr) ||
-        (rel == ctx.target->symbolicRel && !sym.isPreemptible)) {
+        ((rel == ctx.target->symbolicRel || rel == ctx.target->cheriCapRel) &&
+         !sym.isPreemptible)) {
       addRelativeReloc<true>(ctx, *sec, offset, sym, addend, expr, type);
       return;
     }
@@ -1310,10 +1295,20 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
       // to the GOT entry and reads the GOT entry when it needs to perform
       // a dynamic relocation.
       // ftp://www.linux-mips.org/pub/linux/mips/doc/ABI/mipsabi.pdf p.4-19
-      if (ctx.arg.emachine == EM_MIPS)
+      // XXX: Excluding R_ABS_CAP is likely wrong, but is the historic
+      // behaviour.
+      if (ctx.arg.emachine == EM_MIPS && expr != R_ABS_CAP)
         ctx.in.mipsGot->addEntry(*sec->file, sym, addend, expr);
       return;
     }
+  }
+
+  if (expr == R_ABS_CAP) {
+    readOnlyCapRelocsError(
+        ctx, sym,
+        "\n>>> referenced by " +
+            SymbolAndOffset(sec, offset).verboseToString(ctx));
+    return;
   }
 
   // When producing an executable, we can perform copy relocations (for

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -923,12 +923,15 @@ template <class PltSection, class GotPltSection>
 static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
                         RelocationBaseSection &rel, RelType type, Symbol &sym) {
   plt.addEntry(sym);
-
-  if (ctx.arg.isCheriAbi && !sym.isPreemptible)
-    error("cannot create non-preemptible PLT entry on CHERI against symbol: " +
-          toStr(ctx, sym));
-
   gotPlt.addEntry(sym);
+
+  if (ctx.arg.isCheriAbi && !sym.isPreemptible) {
+    addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
+                            sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,
+                            false, [] { return ""; });
+    return;
+  }
+
   rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx),
                 sym.isPreemptible ? DynamicReloc::AgainstSymbol
                                   : DynamicReloc::AddendOnlyWithTargetVA,

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -211,6 +211,16 @@ bool lld::elf::needsGot(RelExpr expr) {
       expr);
 }
 
+// Returns true if Expr refers to a MIPS captable entry. Note this function
+// returns false for TLS variables even though then need a captable entry,
+// because TLS variables use the captable differently than regular variables.
+static bool needsMipsCheriCapTable(RelExpr expr) {
+  return oneof<R_MIPS_CHERI_CAPTAB_INDEX,
+               R_MIPS_CHERI_CAPTAB_INDEX_SMALL_IMMEDIATE,
+               R_MIPS_CHERI_CAPTAB_INDEX_CALL,
+               R_MIPS_CHERI_CAPTAB_INDEX_CALL_SMALL_IMMEDIATE>(expr);
+}
+
 // True if this expression is of the form Sym - X, where X is a position in the
 // file (PC, or GOT for example).
 static bool isRelExpr(RelExpr expr) {
@@ -1175,17 +1185,6 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
     return;
   }
 
-  if (oneof<R_MIPS_CHERI_CAPTAB_INDEX,
-            R_MIPS_CHERI_CAPTAB_INDEX_SMALL_IMMEDIATE,
-            R_MIPS_CHERI_CAPTAB_INDEX_CALL,
-            R_MIPS_CHERI_CAPTAB_INDEX_CALL_SMALL_IMMEDIATE>(expr)) {
-    std::lock_guard<std::mutex> lock(ctx.relocMutex);
-    ctx.in.mipsCheriCapTable->addEntry(sym, expr, sec, offset);
-    // Write out the index into the instruction
-    sec->relocations.push_back({expr, type, offset, addend, &sym});
-    return;
-  }
-
   if (needsGot(expr)) {
     if (ctx.arg.emachine == EM_MIPS) {
       // MIPS ABI has special rules to process GOT entries and doesn't
@@ -1205,6 +1204,8 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
       else
         sym.setFlags(NEEDS_GOT | NEEDS_GOT_NONAUTH);
     }
+  } else if (needsMipsCheriCapTable(expr)) {
+    ctx.in.mipsCheriCapTable->addEntry(sym, expr, sec, offset);
   } else if (needsPlt(expr)) {
     sym.setFlags(NEEDS_PLT);
   } else if (LLVM_UNLIKELY(isIfunc)) {
@@ -1407,17 +1408,17 @@ static unsigned handleMipsTlsRelocation(Ctx &ctx, RelType type, Symbol &sym,
   }
   if (expr == R_MIPS_CHERI_CAPTAB_TLSLD) {
     ctx.in.mipsCheriCapTable->addTlsIndex();
-    c.relocations.push_back({expr, type, offset, addend, &sym});
+    c.addReloc({expr, type, offset, addend, &sym});
     return 1;
   }
   if (expr == R_MIPS_CHERI_CAPTAB_TLSGD) {
     ctx.in.mipsCheriCapTable->addDynTlsEntry(sym);
-    c.relocations.push_back({expr, type, offset, addend, &sym});
+    c.addReloc({expr, type, offset, addend, &sym});
     return 1;
   }
   if (expr == R_MIPS_CHERI_CAPTAB_TPREL) {
     ctx.in.mipsCheriCapTable->addTlsEntry(sym);
-    c.relocations.push_back({expr, type, offset, addend, &sym});
+    c.addReloc({expr, type, offset, addend, &sym});
     return 1;
   }
   return 0;

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -885,6 +885,12 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
   Partition &part = isec.getPartition(ctx);
 
   if (expr == R_ABS_CAP) {
+    if (shard) {
+      std::lock_guard<std::mutex> lock(relocMutex);
+      addRelativeReloc(isec, offsetInSec, sym, addend, expr, type);
+      return;
+    }
+
     addRelativeCapabilityRelocation(ctx, isec, offsetInSec, &sym, addend, expr,
                                     type);
     return;

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -884,7 +884,7 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
                              RelExpr expr, RelType type) {
   Partition &part = isec.getPartition(ctx);
 
-  if (expr == R_CHERI_CAPABILITY) {
+  if (expr == R_ABS_CAP) {
     assert(!sym.isPreemptible);
     addCapabilityRelocation(ctx, &sym, type, &isec, offsetInSec, expr, addend,
                             false, [] { return ""; });
@@ -935,14 +935,14 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
   if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeCheriRelocs) {
     if (!sym.isPreemptible) {
       addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
-                              sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,
-                              false, [] { return ""; });
+                              sym.getGotPltOffset(ctx), R_ABS_CAP, 0, false,
+                              [] { return ""; });
       return;
     }
 
     addCapabilityRelocation(ctx, &plt, *ctx.target->cheriCapRel, &gotPlt,
-                            sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,
-                            false, [] { return ""; });
+                            sym.getGotPltOffset(ctx), R_ABS_CAP, 0, false,
+                            [] { return ""; });
   }
 
   rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx),
@@ -954,7 +954,7 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
 void elf::addGotEntry(Ctx &ctx, Symbol &sym) {
   ctx.in.got->addEntry(sym);
   uint64_t off = sym.getGotOffset(ctx);
-  RelExpr expr = ctx.arg.isCheriAbi ? R_CHERI_CAPABILITY : R_ABS;
+  RelExpr expr = ctx.arg.isCheriAbi ? R_ABS_CAP : R_ABS;
 
   // If preemptible, emit a GLOB_DAT relocation.
   if (sym.isPreemptible) {
@@ -1063,7 +1063,7 @@ bool RelocationScanner::isStaticLinkTimeConstant(RelExpr e, RelType type,
   // there is no way to store the tag bit
   // The exception is for non-preemptible undef weak symbols, which are
   // NULL-derived constants.
-  if (e == R_CHERI_CAPABILITY)
+  if (e == R_ABS_CAP)
     return !sym.isPreemptible && sym.isUndefWeak();
 
   // These never do, except if the entire file is position dependent or if
@@ -1225,7 +1225,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
   // handling of GOT-generating relocations.
   if (isStaticLinkTimeConstant(expr, type, sym, offset) ||
       (!ctx.arg.isPic && sym.isUndefWeak())) {
-    if (expr == R_CHERI_CAPABILITY)
+    if (expr == R_ABS_CAP)
       addNullDerivedCapability(ctx, sym, *sec, offset, addend);
     else
       sec->addReloc({expr, type, offset, addend, &sym});
@@ -1242,7 +1242,7 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
                   !(ctx.arg.zText ||
                     (isa<EhInputSection>(sec) && ctx.arg.emachine != EM_MIPS));
 
-  if (expr == R_CHERI_CAPABILITY) {
+  if (expr == R_ABS_CAP) {
     std::lock_guard<std::mutex> lock(ctx.relocMutex);
     static auto getRelocTargetLocation = [&]() -> std::string {
       return "\n>>> referenced by " +

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -886,8 +886,8 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
 
   if (expr == R_ABS_CAP) {
     if (shard) {
-      std::lock_guard<std::mutex> lock(relocMutex);
-      addRelativeReloc(isec, offsetInSec, sym, addend, expr, type);
+      std::lock_guard<std::mutex> lock(ctx.relocMutex);
+      addRelativeReloc(ctx, isec, offsetInSec, sym, addend, expr, type);
       return;
     }
 

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -885,9 +885,8 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
   Partition &part = isec.getPartition(ctx);
 
   if (expr == R_ABS_CAP) {
-    assert(!sym.isPreemptible);
-    addCapabilityRelocation(ctx, &sym, type, &isec, offsetInSec, expr, addend,
-                            [] { return ""; });
+    addRelativeCapabilityRelocation(ctx, isec, offsetInSec, &sym, addend, expr,
+                                    type);
     return;
   }
 
@@ -934,15 +933,14 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
 
   if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeCheriRelocs) {
     if (!sym.isPreemptible) {
-      addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
-                              sym.getGotPltOffset(ctx), R_ABS_CAP, 0,
-                              [] { return ""; });
+      addRelativeCapabilityRelocation(ctx, gotPlt, sym.getGotPltOffset(ctx),
+                                      &sym, 0, R_ABS_CAP,
+                                      *ctx.target->cheriCapRel);
       return;
     }
 
-    addCapabilityRelocation(ctx, &plt, *ctx.target->cheriCapRel, &gotPlt,
-                            sym.getGotPltOffset(ctx), R_ABS_CAP, 0,
-                            [] { return ""; });
+    addRelativeCapabilityRelocation(ctx, gotPlt, sym.getGotPltOffset(ctx), &plt,
+                                    0, R_ABS_CAP, *ctx.target->cheriCapRel);
   }
 
   rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx),

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -925,7 +925,7 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
   plt.addEntry(sym);
   gotPlt.addEntry(sym);
 
-  if (ctx.arg.isCheriAbi) {
+  if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeCheriRelocs) {
     if (!sym.isPreemptible) {
       addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
                               sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -925,21 +925,23 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
   plt.addEntry(sym);
   gotPlt.addEntry(sym);
 
-  if (ctx.arg.isCheriAbi && !sym.isPreemptible) {
-    addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
+  if (ctx.arg.isCheriAbi) {
+    if (!sym.isPreemptible) {
+      addCapabilityRelocation(ctx, &sym, *ctx.target->cheriCapRel, &gotPlt,
+                              sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,
+                              false, [] { return ""; });
+      return;
+    }
+
+    addCapabilityRelocation(ctx, &plt, *ctx.target->cheriCapRel, &gotPlt,
                             sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,
                             false, [] { return ""; });
-    return;
   }
 
   rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx),
                 sym.isPreemptible ? DynamicReloc::AgainstSymbol
                                   : DynamicReloc::AddendOnlyWithTargetVA,
                 sym, 0, R_ABS});
-  if (ctx.arg.isCheriAbi)
-    addCapabilityRelocation(ctx, &plt, *ctx.target->cheriCapRel, &gotPlt,
-                            sym.getGotPltOffset(ctx), R_CHERI_CAPABILITY, 0,
-                            false, [] { return ""; });
 }
 
 void elf::addGotEntry(Ctx &ctx, Symbol &sym) {

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -41,6 +41,8 @@ using JumpModType = uint32_t;
 enum RelExpr {
   R_ABS,
   R_ABS_CAP,
+  R_ABS_CAP_ADDR,
+  R_ABS_CAP_META,
   R_ADDEND,
   R_DTPREL,
   R_GOT,

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -40,6 +40,7 @@ using JumpModType = uint32_t;
 // doesn't have to know about architecture-specific details.
 enum RelExpr {
   R_ABS,
+  R_ABS_CAP,
   R_ADDEND,
   R_DTPREL,
   R_GOT,
@@ -130,7 +131,6 @@ enum RelExpr {
   R_MIPS_CHERI_CAPTAB_TLSGD,
   R_MIPS_CHERI_CAPTAB_TLSLD,
   R_MIPS_CHERI_CAPTAB_TPREL,
-  R_CHERI_CAPABILITY,
   R_CHERIOT_COMPARTMENT_CGPREL_HI,
   R_CHERIOT_COMPARTMENT_CGPREL_LO_S,
   R_CHERIOT_COMPARTMENT_CGPREL_LO_I,

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -684,7 +684,6 @@ GotSection::GotSection(Ctx &ctx)
   numEntries = ctx.target->gotHeaderEntriesNum;
 }
 
-void GotSection::addConstant(const Relocation &r) { relocations.push_back(r); }
 void GotSection::addEntry(const Symbol &sym) {
   // TODO: Separate out TLS IE entries for CHERI so we can pack them more
   // efficiently rather than consuming a whole capability-sized slot for an

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -1750,8 +1750,27 @@ RelocationBaseSection::RelocationBaseSection(Ctx &ctx, StringRef name,
 void RelocationBaseSection::addSymbolReloc(
     RelType dynType, InputSectionBase &isec, uint64_t offsetInSec, Symbol &sym,
     int64_t addend, std::optional<RelType> addendRelType) {
+  bool isCap = dynType == ctx.target->cheriCapRel ||
+               dynType == ctx.target->cheriCapCallRel;
+  if (isCap && sym.isFunc() && addend != 0) {
+    auto diag = Warn(ctx);
+    diag << "capability relocation with non-zero addend (0x"
+         << llvm::utohexstr(addend) << ") against preemptible function "
+         << toStr(ctx, sym)
+         << "; this may not be supported by the runtime linker.";
+    printLocationMessage(diag, isec, sym, offsetInSec);
+  }
+
+  // .chericap initialises the memory to 0xcacacaca not 0, so if writing
+  // addends we still need to write even it if zero (and must have an
+  // addendRelType in order to do so).
+  // TODO: Stop doing this in the assembler and drop this hack
+  bool writeZero = isCap;
+  if (writeZero && !addendRelType)
+    addendRelType = dynType;
   addReloc(DynamicReloc::AgainstSymbol, dynType, isec, offsetInSec, sym, addend,
-           R_ADDEND, addendRelType ? *addendRelType : ctx.target->noneRel);
+           R_ADDEND, addendRelType ? *addendRelType : ctx.target->noneRel,
+           writeZero);
 }
 
 void RelocationBaseSection::addAddendOnlyRelocIfNonPreemptible(

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -552,14 +552,6 @@ public:
     // the added to the output file since it will be initialized to 0xcacacaca
     if (expr == R_CHERI_CAPABILITY) {
       expr = R_ADDEND;
-      if (sym.isFunc() && addend != 0) {
-        auto diag = Warn(ctx);
-        diag << "capability relocation with non-zero addend (0x"
-             << llvm::utohexstr(addend) << ") against preemptible function "
-             << toStr(ctx, sym)
-             << "; this may not be supported by the runtime linker.";
-        printLocationMessage(diag, sec, sym, offsetInSec);
-      }
     }
     if (writeAddend)
       sec.addReloc({expr, addendRelType, offsetInSec, addend, &sym});

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -112,7 +112,7 @@ public:
   bool isNeeded() const override;
   void writeTo(uint8_t *buf) override;
 
-  void addConstant(const Relocation &r) { addReloc(r); }
+  void addConstant(Ctx &ctx, const Relocation &r) { addReloc(ctx, r); }
   void addEntry(const Symbol &sym);
   void addAuthEntry(const Symbol &sym);
   bool addTlsDescEntry(const Symbol &sym);
@@ -547,7 +547,7 @@ public:
     // Write the addends to the relocated address if required. We skip
     // it if the written value would be zero, unless forced.
     if (ctx.arg.writeAddends && (expr != R_ADDEND || addend != 0 || writeZero))
-      sec.addReloc({expr, addendRelType, offsetInSec, addend, &sym});
+      sec.addReloc(ctx, {expr, addendRelType, offsetInSec, addend, &sym});
     addReloc<shard>({dynType, &sec, offsetInSec, kind, sym, addend, expr});
   }
   bool isNeeded() const override {

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -112,7 +112,7 @@ public:
   bool isNeeded() const override;
   void writeTo(uint8_t *buf) override;
 
-  void addConstant(const Relocation &r);
+  void addConstant(const Relocation &r) { addReloc(r); }
   void addEntry(const Symbol &sym);
   void addAuthEntry(const Symbol &sym);
   bool addTlsDescEntry(const Symbol &sym);

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -543,17 +543,10 @@ public:
   template <bool shard = false>
   void addReloc(DynamicReloc::Kind kind, RelType dynType, InputSectionBase &sec,
                 uint64_t offsetInSec, Symbol &sym, int64_t addend, RelExpr expr,
-                RelType addendRelType) {
+                RelType addendRelType, bool writeZero = false) {
     // Write the addends to the relocated address if required. We skip
-    // it if the written value would be zero.
-    bool writeAddend =
-        ctx.arg.writeAddends && (expr != R_ADDEND || addend != 0);
-    // If we are adding a dynamic R_CHERI_CAPABILITY relocation we need to write
-    // the added to the output file since it will be initialized to 0xcacacaca
-    if (expr == R_CHERI_CAPABILITY) {
-      expr = R_ADDEND;
-    }
-    if (writeAddend)
+    // it if the written value would be zero, unless forced.
+    if (ctx.arg.writeAddends && (expr != R_ADDEND || addend != 0 || writeZero))
       sec.addReloc({expr, addendRelType, offsetInSec, addend, &sym});
     addReloc<shard>({dynType, &sec, offsetInSec, kind, sym, addend, expr});
   }

--- a/lld/test/ELF/cheri/cap-table/local-fn-ptr-in-plt-abi.c
+++ b/lld/test/ELF/cheri/cap-table/local-fn-ptr-in-plt-abi.c
@@ -23,13 +23,13 @@
 // RUN: llvm-readobj --dyn-symbols --dyn-relocations --cap-relocs --cap-table %t-pie.exe | FileCheck %s --check-prefixes CHECK,CHECK-NODYN
 // RUN: ld.lld %t.o %t-shlib.so -o %t.exe --verbose-cap-relocs 2>&1 | FileCheck %s -check-prefixes VERBOSE-MSG,EXE-MSG
 // RUN: llvm-readobj --dyn-symbols --dyn-relocations --cap-relocs --cap-table %t.exe | FileCheck %s --check-prefixes CHECK,CHECK-NODYN
-// VERBOSE-MSG:      Using trampoline for function pointer against local function return1
+// VERBOSE-MSG:      Forcing symbolic relocation for non-preemptible trampoline-using function pointer against local function return1
 // VERBOSE-MSG-NEXT: >>> defined in ({{.+}}local-fn-ptr-in-plt-abi.c.tmp.o:(function return1{{.+}}))
 // VERBOSE-MSG-NEXT: Adding new symbol __cheri_fnptr_return1 to allow relocation against local function return1
 // VERBOSE-MSG-NEXT: >>> defined in ({{.+}}local-fn-ptr-in-plt-abi.c.tmp.o:(function return1{{.+}}))
-// VERBOSE-MSG-NEXT: Using trampoline for function pointer against function global_return2
-// VERBOSE-MSG-NEXT: >>> defined in 
 // For executables without --export-dynamic we add a new STV_HIDDEN symbol:
+// EXE-MSG:      Forcing symbolic relocation for non-preemptible trampoline-using function pointer against function global_return2
+// EXE-MSG-NEXT: >>> defined in ({{.+}}local-fn-ptr-in-plt-abi.c.tmp.o:(function global_return2{{.+}}))
 // EXE-MSG-NEXT: Adding new symbol __cheri_fnptr_global_return2 to allow relocation against function global_return2
 // EXE-MSG-NEXT: >>> defined in ({{.+}}local-fn-ptr-in-plt-abi.c.tmp.o:(function global_return2{{.+}}))
 // VERBOSE-MSG-EMPTY:
@@ -109,7 +109,7 @@
 
 // no need for trampolines in static executable
 // RUN: ld.lld %t.o %t-shlib.o -o %t-static.exe --verbose-cap-relocs 2>&1 | FileCheck %s --allow-empty --check-prefix STATIC-MESSAGE
-// STATIC-MESSAGE-NOT: Using trampoline for function pointer
+// STATIC-MESSAGE-NOT: Forcing symbolic relocation for non-preemptible trampoline-using function pointer
 
 // RUN: llvm-readobj --dyn-symbols --dyn-relocations --cap-relocs --cap-table %t-static.exe | FileCheck %s --check-prefix STATIC
 // STATIC-LABEL: Dynamic Relocations {

--- a/lld/test/ELF/cheri/cap-table/local-fn-ptr-in-plt-abi.c
+++ b/lld/test/ELF/cheri/cap-table/local-fn-ptr-in-plt-abi.c
@@ -108,8 +108,8 @@
 // CHECK-NEXT: ]
 
 // no need for trampolines in static executable
-// RUN: ld.lld %t.o %t-shlib.o -o %t-static.exe --verbose-cap-relocs 2>&1 | FileCheck %s -check-prefix STATIC-MESSAGE
-// STATIC-MESSAGE: Do not need function pointer trampoline for return1 in static binary
+// RUN: ld.lld %t.o %t-shlib.o -o %t-static.exe --verbose-cap-relocs 2>&1 | FileCheck %s --allow-empty --check-prefix STATIC-MESSAGE
+// STATIC-MESSAGE-NOT: Using trampoline for function pointer
 
 // RUN: llvm-readobj --dyn-symbols --dyn-relocations --cap-relocs --cap-table %t-static.exe | FileCheck %s --check-prefix STATIC
 // STATIC-LABEL: Dynamic Relocations {

--- a/lld/test/ELF/cheri/cap-table/non-preemptible-fn-ptr-unique-plt-abi.c
+++ b/lld/test/ELF/cheri/cap-table/non-preemptible-fn-ptr-unique-plt-abi.c
@@ -125,14 +125,8 @@
 // CHECK-NEXT: ]
 
 // no need for trampolines in static executable
-// RUN: ld.lld %t.o %t2.o -o %t-static.exe --verbose-cap-relocs 2>&1 | FileCheck %s -check-prefix STATIC-MESSAGE
-// STATIC-MESSAGE: Do not need function pointer trampoline for default_callback in static binary
-// STATIC-MESSAGE-NEXT: Do not need function pointer trampoline for static_callback in static binary
-// STATIC-MESSAGE-NEXT: Do not need function pointer trampoline for default_callback in static binary
-// STATIC-MESSAGE-NEXT: Do not need function pointer trampoline for static_callback in static binary
-// STATIC-MESSAGE-NEXT: Do not need function pointer trampoline for default_callback in static binary
-// STATIC-MESSAGE-NEXT: Do not need function pointer trampoline for static_callback in static binary
-// STATIC-MESSAGE-EMPTY:
+// RUN: ld.lld %t.o %t2.o -o %t-static.exe --verbose-cap-relocs 2>&1 | FileCheck %s --allow-empty --check-prefix STATIC-MESSAGE
+// STATIC-MESSAGE-NOT: Using trampoline for function pointer
 
 // RUN: llvm-readobj --dyn-symbols --dyn-relocations --cap-relocs --cap-table %t-static.exe | FileCheck %s --check-prefix STATIC
 // STATIC-LABEL: Dynamic Relocations {

--- a/lld/test/ELF/cheri/cap-table/non-preemptible-fn-ptr-unique-plt-abi.c
+++ b/lld/test/ELF/cheri/cap-table/non-preemptible-fn-ptr-unique-plt-abi.c
@@ -126,7 +126,7 @@
 
 // no need for trampolines in static executable
 // RUN: ld.lld %t.o %t2.o -o %t-static.exe --verbose-cap-relocs 2>&1 | FileCheck %s --allow-empty --check-prefix STATIC-MESSAGE
-// STATIC-MESSAGE-NOT: Using trampoline for function pointer
+// STATIC-MESSAGE-NOT: Forcing symbolic relocation for non-preemptible trampoline-using function pointer
 
 // RUN: llvm-readobj --dyn-symbols --dyn-relocations --cap-relocs --cap-table %t-static.exe | FileCheck %s --check-prefix STATIC
 // STATIC-LABEL: Dynamic Relocations {

--- a/lld/test/ELF/cheri/riscv/ifunc-nonpreemptible.s
+++ b/lld/test/ELF/cheri/riscv/ifunc-nonpreemptible.s
@@ -1,0 +1,72 @@
+# REQUIRES: riscv
+# RUN: %riscv32_cheri_purecap_llvm-mc -filetype=obj %s -o %t.32.o
+# RUN: ld.lld %t.32.o -z separate-code -o %t.32
+# RUN: llvm-readobj -r --cap-relocs -x .got.plt %t.32 | FileCheck --check-prefix=RELOC32 %s
+# RUN: llvm-readelf -x .got.plt %t.32 | FileCheck --check-prefix=GOTPLT32 %s
+# RUN: llvm-readelf -S -s %t.32 | FileCheck --check-prefixes=SEC,NM %s
+# RUN: llvm-objdump -d --no-show-raw-insn %t.32 | FileCheck --check-prefixes=DIS,DIS32 %s
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %s -o %t.64.o
+# RUN: ld.lld %t.64.o -z separate-code -o %t.64
+# RUN: llvm-readelf -S -s %t.64 | FileCheck --check-prefixes=SEC,NM %s
+# RUN: llvm-readobj -r --cap-relocs -x .got.plt %t.64 | FileCheck --check-prefix=RELOC64 %s
+# RUN: llvm-readelf -x .got.plt %t.64 | FileCheck --check-prefix=GOTPLT64 %s
+# RUN: llvm-objdump -d --no-show-raw-insn %t.64 | FileCheck --check-prefixes=DIS,DIS64 %s
+
+# SEC: .iplt PROGBITS {{0*}}00011010
+
+## Canonical PLT in .iplt
+# NM: {{0*}}00011010 16 FUNC GLOBAL DEFAULT {{.*}} func
+
+# RELOC32:      Relocations [
+# RELOC32-NEXT: ]
+# RELOC32:      CHERI __cap_relocs [
+# RELOC32-NEXT:   0x012000 (fptr) Base: 0x11010 (func+0) Length: 16 Perms: Function
+# RELOC32-NEXT:   0x012008 Base: 0x11000 ($x+0) Length: 4 Perms: GNU Indirect Function
+# RELOC32-NEXT: ]
+# GOTPLT32:      section '.got.plt':
+# GOTPLT32-NEXT: 0x00012008 00000000 00000000
+
+# RELOC64:      Relocations [
+# RELOC64-NEXT: ]
+# RELOC64:      CHERI __cap_relocs [
+# RELOC64-NEXT:   0x012000 (fptr) Base: 0x11010 (func+0) Length: 16 Perms: Function
+# RELOC64-NEXT:   0x012010 Base: 0x11000 ($x+0) Length: 4 Perms: GNU Indirect Function
+# RELOC64-NEXT: ]
+# GOTPLT64:      section '.got.plt':
+# GOTPLT64-NEXT: 0x00012010 00000000 00000000 00000000 00000000
+
+# DIS:      <_start>:
+## func - . = 0x11010-0x11004 = 12
+# DIS-NEXT: 11004: auipcc a0, 0
+# DIS-NEXT:        cincoffset a0, a0, 0xc
+
+# DIS:      Disassembly of section .iplt:
+# DIS:      <func>:
+## 32-bit: &.got.plt[func]-. = 0x12008-0x11010 = 4096*1-8
+## 64-bit: &.got.plt[func]-. = 0x12010-0x11010 = 4096*1+0
+# DIS-NEXT: 11010: auipcc t3, 0x1
+# DIS32-NEXT:      lc t3, -0x8(t3)
+# DIS64-NEXT:      lc t3, 0x0(t3)
+# DIS-NEXT:        jalr t1, t3
+# DIS-NEXT:        nop
+
+.text
+.globl func
+.type func, @gnu_indirect_function
+func:
+  cret
+  .size func, . - func
+
+.globl _start
+.type _start, @function
+_start:
+  cllc ca0, func
+  .size _start, . - _start
+
+.data
+.globl fptr
+.type fptr, @object
+fptr:
+  .chericap func
+  .size fptr, . - fptr

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -98,6 +98,7 @@ add_llvm_component_library(LLVMTransformUtils
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Transforms/Utils
 
   DEPENDS
+  vt_gen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2712,9 +2712,23 @@ printELFCapRelocations(const ELFObjectFile<ELFT> *Obj) {
     uint64_t Perms =
         support::endian::read<TargetUint, ELFT::Endianness, 1>(
                 entry + 4*sizeof(TargetUint));
-    bool isFunction = Perms & (UINT64_C(1) << ((sizeof(TargetUint) * 8) - 1));
-    bool isConstant = Perms & (UINT64_C(1) << ((sizeof(TargetUint) * 8) - 2));
-    //Perms &= 0xffffffff;
+    const uint64_t Function = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 1);
+    const uint64_t Constant = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 2);
+    StringRef PermStr;
+    switch (Perms) {
+    case 0:
+      PermStr = "";
+      break;
+    case Constant:
+      PermStr = " (Constant)";
+      break;
+    case Function:
+      PermStr = " (Function)";
+      break;
+    default:
+      PermStr = " (Unknown)";
+      break;
+    }
     StringRef Symbol = "<Unnamed symbol>";
     if (SymbolNames.find(Base) != SymbolNames.end())
       Symbol = SymbolNames[Base];
@@ -2722,9 +2736,8 @@ printELFCapRelocations(const ELFObjectFile<ELFT> *Obj) {
            << format(AddrFmt.data(), Base)
            << ")\tOffset: " << format(AddrFmt.data(), Offset)
            << "\tLength: " << format(AddrFmt.data(), Length)
-           << "\tPermissions: " << format(PermsFmt.data(), Perms)
-           << (isFunction ? " (Function)\n"
-                          : (isConstant ? " (Constant)\n" : "\n"));
+           << "\tPermissions: " << format(PermsFmt.data(), Perms) << PermStr
+           << "\n";
   }
   outs() << "\n";
 }

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2714,6 +2714,7 @@ printELFCapRelocations(const ELFObjectFile<ELFT> *Obj) {
                 entry + 4*sizeof(TargetUint));
     const uint64_t Function = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 1);
     const uint64_t Constant = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 2);
+    const uint64_t Indirect = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 3);
     StringRef PermStr;
     switch (Perms) {
     case 0:
@@ -2724,6 +2725,9 @@ printELFCapRelocations(const ELFObjectFile<ELFT> *Obj) {
       break;
     case Function:
       PermStr = " (Function)";
+      break;
+    case Function | Indirect:
+      PermStr = " (GNU Indirect Function)";
       break;
     default:
       PermStr = " (Unknown)";

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -3528,6 +3528,7 @@ template <class ELFT> void ELFDumper<ELFT>::printCheriCapRelocs() {
                 entry + 4*sizeof(TargetUint));
     const uint64_t Function = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 1);
     const uint64_t Constant = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 2);
+    const uint64_t Indirect = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 3);
     StringRef PermStr;
     switch (Perms) {
     case 0:
@@ -3538,6 +3539,9 @@ template <class ELFT> void ELFDumper<ELFT>::printCheriCapRelocs() {
       break;
     case Function:
       PermStr = "Function";
+      break;
+    case Function | Indirect:
+      PermStr = "GNU Indirect Function";
       break;
     default:
       PermStr = "Unknown";

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -3526,11 +3526,23 @@ template <class ELFT> void ELFDumper<ELFT>::printCheriCapRelocs() {
     uint64_t Perms =
         support::endian::read<TargetUint, ELFT::Endianness, 1>(
                 entry + 4*sizeof(TargetUint));
-    bool isFunction = Perms & (UINT64_C(1) << ((sizeof(TargetUint) * 8) - 1));
-    bool isReadOnly = Perms & (UINT64_C(1) << ((sizeof(TargetUint) * 8) - 2));
-    const char *PermStr =
-        isFunction ? "Function" : (isReadOnly ? "Constant" : "Object");
-    // Perms &= 0xffffffff;
+    const uint64_t Function = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 1);
+    const uint64_t Constant = UINT64_C(1) << ((sizeof(TargetUint) * 8) - 2);
+    StringRef PermStr;
+    switch (Perms) {
+    case 0:
+      PermStr = "Object";
+      break;
+    case Constant:
+      PermStr = "Constant";
+      break;
+    case Function:
+      PermStr = "Function";
+      break;
+    default:
+      PermStr = "Unknown";
+      break;
+    }
     std::string BaseSymbol;
     if (Base == 0) {
       // Base is 0 -> either it is really NULL or (more likely) there is a


### PR DESCRIPTION
- **[ELF][CHERI] Add addPltEntry infrastructure for cross-compartment calls**
- **[NFC][ELF][CHERI] Centralise cap relocs code in addPltEntry**
- **[NFC][ELF][CHERI] Add useRelativeCheriRelocs guard in addPltEntry**
- **[NFCI][ELF][CHERI] Push addCapabilityRelocation into addRelativeReloc**
- **[NFCI][ELF][CHERI] Move non-zero addend check to addCapabilityRelocation**
- **[NFC][ELF][CHERI] Stop passing R_CHERI_CAPABILITY to addReloc**
- **[NFC][ELF][CHERI] Fix relocation name in comments and add TODO**
- **[NFC][ELF][CHERI] Rename R_CHERI_CAPABILITY to R_ABS_CAP**
- **[NFCI][ELF][CHERI][Mips] Infer isCallExpr from RelType**
- **[ELF][CHERI][Mips] Drop PLT ABI static binary verbose message**
- **[NFC][ELF][CHERI][Mips] Extract new needsCheriMipsTrampoline**
- **[NFC][ELF][CHERI] Extract new addRelativeCapabilityRelocation**
- **[NFC][ELF][CHERI] Use new addRelativeCapabilityRelocation**
- **[NFC][ELF][CHERI] Rename useRelativeCheriRelocs to useRelativeElfCheriRelocs**
- **[ELF][Mips][RISCV] Support CHERI_CAPABILITY(_CALL) in relocate**
- **[NFCI][ELF][CHERI] Teach addSymbolReloc to handle capabilities and use**
- **[NFC][ELF][CHERI][Mips] Extract new getCheriMipsTrampolineSym**
- **[ELF][CHERI][Mips] Move trampoline handling to addRelativeCapabilityRelocation**
- **[NFCI][ELF][CHERI][Mips] Make MipsCheriCapTableSection more like addGotEntry**
- **[ELf][CHERI] Handle shard for R_ABS_CAP in addRelativeReloc**
- **[ELF][Mips][RISCV] Teach getDynRel about cheriCapRel**
- **[ELF][CHERI] Follow R_ABS for R_ABS_CAP in processAux**
- **[NFC][ELF][CHERI] Remove now-unused addCapabilityRelocation**
- **[NFC][ELF] De-template processAux**
- **[NFC][ELF] Drop a gratuitous whitespace diff**
- **[NFC][ELF] Don't reimplement addReloc in GotSection**
- **[NFC][ELF][CHERI][Mips] Use addReloc via new addConstant for captable**
- **[NFC][ELF][CHERI][Mips] More closely follow MIPS GOT for captable**
- **[NFC][ELF][CHERI] Fold addNullDerivedCapability into addReloc**
- **[NFC][ELF][CHERI] Remove stray prototype**
- **[RISCV][CHERI] Support both Xcheri and Zcheri assembly in runtime libs. (#780)**
- **Utils: add missing dep for llvm/CodeGen/GenVT.inc**
- **[Headers] Declare start/stop/end symbols as arrays in cheri_init_globals.h**
- **[Headers] Trap on caprelocs with unknown permissions**
- **[llvm-objdump][llvm-readobj] Be strict for decoding caprelocs permissions**
- **[Headers] Skip IRELATIVE-style caprelocs in cheri_init_globals.h**
- **[llvm-objdump][llvm-readobj] Decode IRELATIVE-style caprelocs permissions**
- **[ELF][CHERI] Set non-zero size for IFUNC canonical PLT on CHERI**
- **[ELF][CHERI] Support emitting IRELATIVE-style caprelocs**
- **[Headers] Add new caprelocs permission for code pointers**
