### PR TITLE
[CHERI] Disable use of SHXADD instructions to materialize frame offset adjustments on pure cap ABIs.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -404,7 +404,9 @@ void RISCVRegisterInfo::adjustReg(MachineBasicBlock &MBB,
   // path.  We avoid anything which can be done with a single lui as it might
   // be compressible.  Note that the sh1add case is fully covered by the 2x addi
   // case just above and is thus omitted.
-  if (ST.hasStdExtZba() && (Val & 0xFFF) != 0) {
+  if (ST.hasStdExtZba() && (Val & 0xFFF) != 0 &&
+      // SHXADD does not work on capability registers
+      !IsPureCapABI) {
     unsigned Opc = 0;
     if (isShiftedInt<12, 3>(Val)) {
       Opc = RISCV::SH3ADD;

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-zbb-adjustreg.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-zbb-adjustreg.ll
@@ -1,0 +1,20 @@
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32cheriotv1-unknown-cheriotrtos -target-abi cheriot  %s -mattr=+xcheri,+xcheripurecap,+xcheriot,+b -o - | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32cheriotv1-unknown-cheriotrtos"
+
+%struct.mlk_polymat = type { [3 x %struct.mlk_polyvec] }
+%struct.mlk_polyvec = type { [3 x %struct.mlk_poly] }
+%struct.mlk_poly = type { [256 x i16] }
+
+; Make sure we don't accidentally try to use a sh3add to compute a capability frame offset.
+; CHECK-LABEL: PQCP_MLKEM_NATIVE_MLKEM768_indcpa_keypair_derand:
+; CHECK-NOT: sh3add
+define ptr addrspace(200) @PQCP_MLKEM_NATIVE_MLKEM768_indcpa_keypair_derand() addrspace(200) #0 {
+entry:
+  %a = alloca %struct.mlk_polymat, align 32, addrspace(200)
+  %e = alloca %struct.mlk_polyvec, align 32, addrspace(200)
+  ret ptr addrspace(200) %e
+}
+
+attributes #0 = { "target-cpu"="cheriot-ibex" }


### PR DESCRIPTION
These instructions aren't capability-safe, so their use results in invalid capability dereferences.
