### PR TITLE
[CHERIoT][StaticAnalyzer] Suppress derefence warnings prior to compartment state mutation

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriotHeapChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriotHeapChecker.cpp
@@ -73,6 +73,10 @@ class CheriotHeapChecker
        &CheriotHeapChecker::postHeapFreeAll},
   };
 
+  const CallDescriptionSet SafeFnMap{
+      {CDM::SimpleFunc, {"token_obj_unseal"}, 2},
+  };
+
 public:
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
   void checkPostCall(const CallEvent &Call, CheckerContext &C) const;
@@ -98,9 +102,26 @@ private:
 
 } // anonymous namespace
 
+REGISTER_TRAIT_WITH_PROGRAMSTATE(ExternalStateMutated, bool)
 REGISTER_MAP_WITH_PROGRAMSTATE(HeapPointers, SymbolRef, HeapPtrState)
 
-bool isCrossCompartmentCall(const CallEvent &Call, const CheckerContext &C) {
+static bool shouldWarnOnDereferences(ProgramStateRef State) {
+  if (State->get<ExternalStateMutated>())
+    return true;
+
+  // Any pending non-ephemeral claims count as state mutation,
+  // unexpectedly terminating the compartment call without
+  // releasing them could cause a leak.
+  for (const auto &[Sym, HPS] : State->get<HeapPointers>()) {
+    if (HPS.isClaimed())
+      return true;
+  }
+
+  return false;
+}
+
+static bool isCrossCompartmentCall(const CallEvent &Call,
+                                   const CheckerContext &C) {
   // Any call through a CC_CHERICCallback pointer is a compartment call.
   auto IsCompartmentCallbackCall = [](const CallEvent &Call) {
     const auto *CallE =
@@ -150,21 +171,39 @@ void CheriotHeapChecker::checkPreCall(const CallEvent &Call,
 
 void CheriotHeapChecker::checkPostCall(const CallEvent &Call,
                                        CheckerContext &C) const {
-  if (const auto *PostFN = PostFnMap.lookup(Call))
+  if (const auto *PostFN = PostFnMap.lookup(Call)) {
     (*PostFN)(this, Call, C);
+    return;
+  }
+
+  // Opaque calls to unrecognized, non-builtin functions may modify
+  // state, which should cause us to enable warnings.
+  ProgramStateRef State = C.getState();
+  bool Changed = false;
+  const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(Call.getDecl());
+  bool IsBuiltin = FD && FD->getBuiltinID() != 0;
+  if (!IsBuiltin && !SafeFnMap.contains(Call)) {
+    const Decl *RD = Call.getRuntimeDefinition().getDecl();
+    if (!RD || !C.getAnalysisManager().getCFG(RD)) {
+      State = State->set<ExternalStateMutated>(true);
+      Changed = true;
+    }
+  }
 
   if (isCrossCompartmentCall(Call, C)) {
     // All ephemeral claims are implicitly released at each cross-compartment
     // call.
-    ProgramStateRef State = C.getState();
     for (const auto &[Sym, HPS] : State->get<HeapPointers>()) {
       if (!HPS.isEphemeral())
         continue;
 
       State = State->set<HeapPointers>(Sym, HeapPtrState::InvalidatedEphemeral);
+      Changed = true;
     }
-    C.addTransition(State);
   }
+
+  if (Changed)
+    C.addTransition(State);
 }
 
 static void printSymbolNameForError(llvm::raw_ostream &os, SymbolRef Sym) {
@@ -179,6 +218,10 @@ static void printSymbolNameForError(llvm::raw_ostream &os, SymbolRef Sym) {
 
 void CheriotHeapChecker::preCheckPointer(const CallEvent &Call,
                                          CheckerContext &C) const {
+  ProgramStateRef State = C.getState();
+  if (!shouldWarnOnDereferences(State))
+    return;
+
   // If the pointer argument points to memory that could be heap memory,
   // check that it is in Claimed state, and report an error if not. This should
   // make sure to include arguments that are pointers to known stack or constant
@@ -188,7 +231,7 @@ void CheriotHeapChecker::preCheckPointer(const CallEvent &Call,
   if (!Sym)
     return;
 
-  const HeapPtrState *HPS = C.getState()->get<HeapPointers>(Sym);
+  const HeapPtrState *HPS = State->get<HeapPointers>(Sym);
   if (!HPS || HPS->isEffectivelyClaimed())
     return;
 
@@ -296,13 +339,31 @@ void CheriotHeapChecker::postHeapFreeAll(const CallEvent &Call,
 
 void CheriotHeapChecker::checkLocation(SVal Loc, bool IsLoad, const Stmt *S,
                                        CheckerContext &C) const {
+  ProgramStateRef State = C.getState();
   SymbolRef Sym = Loc.getLocSymbolInBase();
-  if (!Sym)
+
+  // If this is a write to non-stack memory that is not one of the
+  // tracked compartment call arguments, then it is an internal state
+  // change that could cause state desynchronization on compartment
+  // crash.
+  const HeapPtrState *HPS = Sym ? State->get<HeapPointers>(Sym) : nullptr;
+  bool WarningsLive = shouldWarnOnDereferences(State);
+  if (!WarningsLive && !IsLoad && !HPS) {
+    const MemRegion *R = Loc.getAsRegion();
+    if (R)
+      R = R->StripCasts();
+    if (!R || !isa<StackSpaceRegion>(R->getMemorySpace(State))) {
+      State = State->set<ExternalStateMutated>(true);
+      C.addTransition(State);
+      return;
+    }
+  }
+
+  if (!WarningsLive || !Sym)
     return;
 
   // This is a dereference of some form, so this is a bug if the
   // claim has already been released either by freeing or invalidation.
-  const HeapPtrState *HPS = C.getState()->get<HeapPointers>(Sym);
   if (!HPS || HPS->isEffectivelyClaimed())
     return;
 
@@ -336,8 +397,11 @@ ProgramStateRef CheriotHeapChecker::checkPointerEscape(
   // FIXME: Unsure why this is needed.
   if (Kind == PointerEscapeKind::PSK_EscapeOnBind)
     return State;
-  if (Call && PostFnMap.lookup(*Call))
-    return State;
+  if (Call) {
+    if (SafeFnMap.contains(*Call) || PreFnMap.lookup(*Call) ||
+        PostFnMap.lookup(*Call))
+      return State;
+  }
   for (SymbolRef Sym : Escaped) {
     if (State->get<HeapPointers>(Sym))
       State = State->set<HeapPointers>(Sym, HeapPtrState::Escaped);

--- a/clang/test/Analysis/Checkers/CHERI/cheriot-heap.c
+++ b/clang/test/Analysis/Checkers/CHERI/cheriot-heap.c
@@ -8,6 +8,10 @@ int heap_claim_ephemeral(void* timeout, const void* ptr, const void* ptr2);
 char check_pointer(const volatile void* ptr, int space,
                    unsigned int rawPermissions, char checkStackNeeded);
 _Bool heap_address_is_valid(void *);
+void *token_obj_unseal(void*, void*);
+
+extern void unknown_call(void);
+extern int unknown_global;
 
 __attribute__((cheri_compartment("bar"))) void crossCompartmentCall(void);
 
@@ -40,11 +44,12 @@ void test_5(int* p) {
     heap_claim(0, p);
     *p = 0;
     heap_free(0, p);
-    *p = 1; // expected-warning{{Store through heap pointer 'p' without a valid claim}}
+    *p = 1;
 }
 
 __attribute__((cheri_compartment("test")))
 void test_6(int* p) {
+    unknown_call();
     heap_claim(0, p);
     *p = 0;
     heap_free_all(0);
@@ -53,6 +58,7 @@ void test_6(int* p) {
 
 __attribute__((cheri_compartment("test")))
 void test_7(int* p) {
+    unknown_call();
     heap_claim_ephemeral(0, p, 0);
     *p = 0;
     heap_free(0, p);
@@ -61,6 +67,7 @@ void test_7(int* p) {
 
 __attribute__((cheri_compartment("test")))
 void test_8(int* p) {
+    unknown_global = 1;
     heap_claim_ephemeral(0, p, 0);
     *p = 0;
     heap_free_all(0);
@@ -108,7 +115,7 @@ void test_14(int* p) {
 
 __attribute__((cheri_compartment("test")))
 void test_15(int* p) {
-    check_pointer(p, 0, 0, 0); // expected-warning{{check_pointer called on potential heap pointer 'p' without a valid claim}}
+    check_pointer(p, 0, 0, 0); // no warn
 }
 
 __attribute__((cheri_compartment("test")))
@@ -137,12 +144,14 @@ void test_20(int* p) {
 
 __attribute__((cheri_compartment("test")))
 void test_21(int* p) {
+    unknown_call();
     if (heap_address_is_valid(p))
         check_pointer(p, 0, 0, 0); // expected-warning{{check_pointer called on potential heap pointer 'p' without a valid claim}}
 }
 
 __attribute__((cheri_compartment("test")))
 void test_22(int* p) {
+    unknown_global = 1;
     *p = 1; // expected-warning{{Store through heap pointer 'p' without a valid claim}}
     heap_claim(0, p);
     *p = 0;
@@ -194,11 +203,13 @@ void test_26(int* p) {
 struct test27_struct { int i; };
 __attribute__((cheri_compartment("test")))
 int test_27(struct test27_struct* p) {
+    unknown_call();
     return p->i; // expected-warning{{Read of heap pointer 'p' without a valid claim}}
 }
 
 __attribute__((cheri_compartment("test")))
 int test_28(int* p) {
+    unknown_call();
     return p[1]; // expected-warning{{Read of heap pointer 'p' without a valid claim}}
 }
 
@@ -208,4 +219,51 @@ int test_29(int *p, Callback f) {
     heap_claim_ephemeral(0, p, 0);
     f();
     return *p; // expected-warning{{Read of heap pointer 'p' after its ephemeral claim was released by a cross-compartment call}}
+}
+
+__attribute__((cheri_compartment("test")))
+void test_30(int* p, int* q) {
+    heap_claim(0, p);
+    heap_claim(0, q);
+    *p = 0;
+    heap_free(0, p);
+    *p = 1; // expected-warning{{Store through heap pointer 'p' without a valid claim}}
+    heap_free(0, q);
+}
+
+__attribute__((cheri_compartment("test")))
+void test_31(int* p) {
+    unknown_call();
+    heap_claim(0, p);
+    *p = 0;
+    heap_free(0, p);
+    *p = 1; // expected-warning{{Store through heap pointer 'p' without a valid claim}}
+}
+
+__attribute__((cheri_compartment("test")))
+void test_32(int* p) {
+    unknown_global = 1;
+    heap_claim(0, p);
+    *p = 0;
+    heap_free(0, p);
+    *p = 1; // expected-warning{{Store through heap pointer 'p' without a valid claim}}
+}
+
+__attribute__((cheri_compartment("test")))
+void test_33(int* p) {
+    unknown_call();
+    check_pointer(p, 0, 0, 0); // expected-warning{{check_pointer called on potential heap pointer 'p' without a valid claim}}
+}
+
+__attribute__((cheri_compartment("test")))
+void test_34(int* p) {
+    token_obj_unseal(0, 0);
+    check_pointer(p, 0, 0, 0); // no warn
+}
+
+__attribute__((cheri_compartment("test")))
+void test_35(int* p, int* q) {
+    int *p2 = (int*)token_obj_unseal(0, p);
+    *p2 = 1;
+    *q = 1; // expected-warning{{Store through heap pointer 'q' without a valid claim}}
 }


### PR DESCRIPTION
This includes a carve-out for capability unsealing, which is known not to change state in
a visible manner.
