### PR TITLE
Integrate changes from CTSRD:dev up to 848e3ddd1be233a5384c8c7e76119c241960ec53

### DIFF
--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -182,13 +182,10 @@ std::string CheriCapRelocLocation::toString(Ctx &ctx) const {
 
 void CheriCapRelocsSection::addCapReloc(bool isCode, CheriCapRelocLocation loc,
                                         const SymbolAndOffset &target,
-                                        int64_t capabilityOffset,
-                                        Symbol *sourceSymbol) {
+                                        int64_t capabilityOffset) {
   assert(!isa<Symbol *>(target.symOrSec) || !target.sym()->isPreemptible);
 
-  auto sourceMsg = [&]() -> std::string {
-    return sourceSymbol ? verboseToString(ctx, sourceSymbol) : loc.toString(ctx);
-  };
+  auto sourceMsg = [&]() -> std::string { return loc.toString(ctx); };
   if (isa<Symbol *>(target.symOrSec) && target.sym()->isUndefined() &&
       !target.sym()->isUndefWeak()) {
     auto diag = (ctx.arg.unresolvedSymbols == UnresolvedPolicy::ReportError)

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -32,6 +32,76 @@ bool hasDynamicLinker(Ctx &ctx) {
   return ctx.arg.shared || ctx.arg.pie || !ctx.sharedFiles.empty();
 }
 
+template <typename ELFT>
+static void getMipsCheriAbiVariant(std::optional<unsigned> &abi,
+                                   SyntheticSection &sec) {
+  abi = static_cast<MipsAbiFlagsSection<ELFT> &>(sec).getCheriAbiVariant();
+}
+
+static bool isCheriMipsTrampolineAbi(Ctx &ctx) {
+  if (ctx.arg.emachine != EM_MIPS)
+    return false;
+
+  if (!ctx.in.mipsAbiFlags)
+    return false;
+
+  std::optional<unsigned> abi;
+  invokeELFT(getMipsCheriAbiVariant, abi, *ctx.in.mipsAbiFlags);
+  if (!abi)
+    return false;
+
+  if (*abi != DF_MIPS_CHERI_ABI_PLT && *abi != DF_MIPS_CHERI_ABI_FNDESC)
+    return false;
+
+  return true;
+}
+
+static bool needsCheriMipsTrampoline(Ctx &ctx, RelType type,
+                                     const Symbol &sym) {
+  // In the PLT ABI (and fndesc?) we have to use an elf relocation for function
+  // pointers to ensure that the runtime linker adds the required trampolines
+  // that sets $cgp:
+
+  if (!isCheriMipsTrampolineAbi(ctx))
+    return false;
+
+  if (!sym.isFunc() || type == *ctx.target->symbolicCapCallRel)
+    return false;
+
+  // In static binaries we do not need PLT stubs for function pointers since
+  // all functions share the same $cgp
+  // TODO: this is no longer true if we were to support dlopen() in static
+  // binaries
+  if (!hasDynamicLinker(ctx))
+    return false;
+
+  return true;
+}
+
+static bool isSymIncludedInDynsym(Ctx &ctx, const Symbol &sym) {
+  if (sym.computeBinding(ctx) == STB_LOCAL)
+    return false;
+  if (!sym.isDefined() && !sym.isCommon())
+    return true;
+
+  return sym.isExported ||
+         (ctx.arg.exportDynamic && (sym.isUsedInRegularObj || !sym.ltoCanOmit));
+}
+
+static Symbol &getCheriMipsTrampolineSym(Ctx &ctx, RelType type, Symbol &sym) {
+  assert(needsCheriMipsTrampoline(ctx, type, sym));
+
+  if (isSymIncludedInDynsym(ctx, sym))
+    return sym;
+
+  Defined &newSym = *ctx.symtab->ensureSymbolWillBeInDynsym(&sym);
+  assert(newSym.isFunc() && "This should only be used for functions");
+  assert(isSymIncludedInDynsym(ctx, newSym));
+  assert(newSym.binding == llvm::ELF::STB_GLOBAL);
+  assert(newSym.visibility() == llvm::ELF::STV_HIDDEN);
+  return newSym;
+}
+
 // See CheriBSD crt_init_globals()
 template <class ELFT>
 struct InMemoryCapRelocEntry {
@@ -190,6 +260,18 @@ void CheriCapRelocsSection::addReloc(
 
   assert(expr == R_ABS_CAP);
   assert(!sym || !sym->isPreemptible);
+
+  if (sym && needsCheriMipsTrampoline(ctx, type, *sym)) {
+    if (ctx.arg.verboseCapRelocs)
+      message("Forcing symbolic relocation for non-preemptible "
+              "trampoline-using function pointer against " +
+              verboseToString(ctx, sym));
+
+    sym = &getCheriMipsTrampolineSym(ctx, type, *sym);
+    getPartition(ctx).relaDyn->addSymbolReloc(type, isec, offsetInSec, *sym,
+                                              addend, type);
+    return;
+  }
 
   auto sourceMsg = [&]() -> std::string { return loc.toString(ctx); };
   if (isa<Symbol *>(target.symOrSec) && target.sym()->isUndefined() &&
@@ -942,91 +1024,11 @@ void MipsCheriCapTableMappingSection::writeTo(uint8_t *buf) {
   memcpy(buf, entries.data(), entries.size() * sizeof(CaptableMappingEntry));
 }
 
-static bool isSymIncludedInDynsym(Ctx &ctx, const Symbol &sym) {
-  if (sym.computeBinding(ctx) == STB_LOCAL) return false;
-  if (!sym.isDefined() && !sym.isCommon()) return true;
-
-  return sym.isExported ||
-         (ctx.arg.exportDynamic && (sym.isUsedInRegularObj || !sym.ltoCanOmit));
-}
-
-template <typename ELFT>
-static void getMipsCheriAbiVariant(std::optional<unsigned> &abi,
-                                   SyntheticSection &sec) {
-  abi = static_cast<MipsAbiFlagsSection<ELFT> &>(sec).getCheriAbiVariant();
-}
-
-static bool isCheriMipsTrampolineAbi(Ctx &ctx) {
-  if (ctx.arg.emachine != EM_MIPS)
-    return false;
-
-  if (!ctx.in.mipsAbiFlags)
-    return false;
-
-  std::optional<unsigned> abi;
-  invokeELFT(getMipsCheriAbiVariant, abi, *ctx.in.mipsAbiFlags);
-  if (!abi)
-    return false;
-
-  if (*abi != DF_MIPS_CHERI_ABI_PLT && *abi != DF_MIPS_CHERI_ABI_FNDESC)
-    return false;
-
-  return true;
-}
-
-static bool needsCheriMipsTrampoline(Ctx &ctx, RelType type,
-                                     const Symbol &sym) {
-  // In the PLT ABI (and fndesc?) we have to use an elf relocation for function
-  // pointers to ensure that the runtime linker adds the required trampolines
-  // that sets $cgp:
-
-  if (!isCheriMipsTrampolineAbi(ctx))
-    return false;
-
-  if (!sym.isFunc() || type == *ctx.target->symbolicCapCallRel)
-    return false;
-
-  // In static binaries we do not need PLT stubs for function pointers since
-  // all functions share the same $cgp
-  // TODO: this is no longer true if we were to support dlopen() in static
-  // binaries
-  if (!lld::elf::hasDynamicLinker(ctx))
-    return false;
-
-  return true;
-}
-
-static Symbol &getCheriMipsTrampolineSym(Ctx &ctx, RelType type, Symbol &sym) {
-  assert(needsCheriMipsTrampoline(ctx, type, sym));
-
-  if (isSymIncludedInDynsym(ctx, sym))
-    return sym;
-
-  Defined &newSym = *ctx.symtab->ensureSymbolWillBeInDynsym(&sym);
-  assert(newSym.isFunc() && "This should only be used for functions");
-  assert(isSymIncludedInDynsym(ctx, newSym));
-  assert(newSym.binding == llvm::ELF::STB_GLOBAL);
-  assert(newSym.visibility() == llvm::ELF::STV_HIDDEN);
-  return newSym;
-}
-
 void addRelativeCapabilityRelocation(
     Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
     llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
     RelExpr expr, RelType type) {
   Partition &part = isec.getPartition(ctx);
-  Symbol *sym = dyn_cast<Symbol *>(symOrSec);
-  assert(expr == R_ABS_CAP);
-  if (sym && needsCheriMipsTrampoline(ctx, type, *sym)) {
-    if (ctx.arg.verboseCapRelocs)
-      message("Forcing symbolic relocation for non-preemptible "
-              "trampoline-using function pointer against " +
-              verboseToString(ctx, sym));
-
-    sym = &getCheriMipsTrampolineSym(ctx, type, *sym);
-    part.relaDyn->addSymbolReloc(type, isec, offsetInSec, *sym, addend, type);
-    return;
-  }
   assert(!ctx.arg.useRelativeElfCheriRelocs &&
          "relative ELF capability relocations not currently implemented");
   part.capRelocs->addReloc(isec, offsetInSec, symOrSec, addend, expr, type);

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -182,7 +182,7 @@ std::string CheriCapRelocLocation::toString(Ctx &ctx) const {
 
 void CheriCapRelocsSection::addCapReloc(bool isCode, CheriCapRelocLocation loc,
                                         const SymbolAndOffset &target,
-                                        int64_t capabilityOffset) {
+                                        int64_t addend) {
   assert(!isa<Symbol *>(target.symOrSec) || !target.sym()->isPreemptible);
 
   auto sourceMsg = [&]() -> std::string { return loc.toString(ctx); };
@@ -199,9 +199,9 @@ void CheriCapRelocsSection::addCapReloc(bool isCode, CheriCapRelocLocation loc,
          << "\n>>> referenced by " << sourceMsg();
   }
 
-  // assert(CapabilityOffset >= 0 && "Negative offsets not supported");
-  if (errorHandler().verbose && capabilityOffset < 0)
-    message("global capability offset " + Twine(capabilityOffset) +
+  // assert(addend >= 0 && "Negative offsets not supported");
+  if (errorHandler().verbose && addend < 0)
+    message("global capability offset " + Twine(addend) +
             " is less than 0:\n>>> Location: " + loc.toString(ctx) +
             "\n>>> Target: " + target.verboseToString(ctx));
 
@@ -212,7 +212,7 @@ void CheriCapRelocsSection::addCapReloc(bool isCode, CheriCapRelocLocation loc,
     return;
   }
 
-  addEntry(loc, {isCode, target, capabilityOffset});
+  addEntry(loc, {isCode, target, addend});
 }
 
 static uint64_t getTargetSize(Ctx &ctx, const CheriCapRelocLocation &location,

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -180,10 +180,16 @@ std::string CheriCapRelocLocation::toString(Ctx &ctx) const {
   return SymbolAndOffset(section, offset).verboseToString(ctx);
 }
 
-void CheriCapRelocsSection::addCapReloc(bool isCode, CheriCapRelocLocation loc,
-                                        const SymbolAndOffset &target,
-                                        int64_t addend) {
-  assert(!isa<Symbol *>(target.symOrSec) || !target.sym()->isPreemptible);
+void CheriCapRelocsSection::addReloc(
+    InputSectionBase &isec, uint64_t offsetInSec,
+    llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
+    RelExpr expr, RelType type) {
+  Symbol *sym = dyn_cast<Symbol *>(symOrSec);
+  CheriCapRelocLocation loc{&isec, offsetInSec};
+  SymbolAndOffset target{symOrSec, 0};
+
+  assert(expr == R_ABS_CAP);
+  assert(!sym || !sym->isPreemptible);
 
   auto sourceMsg = [&]() -> std::string { return loc.toString(ctx); };
   if (isa<Symbol *>(target.symOrSec) && target.sym()->isUndefined() &&
@@ -212,6 +218,7 @@ void CheriCapRelocsSection::addCapReloc(bool isCode, CheriCapRelocLocation loc,
     return;
   }
 
+  bool isCode = type == ctx.target->symbolicCodeCapRel;
   addEntry(loc, {isCode, target, addend});
 }
 
@@ -1020,12 +1027,9 @@ void addRelativeCapabilityRelocation(
     part.relaDyn->addSymbolReloc(type, isec, offsetInSec, *sym, addend, type);
     return;
   }
-  bool isCode = type == ctx.target->symbolicCodeCapRel;
-  assert(!sym || !sym->isPreemptible);
   assert(!ctx.arg.useRelativeElfCheriRelocs &&
          "relative ELF capability relocations not currently implemented");
-  part.capRelocs->addCapReloc(isCode, {&isec, offsetInSec}, {symOrSec, 0u},
-                              addend);
+  part.capRelocs->addReloc(isec, offsetInSec, symOrSec, addend, expr, type);
 }
 
 // CHERI-MIPS using the PLT and fndesc ABIs uses a different mechanism for

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -846,8 +846,8 @@ uint64_t MipsCheriCapTableSection::assignIndices(uint64_t startIndex,
     else if (targetSym->isUndefWeak())
       addConstant(ctx, {R_ABS_CAP, elfCapabilityReloc, off, 0, targetSym});
     else
-      addRelativeCapabilityRelocation(ctx, *this, off, targetSym, 0, R_ABS_CAP,
-                                      elfCapabilityReloc);
+      ctx.mainPart->capRelocs->addReloc(*this, off, *targetSym, 0, R_ABS_CAP,
+                                        elfCapabilityReloc);
   }
   assert(assignedSmallIndexes + assignedLargeIndexes == entries.size());
   return assignedSmallIndexes + assignedLargeIndexes;
@@ -1022,16 +1022,6 @@ void MipsCheriCapTableMappingSection::writeTo(uint8_t *buf) {
   }
   assert(entries.size() * sizeof(CaptableMappingEntry) == getSize());
   memcpy(buf, entries.data(), entries.size() * sizeof(CaptableMappingEntry));
-}
-
-void addRelativeCapabilityRelocation(
-    Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
-    llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
-    RelExpr expr, RelType type) {
-  Partition &part = isec.getPartition(ctx);
-  assert(!ctx.arg.useRelativeElfCheriRelocs &&
-         "relative ELF capability relocations not currently implemented");
-  part.capRelocs->addReloc(isec, offsetInSec, symOrSec, addend, expr, type);
 }
 
 // CHERI-MIPS using the PLT and fndesc ABIs uses a different mechanism for

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -90,12 +90,12 @@ public:
                 RelType type) {
     addReloc(isec, offsetInSec, &targetSec, addend, expr, type);
   }
-  void addReloc(InputSectionBase &isec, uint64_t offsetInSec,
-                llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
-                int64_t addend, RelExpr expr, RelType type);
 
 private:
   template <class ELFT> void writeToImpl(uint8_t *);
+  void addReloc(InputSectionBase &isec, uint64_t offsetInSec,
+                llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
+                int64_t addend, RelExpr expr, RelType type);
   bool addEntry(CheriCapRelocLocation loc, CheriCapReloc relocation) {
     auto it = relocsMap.insert(std::make_pair(loc, relocation));
     // assert(it.first->second == Relocation);

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -82,8 +82,7 @@ public:
   size_t getSize() const override { return relocsMap.size() * entsize; }
   void writeTo(uint8_t *buf) override;
   void addCapReloc(bool isCode, CheriCapRelocLocation loc,
-                   const SymbolAndOffset &target, int64_t capabilityOffset,
-                   Symbol *sourceSymbol = nullptr);
+                   const SymbolAndOffset &target, int64_t capabilityOffset);
 
 private:
   template <class ELFT> void writeToImpl(uint8_t *);

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -81,8 +81,18 @@ public:
   bool isNeeded() const override { return !relocsMap.empty(); }
   size_t getSize() const override { return relocsMap.size() * entsize; }
   void writeTo(uint8_t *buf) override;
-  void addCapReloc(bool isCode, CheriCapRelocLocation loc,
-                   const SymbolAndOffset &target, int64_t addend);
+  void addReloc(InputSectionBase &isec, uint64_t offsetInSec, Symbol &sym,
+                int64_t addend, RelExpr expr, RelType type) {
+    addReloc(isec, offsetInSec, &sym, addend, expr, type);
+  }
+  void addReloc(InputSectionBase &isec, uint64_t offsetInSec,
+                InputSectionBase &targetSec, int64_t addend, RelExpr expr,
+                RelType type) {
+    addReloc(isec, offsetInSec, &targetSec, addend, expr, type);
+  }
+  void addReloc(InputSectionBase &isec, uint64_t offsetInSec,
+                llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec,
+                int64_t addend, RelExpr expr, RelType type);
 
 private:
   template <class ELFT> void writeToImpl(uint8_t *);

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -82,7 +82,7 @@ public:
   size_t getSize() const override { return relocsMap.size() * entsize; }
   void writeTo(uint8_t *buf) override;
   void addCapReloc(bool isCode, CheriCapRelocLocation loc,
-                   const SymbolAndOffset &target, int64_t capabilityOffset);
+                   const SymbolAndOffset &target, int64_t addend);
 
 private:
   template <class ELFT> void writeToImpl(uint8_t *);

--- a/lld/ELF/Arch/Cheri.h
+++ b/lld/ELF/Arch/Cheri.h
@@ -363,11 +363,6 @@ inline uint64_t getBiasedCGPOffsetLo12(Ctx &ctx, const Symbol &sym)
   return (mask << 11) | (Displacement & ((1L << 11) - 1));
 }
 
-void addRelativeCapabilityRelocation(
-    Ctx &ctx, InputSectionBase &isec, uint64_t offsetInSec,
-    llvm::PointerUnion<Symbol *, InputSectionBase *> symOrSec, int64_t addend,
-    RelExpr expr, RelType type);
-
 bool needsCheriPccSegment(Ctx &ctx);
 
 // Align OutputSections as needed to ensure the bounds of capabilities

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -893,15 +893,14 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
                              RelExpr expr, RelType type) {
   Partition &part = isec.getPartition(ctx);
 
-  if (expr == R_ABS_CAP) {
+  if (expr == R_ABS_CAP && !ctx.arg.useRelativeElfCheriRelocs) {
     if (shard) {
       std::lock_guard<std::mutex> lock(ctx.relocMutex);
       addRelativeReloc(ctx, isec, offsetInSec, sym, addend, expr, type);
       return;
     }
 
-    addRelativeCapabilityRelocation(ctx, isec, offsetInSec, &sym, addend, expr,
-                                    type);
+    part.capRelocs->addReloc(isec, offsetInSec, sym, addend, expr, type);
     return;
   }
 
@@ -920,6 +919,9 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
       isec.relocations.push_back({expr, type, offsetInSec, addend, &sym});
     return;
   }
+
+  assert(expr != R_ABS_CAP &&
+         "relative ELF capability relocations not currently implemented");
 
   // Add a relative relocation. If relrDyn section is enabled, and the
   // relocation offset is guaranteed to be even, add the relocation to
@@ -951,15 +953,15 @@ static void addPltEntry(Ctx &ctx, PltSection &plt, GotPltSection &gotPlt,
 
   if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeElfCheriRelocs) {
     if (!sym.isPreemptible) {
-      addRelativeCapabilityRelocation(ctx, gotPlt, sym.getGotPltOffset(ctx),
-                                      &sym, 0, R_ABS_CAP,
-                                      *ctx.target->symbolicCapRel);
+      ctx.mainPart->capRelocs->addReloc(gotPlt, sym.getGotPltOffset(ctx), sym,
+                                        0, R_ABS_CAP,
+                                        *ctx.target->symbolicCapRel);
       return;
     }
 
-    addRelativeCapabilityRelocation(ctx, gotPlt, sym.getGotPltOffset(ctx), &plt,
-                                    0, R_ABS_CAP,
-                                    *ctx.target->symbolicCodeCapRel);
+    ctx.mainPart->capRelocs->addReloc(gotPlt, sym.getGotPltOffset(ctx), plt, 0,
+                                      R_ABS_CAP,
+                                      *ctx.target->symbolicCodeCapRel);
   }
 
   rel.addReloc({type, &gotPlt, sym.getGotPltOffset(ctx),

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -894,13 +894,16 @@ static void addRelativeReloc(Ctx &ctx, InputSectionBase &isec,
   Partition &part = isec.getPartition(ctx);
 
   if (expr == R_ABS_CAP && !ctx.arg.useRelativeElfCheriRelocs) {
-    if (shard) {
-      std::lock_guard<std::mutex> lock(ctx.relocMutex);
-      addRelativeReloc(ctx, isec, offsetInSec, sym, addend, expr, type);
-      return;
-    }
+    auto fn = [&]() {
+      part.capRelocs->addReloc(isec, offsetInSec, sym, addend, expr, type);
+    };
 
-    part.capRelocs->addReloc(isec, offsetInSec, sym, addend, expr, type);
+    if constexpr (shard) {
+      std::lock_guard<std::mutex> lock(ctx.relocMutex);
+      fn();
+    } else
+      fn();
+
     return;
   }
 

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1225,7 +1225,8 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
           "PCC-accessed symbol defined in unsupported section type");
     // TODO: Make this an error in future? Would need special relocation to
     // allow bypassing for specific use cases (e.g. kernel startup code).
-    if ((osec->flags & SHF_WRITE) && !isRelroSection(ctx, osec))
+    if ((osec->flags & SHF_WRITE) &&
+        !isRelroSection(ctx, osec, /*ignoreZRelro=*/true))
       warn("relocation " + toStr(ctx, type) + " against symbol '" +
            toStr(ctx, sym) + "' in non-PCC section" + sec->getLocation(offset));
     else

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1047,8 +1047,7 @@ static void addTgotEntry(Ctx &ctx, Symbol &sym) {
   if (sym.isUndefWeak())
     ctx.in.tgot->addConstant({expr, type, off, 0, &sym});
   else if (ctx.arg.isCheriAbi && !ctx.arg.useRelativeElfCheriRelocs)
-    ctx.in.tgotCapRelocs->addCapReloc(false, {ctx.in.tgot.get(), off},
-                                      {&sym, 0}, 0);
+    ctx.in.tgotCapRelocs->addReloc(*ctx.in.tgot, off, sym, 0, expr, type);
   else
     ctx.in.relaTgot->addReloc(DynamicReloc::AddendOnlyWithTargetVA,
                               ctx.target->tgotRel, *ctx.in.tgot, off, sym, 0,

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -576,7 +576,12 @@ public:
     return !relocs.empty() ||
            llvm::any_of(relocsVec, [](auto &v) { return !v.empty(); });
   }
-  size_t getSize() const override { return relocs.size() * this->entsize; }
+  size_t getSize() const override {
+    size_t count = relocs.size();
+    for (const auto &v : relocsVec)
+      count += v.size();
+    return count * this->entsize;
+  }
   size_t getRelativeRelocCount() const { return numRelativeRelocs; }
   void mergeRels();
   void partitionRels();

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -587,8 +587,9 @@ template <class ELFT> void Writer<ELFT>::addSectionSymbols() {
 //
 // This function returns true if a section needs to be put into a
 // PT_GNU_RELRO segment.
-bool elf::isRelroSection(Ctx &ctx, const OutputSection *sec) {
-  if (!ctx.arg.zRelro)
+bool elf::isRelroSection(Ctx &ctx, const OutputSection *sec,
+                         bool ignoreZRelro) {
+  if (!ignoreZRelro && !ctx.arg.zRelro)
     return false;
   if (sec->relro)
     return true;
@@ -1867,7 +1868,8 @@ static bool isCheriBoundsSection(Ctx &ctx, const OutputSection *sec) {
   // derived from PCC, so include all read-only sections as a workaround for
   // now.  Once CheriBSD 25.03 is no longer supported, this can be removed.
   if (sec->type == SHT_PROGBITS &&
-      (((flags & SHF_WRITE) == 0) || isRelroSection(ctx, sec)))
+      (((flags & SHF_WRITE) == 0) ||
+       isRelroSection(ctx, sec, /*ignoreZRelro=*/true)))
     return true;
 
   return false;

--- a/lld/ELF/Writer.h
+++ b/lld/ELF/Writer.h
@@ -25,7 +25,8 @@ uint8_t getMipsIsaExt(uint64_t oldExt, llvm::StringRef oldFile, uint64_t newExt,
 void checkMipsShlibCompatible(Ctx &ctx, InputFile *f, uint64_t shlibCheriFlags,
                               uint64_t targetCheriFlags);
 bool isCheriAbi(const InputFile *f);
-bool isRelroSection(Ctx &ctx, const OutputSection *sec);
+bool isRelroSection(Ctx &ctx, const OutputSection *sec,
+                    bool ignoreZRelro = false);
 
 } // namespace lld::elf
 

--- a/lld/test/ELF/cheri/riscv/pcc-segment-znorelro.s
+++ b/lld/test/ELF/cheri/riscv/pcc-segment-znorelro.s
@@ -1,0 +1,29 @@
+# REQUIRES: riscv
+
+## Ensure that we allow would-be-relro sections to be included in PCC bounds
+## even if -z norelro is passed, making them not relro in reality.
+
+# RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %s -o %t.o
+# RUN: ld.lld -z separate-code -z norelro %t.o -o %t
+# RUN: llvm-readelf -S -l %t | FileCheck %s
+
+# CHECK-LABEL: Section Headers:
+# CHECK-NEXT:    [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
+# CHECK-NEXT:    [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
+# CHECK-NEXT:    [ 1] .text             PROGBITS        0000000000011000 001000 000008 00  AX  0   0  8
+# CHECK-NEXT:    [ 2] .data.rel.ro      PROGBITS        0000000000012000 002000 000001 00  WA  0   0  1
+# CHECK-NEXT:    [ 3] .pad.cheri.pcc    PROGBITS        0000000000012001 002001 000007 00  WA  0   0  1
+
+# CHECK-LABEL: Program Headers:
+# CHECK-NEXT:    Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+# CHECK-NEXT:    PHDR           0x000040 0x0000000000010040 0x0000000000010040 0x000150 0x000150 R   0x8
+# CHECK-NEXT:    LOAD           0x000000 0x0000000000010000 0x0000000000010000 0x000190 0x000190 R   0x1000
+# CHECK-NEXT:    LOAD           0x001000 0x0000000000011000 0x0000000000011000 0x000008 0x000008 R E 0x1000
+# CHECK-NEXT:    LOAD           0x002000 0x0000000000012000 0x0000000000012000 0x000008 0x000008 RW  0x1000
+# CHECK-NEXT:    CHERI_PCC      0x001000 0x0000000000011000 0x0000000000011000 0x001008 0x001008 R E 0x8
+
+cllc ct0, foo
+
+.section .data.rel.ro
+foo:
+.space 1

--- a/llvm/lib/Target/Mips/CheriRangeChecker.cpp
+++ b/llvm/lib/Target/Mips/CheriRangeChecker.cpp
@@ -30,12 +30,10 @@ namespace {
 // Operands for an allocation.  Either one or two integers (constant or
 // variable).  If there are two, then they must be multiplied together.
 struct ValueSource {
-  ValueSource() = default;
   Value *Base = nullptr;
   int64_t Offset = 0;
 };
 struct AllocOperands {
-  AllocOperands() = default;
   Value *Size = nullptr;
   Value *SizeMultiplier = nullptr;
   ValueSource ValueSrc;


### PR DESCRIPTION
- **[NFC][ELF][CHERI] Drop unused sourceSymbol argument for addCapReloc**
- **[NFC][ELF][CHERI] Rename addCapReloc's capabilityOffset to addend**
- **[NFC][ELF][CHERI] Rename addCapReloc to addReloc and normalise interface**
- **[NFC][ELF][CHERI] Move CHERI-MIPS trampoline code into CheriCapRelocsSection**
- **[NFC][ELF][CHERI] Inline addRelativeCapabilityRelocation**
- **[NFC][ELF][CHERI] Make CheriCapRelocsSection::addReloc private**
- **[NFC][ELF] Avoid confusing recursion in addRelativeReloc**
- **[ELF] Include sharded relocations in RelocationBaseSection::getSize**
- **[ELF][CHERI] Include relro sections in PCC bounds even for -z norelro**
- **CheriRangeChecker: C++20 aggregate type rules**
