### PR TITLE
[CHERI] Prevent indirect tail calls from using callee-saved registers as the destination.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -2196,7 +2196,7 @@ def : InstAlias<"ct.ctail $dst", (PseudoCTAIL cap_call_symbol:$dst)>;
 let Predicates = [HasCheri, IsCapMode, IsPureCapABI], isCall = 1,
     isTerminator = 1, isReturn = 1, isBarrier = 1,
     Uses = [X2_Y] in def PseudoCTAILIndirect
-    : Pseudo<(outs), (ins YGPRNoX0X1:$rs1), [(riscv_cap_tail YGPRNoX0X1:$rs1)]>,
+    : Pseudo<(outs), (ins YGPRTC:$rs1), [(riscv_cap_tail YGPRTC:$rs1)]>,
     PseudoInstExpansion<(CJALR X0_Y, YGPR:$rs1, 0)>;
 
 let Predicates = [HasCheri, IsCapMode, IsPureCapABI] in {

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -431,7 +431,7 @@ def GPRTCNonX7 : GPRRegisterClass<(sub GPRTC, X7)>;
 
 def YGPRTC
     : RegisterClass<"RISCV", [YLenVT, YLenFloatVT], 64,
-                    (add(sequence "X%u_Y", 5, 7), (sequence "X%u_Y", 10, 17),
+                    (add(sequence "X%u_Y", 6, 7), (sequence "X%u_Y", 10, 17),
                         (sequence "X%u_Y", 28, 31))> {
   let RegInfos = YLenRI;
 }


### PR DESCRIPTION
This would cause the destination register to get overwritten by the function epilogue.
