### PR TITLE
[CHERIoT] Fix machine verifier error on Transforms/LoopStrengthReduce/cheriot-lsr3.ll

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -2089,7 +2089,7 @@ def : Pat<(brind (cptradd YGPR:$rs1, simm12_lo:$imm12)),
 } // Predicates = [HasCheri, IsCapMode, IsPureCapABI]
 
 let Predicates = [HasCheri, IsCapMode],
-    isCall = 1, isBarrier = 1, isCodeGenOnly = 0, hasSideEffects = 0,
+    isCall = 1, isCodeGenOnly = 0, hasSideEffects = 0,
     mayStore = 0, mayLoad = 0, Size = 8 in
 def PseudoCCALLReg : Pseudo<(outs YGPR:$rd),
                             (ins cap_call_symbol:$func), []> {

--- a/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr3.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr3.ll
@@ -1,4 +1,4 @@
-; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot -mattr=+xcheri,+xcheripurecap -o - %s | FileCheck %s
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot -mattr=+xcheri,+xcheripurecap -verify-machineinstrs -o - %s | FileCheck %s
 target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
 target triple = "riscv32cheriotv1-unknown-cheriotrtos"
 


### PR DESCRIPTION
This was due to PseudoCCALLReg being incorrectly marked as a control flow barrier, when it in fact is not.
