### PR TITLE
[CHERIoT] Un-break R_RISCV_CHERIOT_COMPARTMENT_LO_S code generation.

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -1088,16 +1088,17 @@ static bool rewriteCheriotLowRelocs(Ctx &ctx, InputSection &sec) {
       modified = true;
       r.type = INTERNAL_R_RISCV_CHERIOT_COMPARTMENT_PCCREL_HI;
       r.expr = R_PC;
-    } else if (r.type == R_RISCV_CHERIOT_COMPARTMENT_LO_I) {
+    } else if (r.type == R_RISCV_CHERIOT_COMPARTMENT_LO_I ||
+               r.type == R_RISCV_CHERIOT_COMPARTMENT_LO_S) {
       // If this is PCC-relative, then the relocation points to the auicgp /
       // auipcc instruction and we need to look there to find the real target.
       if (!isPCCRelative(ctx, nullptr, r.sym))
-        fatal("R_RISCV_CHERIOT_COMPARTMENT_LO_I must point to "
+        fatal("R_RISCV_CHERIOT_COMPARTMENT_LO_[I/S] must point to "
               "R_RISCV_COMPARTMENT_HI");
 
       const Defined *d = cast<Defined>(r.sym);
       if (!d->section)
-        error("R_RISCV_CHERIOT_COMPARTMENT_LO_I relocation points to an "
+        error("R_RISCV_CHERIOT_COMPARTMENT_LO_[I/S] relocation points to an "
               "absolute symbol: " +
               r.sym->getName());
       InputSection *isec = cast<InputSection>(d->section);
@@ -1127,6 +1128,8 @@ static bool rewriteCheriotLowRelocs(Ctx &ctx, InputSection &sec) {
       // If the target is PCC-relative then the auipcc can't be erased and so
       // skip the rewriting.
       if (isPCCRelative(ctx, nullptr, target->sym)) {
+        assert(r.type != R_RISCV_CHERIOT_COMPARTMENT_LO_S &&
+               "Malformed R_RISCV_CHERIOT_COMPARTMENT_LO_S relocation!");
         r.type = INTERNAL_R_RISCV_CHERIOT_COMPARTMENT_PCCREL_LO_I;
         r.expr = RE_RISCV_PC_INDIRECT;
         continue;

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -1048,8 +1048,8 @@ uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
   // Reached only for CGP-relative relocations.  PCC-relative addresses are
   // calculated with the R_PC and R_PC_INDIRECT cases.
   case RE_CHERIOT_COMPARTMENT_CGPREL_LO:
-    if (isPCCRelative(ctx, nullptr, r.sym))
-      fatal("Malformed RE_CHERIOT_COMPARTMENT_CGPREL_LO_I relocation!");
+    assert(!isPCCRelative(ctx, nullptr, r.sym) &&
+           "Malformed RE_CHERIOT_COMPARTMENT_CGPREL_LO relocation!");
     return getBiasedCGPOffsetLo12(ctx, *r.sym);
   case RE_CHERIOT_COMPARTMENT_CGPREL_HI:
     return (getBiasedCGPOffset(ctx, *r.sym) -

--- a/lld/test/ELF/cheri/riscv/cheriot_compartment_lo_s.s
+++ b/lld/test/ELF/cheri/riscv/cheriot_compartment_lo_s.s
@@ -1,0 +1,35 @@
+# REQUIRES: riscv
+# RUN: llvm-mc -triple=riscv32cheriot-unknown-cheriotrtos -mcpu=cheriot -mattr=+c,+xcheri,+xcheripurecap,+xcheriot -filetype=obj %s -o %t.o
+# RUN: ld.lld %t.o -o %t.exe
+# RUN: llvm-objdump -d %t.exe | FileCheck %s
+
+	.attribute	4, 16
+	.attribute	5, "rv32e2p0_m2p0_c2p0_zmmul1p0_xcheri0p0_xcheriot1p0_xcheripurecap0p0"
+	.section	.text,"ax",@progbits
+	.globl	_start
+	.p2align	1
+	.type	_start,@function
+.CGP_BLOCK:
+	ct.auipcc	t1, %cheriot_compartment_hi(cgp_label)
+    ct.csw	ra, %cheriot_compartment_lo_s(.CGP_BLOCK)(t1)
+.CGP_FAR_BLOCK:
+	ct.auipcc	t1, %cheriot_compartment_hi(cgp_far_label)
+    ct.csw	ra, %cheriot_compartment_lo_s(.CGP_FAR_BLOCK)(t1)
+
+# CHECK: 000110f4 <.CGP_BLOCK>:
+# CHECK-NEXT: 110f4: ffffe37b      ct.auicgp       t1, 0xffffe
+# CHECK-NEXT: 110f8: fe132e23      ct.csw  ra, -0x4(t1)
+
+# CHECK: 000110fc <.CGP_FAR_BLOCK>:
+# CHECK-NEXT: 110fc: 0000237b      ct.auicgp       t1, 0x2
+# CHECK-NEXT: 11100: 00132023      ct.csw  ra, 0x0(t1)
+
+.section        .data,"aw",@progbits
+.type   cgp_label,@object
+.globl  cgp_label
+.p2align        4, 0x0
+cgp_label:
+	.word 2
+.zero 8192
+cgp_far_label:
+	.word 3

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
@@ -174,6 +174,7 @@ unsigned RISCVELFObjectWriter::getRelocType(const MCFixup &Fixup,
   case RISCV::fixup_riscv_cheriot_compartment_lo_i:
     return ELF::R_RISCV_CHERIOT_COMPARTMENT_LO_I;
   case RISCV::fixup_riscv_cheriot_compartment_lo_s:
+    return ELF::R_RISCV_CHERIOT_COMPARTMENT_LO_S;
   case RISCV::fixup_riscv_cheriot_compartment_size:
     return ELF::R_RISCV_CHERIOT_COMPARTMENT_SIZE;
   }


### PR DESCRIPTION
What started as a simple plan to add a test for R_RISCV_CHERIOT_COMPARTMENT_LO_S linking uncovered the fact that we've been silently generating R_RISCV_CHERIOT_COMPARTMENT_SIZE in place of R_RISCV_CHERIOT_COMPARTMENT_LO_S since 08a39295a96335f7d71fa4d8dff1c57ea995e8a2, and somehow nobody ever noticed. This change corrects that, fixes the relatively minor downstream issues exposed in LLD by doing so, and adds a basic sanity test so that we don't break it again.
