### PR TITLE
[MachineOutliner] Do not allow debug instructions to affect liveness computations.

### DIFF
--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -1153,6 +1153,8 @@ bool MachineOutliner::outline(
                  Last = std::next(CallInst.getReverse());
              Iter != Last; Iter++) {
           MachineInstr *MI = &*Iter;
+          if (MI->isDebugInstr())
+            continue;
           SmallSet<Register, 2> InstrUseRegs;
           for (MachineOperand &MOP : MI->operands()) {
             // Skip over anything that isn't a register.

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-machineoutliner-crash.mir
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-machineoutliner-crash.mir
@@ -1,0 +1,205 @@
+# RUN: llc -o /dev/null %s -run-pass=machine-outliner -verify-machineinstrs --filetype=asm --code-model=small --mcpu=cheriot --mtriple=riscv32-unknown-cheriotrtos -target-abi cheriot -mattr=+xcheri,+xcheripurecap,+xcheriot
+--- |
+  ; ModuleID = './reduced.bc'
+  target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+  target triple = "riscv32-unknown-cheriotrtos"
+  
+  %struct.d = type { i8 }
+  
+  @bz = external addrspace(200) global i32
+  
+  ; Function Attrs: minsize
+  define i32 @_Z1gi(i32 %h) addrspace(200) #0 {
+  entry:
+    %agg.tmp.ensured = alloca %struct.d, align 1, addrspace(200)
+    %0 = load i32, ptr addrspace(200) @bz, align 4
+    %1 = call addrspace(200) ptr addrspace(200) @llvm.cheri.bounded.stack.cap.i32(ptr addrspace(200) %agg.tmp.ensured, i32 1)
+    call addrspace(200) void @_ZN1dC1Ei(ptr addrspace(200) %1, i32 %0)
+    store i32 %h, ptr addrspace(200) null, align 4
+    %2 = load i32, ptr addrspace(200) @bz, align 4
+    ret i32 %2
+  }
+  
+  declare void @_ZN1dC1Ei(ptr addrspace(200), i32) addrspace(200) #1
+  
+  ; Function Attrs: minsize
+  define i32 @_Z1ii1a(i32 %h, i32 %j.coerce) addrspace(200) #0 !dbg !4 {
+  entry:
+    %agg.tmp.ensured = alloca %struct.d, align 1, addrspace(200)
+      #dbg_value(i32 %j.coerce, !6, !DIExpression(), !8)
+    tail call addrspace(200) void null()
+    %tobool.not = icmp eq i32 %j.coerce, 0
+    br i1 %tobool.not, label %if.end, label %if.then
+  
+  if.then:                                          ; preds = %entry
+    ret i32 0
+  
+  if.end:                                           ; preds = %entry
+    %0 = load i32, ptr addrspace(200) @bz, align 4
+    %1 = call addrspace(200) ptr addrspace(200) @llvm.cheri.bounded.stack.cap.i32(ptr addrspace(200) %agg.tmp.ensured, i32 1)
+    call addrspace(200) void @_ZN1dC1Ei(ptr addrspace(200) %1, i32 %0)
+    %2 = load i32, ptr addrspace(200) @bz, align 4
+    store i32 %2, ptr addrspace(200) null, align 4
+    call addrspace(200) void null(i8 0, i32 %h)
+    unreachable
+  }
+  
+  ; Function Attrs: nounwind willreturn memory(none)
+  declare ptr addrspace(200) @llvm.cheri.bounded.stack.cap.i32(ptr addrspace(200), i32) addrspace(200) #2
+  
+  attributes #0 = { minsize "target-cpu"="cheriot" "target-features"="+xcheri,+xcheripurecap,+xcheriot" }
+  attributes #1 = { "target-cpu"="cheriot" "target-features"="+xcheri,+xcheripurecap,+xcheriot" }
+  attributes #2 = { nounwind willreturn memory(none) }
+  
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3}
+  
+  !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 23.1.0 (git@github.com:resistor/llvm-project.git 925a406c44db15aac0cafe5bb231d4dc3de1bc94)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: !2, splitDebugInlining: false, nameTableKind: None)
+  !1 = !DIFile(filename: "main-6f217a.cpp", directory: "/Users/resistor/Documents/cheriot-rtos/tests", checksumkind: CSK_MD5, checksum: "57650f2fea3aebd5d28a7183295fc7f3")
+  !2 = !{}
+  !3 = !{i32 2, !"Debug Info Version", i32 3}
+  !4 = distinct !DISubprogram(name: "i", linkageName: "_Z1ii1a", scope: !1, file: !1, line: 18, type: !5, scopeLine: 18, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2, keyInstructions: true)
+  !5 = distinct !DISubroutineType(types: !2)
+  !6 = !DILocalVariable(name: "j", arg: 2, scope: !4, file: !1, line: 18, type: !7)
+  !7 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "a", file: !1, line: 1, size: 32, flags: DIFlagTypePassByValue, elements: !2, identifier: "_ZTS1a")
+  !8 = !DILocation(line: 0, scope: !4)
+...
+---
+name:            _Z1gi
+alignment:       2
+tracksRegLiveness: true
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+hasFakeUses:     false
+tracksDebugUserValues: true
+liveins:
+  - { reg: '$x10' }
+frameInfo:
+  stackSize:       32
+  maxAlignment:    8
+  adjustsStack:    true
+  hasCalls:        true
+  maxCallFrameSize: 0
+  isCalleeSavedInfoValid: true
+  localFrameSize:  1
+stack:
+  - { id: 0, name: agg.tmp.ensured, offset: -25, size: 1, alignment: 1, 
+      local-offset: -1 }
+  - { id: 1, type: spill-slot, offset: -8, size: 8, alignment: 8, callee-saved-register: '$x1_y' }
+  - { id: 2, type: spill-slot, offset: -16, size: 8, alignment: 8, callee-saved-register: '$x8_y' }
+  - { id: 3, type: spill-slot, offset: -24, size: 8, alignment: 8, callee-saved-register: '$x9_y' }
+machineFunctionInfo:
+  varArgsFrameIndex: 0
+  varArgsSaveSize: 0
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x1_y, $x8_y, $x9_y
+  
+    $x2_y = frame-setup CIncOffsetImm $x2_y, -32
+    frame-setup CFI_INSTRUCTION def_cfa_offset 32
+    frame-setup CSC_64 killed $x1_y, $x2_y, 24 :: (store (s64) into %stack.1)
+    frame-setup CSC_64 killed $x8_y, $x2_y, 16 :: (store (s64) into %stack.2)
+    frame-setup CSC_64 killed $x9_y, $x2_y, 8 :: (store (s64) into %stack.3)
+    frame-setup CFI_INSTRUCTION offset $x1, -8
+    frame-setup CFI_INSTRUCTION offset $x8, -16
+    frame-setup CFI_INSTRUCTION offset $x9, -24
+    $x8 = ADDI $x10, 0
+    renamable $x9_y = PseudoCLLCInbounds @bz
+    renamable $x11 = CLW renamable $x9_y, 0 :: (dereferenceable load (s32) from @bz, addrspace 200)
+    renamable $x10_y = CIncOffsetImm $x2_y, 7
+    renamable $x10_y = CSetBoundsImm killed renamable $x10_y, 1
+    PseudoCCALL target-flags(riscv-call) @_ZN1dC1Ei, csr_cheriot, implicit-def dead $x1_y, implicit $x10_y, implicit $x11, implicit-def $x2_y
+    renamable $x10 = CLW killed renamable $x9_y, 0 :: (dereferenceable load (s32) from @bz, addrspace 200)
+    CSW killed renamable $x8, $x0_y, 0 :: (store (s32) into `ptr addrspace(200) null`, addrspace 200)
+    $x1_y = frame-destroy CLC_64 $x2_y, 24 :: (load (s64) from %stack.1)
+    $x8_y = frame-destroy CLC_64 $x2_y, 16 :: (load (s64) from %stack.2)
+    $x9_y = frame-destroy CLC_64 $x2_y, 8 :: (load (s64) from %stack.3)
+    frame-destroy CFI_INSTRUCTION restore $x1
+    frame-destroy CFI_INSTRUCTION restore $x8
+    frame-destroy CFI_INSTRUCTION restore $x9
+    $x2_y = frame-destroy CIncOffsetImm $x2_y, 32
+    frame-destroy CFI_INSTRUCTION def_cfa_offset 0
+    PseudoCRET implicit $x10
+...
+---
+name:            _Z1ii1a
+alignment:       2
+tracksRegLiveness: true
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+hasFakeUses:     false
+tracksDebugUserValues: true
+liveins:
+  - { reg: '$x10' }
+  - { reg: '$x11' }
+frameInfo:
+  stackSize:       32
+  maxAlignment:    8
+  adjustsStack:    true
+  hasCalls:        true
+  maxCallFrameSize: 0
+  isCalleeSavedInfoValid: true
+  localFrameSize:  1
+stack:
+  - { id: 0, name: agg.tmp.ensured, offset: -25, size: 1, alignment: 1, 
+      local-offset: -1 }
+  - { id: 1, type: spill-slot, offset: -8, size: 8, alignment: 8, callee-saved-register: '$x1_y' }
+  - { id: 2, type: spill-slot, offset: -16, size: 8, alignment: 8, callee-saved-register: '$x8_y' }
+  - { id: 3, type: spill-slot, offset: -24, size: 8, alignment: 8, callee-saved-register: '$x9_y' }
+machineFunctionInfo:
+  varArgsFrameIndex: 0
+  varArgsSaveSize: 0
+body:             |
+  bb.0.entry:
+    successors: %bb.2(0x00000000), %bb.1(0x80000000)
+    liveins: $x10, $x11, $x1_y, $x8_y, $x9_y
+  
+    DBG_VALUE $x11, $noreg, !6, !DIExpression(), debug-location !8
+    $x2_y = frame-setup CIncOffsetImm $x2_y, -32
+    frame-setup CFI_INSTRUCTION def_cfa_offset 32
+    frame-setup CSC_64 killed $x1_y, $x2_y, 24 :: (store (s64) into %stack.1)
+    frame-setup CSC_64 killed $x8_y, $x2_y, 16 :: (store (s64) into %stack.2)
+    frame-setup CSC_64 killed $x9_y, $x2_y, 8 :: (store (s64) into %stack.3)
+    frame-setup CFI_INSTRUCTION offset $x1, -8
+    frame-setup CFI_INSTRUCTION offset $x8, -16
+    frame-setup CFI_INSTRUCTION offset $x9, -24
+    $x9 = ADDI $x11, 0
+    DBG_VALUE $x9, $noreg, !6, !DIExpression(), debug-location !8
+    $x8 = ADDI $x10, 0
+    $x10_y = CMove $x0_y
+    PseudoCCALLIndirect killed renamable $x10_y, csr_cheriot, implicit-def dead $x1_y, implicit-def $x2_y
+    BEQ killed renamable $x9, $x0, %bb.2
+  
+  bb.1.if.then:
+    DBG_VALUE $x9, $noreg, !6, !DIExpression(), debug-location !8
+    $x10 = ADDI $x0, 0
+    $x1_y = frame-destroy CLC_64 $x2_y, 24 :: (load (s64) from %stack.1)
+    $x8_y = frame-destroy CLC_64 $x2_y, 16 :: (load (s64) from %stack.2)
+    $x9_y = frame-destroy CLC_64 $x2_y, 8 :: (load (s64) from %stack.3)
+    DBG_VALUE $x11, $noreg, !6, !DIExpression(DW_OP_LLVM_entry_value, 1), debug-location !8
+    frame-destroy CFI_INSTRUCTION restore $x1
+    frame-destroy CFI_INSTRUCTION restore $x8
+    frame-destroy CFI_INSTRUCTION restore $x9
+    $x2_y = frame-destroy CIncOffsetImm $x2_y, 32
+    frame-destroy CFI_INSTRUCTION def_cfa_offset 0
+    PseudoCRET implicit $x10
+  
+  bb.2.if.end:
+    liveins: $x8
+  
+    DBG_VALUE $x9, $noreg, !6, !DIExpression(), debug-location !8
+    renamable $x9_y = PseudoCLLCInbounds @bz
+    DBG_VALUE $x11, $noreg, !6, !DIExpression(DW_OP_LLVM_entry_value, 1), debug-location !8
+    renamable $x11 = CLW renamable $x9_y, 0 :: (dereferenceable load (s32) from @bz, addrspace 200)
+    renamable $x10_y = CIncOffsetImm $x2_y, 7
+    renamable $x10_y = CSetBoundsImm killed renamable $x10_y, 1
+    PseudoCCALL target-flags(riscv-call) @_ZN1dC1Ei, csr_cheriot, implicit-def dead $x1_y, implicit $x10_y, implicit $x11, implicit-def $x2_y
+    renamable $x10 = CLW killed renamable $x9_y, 0 :: (dereferenceable load (s32) from @bz, addrspace 200)
+    $x12_y = CMove $x0_y
+    CSW killed renamable $x10, $x0_y, 0 :: (store (s32) into `ptr addrspace(200) null`, addrspace 200)
+    $x10 = ADDI $x0, 0
+    $x11 = ADDI killed renamable $x8, 0
+    PseudoCCALLIndirect killed renamable $x12_y, csr_cheriot, implicit-def dead $x1_y, implicit $x10, implicit $x11, implicit-def $x2_y
+...


### PR DESCRIPTION
Because DBG_VALUE precedes the actual definition of a physical register, considering
these during the liveness updating phase of MachineOutliner was causing every register
definition to also be marked as a use, which would eventually lead to a verifier error
when a use without a def was detected.
