### PR TITLE
`InstCombine`: fix folding of `icmp eq i32 (ptrtoint ptr), null` in p200

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -6407,7 +6407,7 @@ Instruction *InstCombinerImpl::foldICmpWithCastOp(ICmpInst &ICmp) {
       PtrTy = cast<VectorType>(PtrTy)->getElementType();
       IntTy = cast<VectorType>(IntTy)->getElementType();
     }
-    return DL.getPointerTypeSizeInBits(PtrTy) == IntTy->getIntegerBitWidth();
+    return DL.getIndexTypeSizeInBits(PtrTy) == IntTy->getIntegerBitWidth();
   };
   if (CastOp0->getOpcode() == Instruction::PtrToInt &&
       CompatibleSizes(SrcTy, DestTy)) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -6407,7 +6407,8 @@ Instruction *InstCombinerImpl::foldICmpWithCastOp(ICmpInst &ICmp) {
       PtrTy = cast<VectorType>(PtrTy)->getElementType();
       IntTy = cast<VectorType>(IntTy)->getElementType();
     }
-    return DL.getIndexTypeSizeInBits(PtrTy) == IntTy->getIntegerBitWidth();
+    return DL.getAddressSizeInBits(PtrTy->getPointerAddressSpace()) ==
+           IntTy->getIntegerBitWidth();
   };
   if (CastOp0->getOpcode() == Instruction::PtrToInt &&
       CompatibleSizes(SrcTy, DestTy)) {

--- a/llvm/test/Transforms/InstCombine/CHERI/cheri-ptrtoint-icmp.ll
+++ b/llvm/test/Transforms/InstCombine/CHERI/cheri-ptrtoint-icmp.ll
@@ -1,0 +1,23 @@
+; Check that
+; RUN: %cheri_opt -S -passes=instcombine %s -o - | FileCheck %s
+source_filename = "vec_optimizes_away.a42c4a0c72f4b4c3-cgu.0"
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32-unknown-cheriotrtos"
+
+define dso_local noundef i1 @foo() unnamed_addr addrspace(200) {
+; CHECK-LABEL: @foo()
+; CHECK-NEXT: start:
+start:
+; CHECK-NEXT:   %0 = tail call noundef align 4 dereferenceable_or_null(12) ptr addrspace(200) @alloc(i32 noundef signext 12, i32 noundef signext 4)
+  %0 = tail call noundef align 4 dereferenceable_or_null(12) ptr addrspace(200) @alloc(i32 noundef signext 12, i32 noundef signext 4)
+
+; CHECK-NEXT:   %1 = icmp eq ptr addrspace(200) %0, null
+  %1 = ptrtoint ptr addrspace(200) %0 to i32
+  %2 = icmp eq i32 %1, 0
+
+; CHECK-NEXT:   ret i1 %1
+  ret i1 %2
+}
+
+declare dso_local noalias noundef ptr addrspace(200) @alloc(i32 noundef signext, i32 allocalign noundef signext) unnamed_addr addrspace(200)
+


### PR DESCRIPTION
Should, hopefully, fix #302.