### PR TITLE
[CHERIoT][LLD] Relax recently introduced warnings related to SHF_WRITE PCC regions.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,6 +68,8 @@ x86_release_task:
     - rm install/bin/ld64*
     - rm install/bin/lld-link
     - rm install/bin/wasm-ld
+    - rm install/lib/liblldb.so
+    - rm install/lib/liblldb.so.[0-9]*
   binaries_artifacts:
     path: "Build/install/**"
 
@@ -102,5 +104,7 @@ arm_release_task:
     - rm install/bin/ld64*
     - rm install/bin/lld-link
     - rm install/bin/wasm-ld
+    - rm install/lib/liblldb.so
+    - rm install/lib/liblldb.so.[0-9]*
   binaries_artifacts:
     path: "Build/install/**"

--- a/lld/ELF/Arch/Cheri.cpp
+++ b/lld/ELF/Arch/Cheri.cpp
@@ -446,7 +446,9 @@ static CapRelocType getTargetType(Ctx &ctx, const SymbolAndOffset &target) {
   if (os) {
     if ((os->flags & SHF_WRITE) == 0 || (!isTls && isRelroSection(ctx, os)))
       return CapRelocType::RODATA;
-    if (os->flags & SHF_EXECINSTR)
+    // Cheriot doesn't distinguish between ro and relro data, so sections
+    // marked SHF_WRITE can still end up in the PCC region.
+    if (os->flags & SHF_EXECINSTR && !ctx.arg.isCheriot)
       warn("Non-function __cap_reloc against symbol in section with "
            "SHF_EXECINSTR (" +
            toString(os->name) + ") for symbol " + target.verboseToString(ctx));

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1225,8 +1225,13 @@ void RelocationScanner::processAux(RelExpr expr, RelType type, uint64_t offset,
           "PCC-accessed symbol defined in unsupported section type");
     // TODO: Make this an error in future? Would need special relocation to
     // allow bypassing for specific use cases (e.g. kernel startup code).
+    // Cheriot doesn't distinguish between ro and relro data, so sections
+    // marked SHF_WRITE can still end up in the PCC region.
+    bool isCheriotCodeSection =
+        ctx.arg.isCheriot && (osec->flags & SHF_EXECINSTR) != 0;
     if ((osec->flags & SHF_WRITE) &&
-        !isRelroSection(ctx, osec, /*ignoreZRelro=*/true))
+        !isRelroSection(ctx, osec, /*ignoreZRelro=*/true) &&
+        !isCheriotCodeSection)
       warn("relocation " + toStr(ctx, type) + " against symbol '" +
            toStr(ctx, sym) + "' in non-PCC section" + sec->getLocation(offset));
     else


### PR DESCRIPTION
Because CHERIoT does not distinguish between rodata and relro, it's common for
PCC regions to end up with SHF_WRITE set. If it were possible to suppress this
in the linker script, we would.
