### PR TITLE
InstCombine: fold `icmp (cheri.address.get %ptr), 0` to `icmp %ptr, null`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -22,9 +22,11 @@
 #include "llvm/Analysis/VectorUtils.h"
 #include "llvm/IR/Cheri.h"
 #include "llvm/IR/ConstantRange.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Transforms/InstCombine/InstCombiner.h"
@@ -6390,10 +6392,32 @@ Instruction *InstCombinerImpl::foldICmpWithCastOp(ICmpInst &ICmp) {
                         SimplifiedOp0 ? SimplifiedOp0 : ICmp.getOperand(0),
                         SimplifiedOp1 ? SimplifiedOp1 : ICmp.getOperand(1));
 
+  if (!isa<Constant>(ICmp.getOperand(1)) && !isa<CastInst>(ICmp.getOperand(1)))
+    return nullptr;
+
+  // CHERI-specific folding of calls to cheri_cap_address_get intrinsic:
+  // icmp eq ptr_size (call ptr_size @llvm.cheri.address.get %ptr), 0
+  // can be folded to
+  // icmp eq ptr %ptr, null
+  if (auto *MaybeCheriAddressGet = dyn_cast<CallInst>(ICmp.getOperand(0))) {
+    if (auto *Callee =
+            dyn_cast<Function>(MaybeCheriAddressGet->getCalledFunction())) {
+      if (Callee->isIntrinsic() &&
+          Callee->getIntrinsicID() == Intrinsic::cheri_cap_address_get) {
+        auto *Op0 = MaybeCheriAddressGet->getOperand(0);
+
+        if (auto *RHSC = dyn_cast<ConstantInt>(ICmp.getOperand(1))) {
+          if (RHSC->isZero() && RHSC->getType() == Callee->getReturnType()) {
+            return new ICmpInst(ICmp.getPredicate(), Op0,
+                                ConstantExpr::getNullValue(Op0->getType()));
+          }
+        }
+      }
+    }
+  }
+
   auto *CastOp0 = dyn_cast<CastInst>(ICmp.getOperand(0));
   if (!CastOp0)
-    return nullptr;
-  if (!isa<Constant>(ICmp.getOperand(1)) && !isa<CastInst>(ICmp.getOperand(1)))
     return nullptr;
 
   Value *Op0Src = CastOp0->getOperand(0);

--- a/llvm/test/Transforms/InstCombine/CHERI/cheri-address-get-icmp.ll
+++ b/llvm/test/Transforms/InstCombine/CHERI/cheri-address-get-icmp.ll
@@ -1,0 +1,23 @@
+; Check that
+; RUN: %cheri_opt -S -passes=instcombine %s -o - | FileCheck %s
+source_filename = "vec_optimizes_away.a42c4a0c72f4b4c3-cgu.0"
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32-unknown-cheriotrtos"
+
+define dso_local noundef i1 @foo() unnamed_addr addrspace(200) {
+; CHECK-LABEL: @foo()
+; CHECK-NEXT: start:
+start:
+; CHECK-NEXT:   %0 = tail call noundef align 4 dereferenceable_or_null(12) ptr addrspace(200) @alloc(i32 noundef signext 12, i32 noundef signext 4)
+  %0 = tail call noundef align 4 dereferenceable_or_null(12) ptr addrspace(200) @alloc(i32 noundef signext 12, i32 noundef signext 4)
+
+; CHECK-NEXT:   %1 = icmp eq ptr addrspace(200) %0, null
+  %1 = tail call addrspace(200) i32 @llvm.cheri.cap.address.get.i32(ptr addrspace(200) %0)
+  %2 = icmp eq i32 %1, 0
+
+; CHECK-NEXT:   ret i1 %1
+  ret i1 %2
+}
+
+declare dso_local noalias noundef ptr addrspace(200) @alloc(i32 noundef signext, i32 allocalign noundef signext) unnamed_addr addrspace(200)
+


### PR DESCRIPTION
As per title. Useful because the use of the `llvm.cheri.cap.address.get` can block optimisations.