### PR TITLE
[CHERIoT] Fix machine verifier failure in CodeGen/RISCV/cheri/cheri-mcu-ccallback.ll

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -495,7 +495,7 @@ bool RISCVExpandPseudo::expandCompartmentCall(MachineBasicBlock &MBB,
   } else {
     assert(Callee.isReg() && "Expected register operand");
     if (Callee.getReg() != RISCV::X6_Y) {
-      BuildMI(&MBB, DL, TII->get(RISCV::CMove)).addReg(RISCV::X6_Y).add(Callee);
+      BuildMI(&MBB, DL, TII->get(RISCV::CMove)).addDef(RISCV::X6_Y).add(Callee);
     }
   }
 

--- a/llvm/test/CodeGen/RISCV/cheri/cheri-mcu-ccallback.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheri-mcu-ccallback.ll
@@ -1,4 +1,4 @@
-; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot  %s -mattr=+xcheri,+xcheripurecap -o - | FileCheck %s
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot  %s -mattr=+xcheri,+xcheripurecap -verify-machineinstrs -o - | FileCheck %s
 ; ModuleID = 'ccallback.c'
 source_filename = "ccallback.c"
 target datalayout = "e-m:e-pf200:64:64:64:32-p:32:32-i64:64-n32-S128-A200-P200-G200"


### PR DESCRIPTION
This is just a missing register-define flag.
