### PR TITLE
[CHERIoT] Implement a relaxation that transforms COMPARTMENT_CGP_HI accesses into loads through a captable GOT when they would be outside of the 12-bit range.

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -213,6 +213,11 @@ RISCV::RISCV(Ctx &ctx) : TargetInfo(ctx) {
   if (ctx.arg.isCheriAbi)
     gotEntrySize = getCapabilitySize();
 
+  // CHERIoT may use a GOT for CGP-relative relocations that end up out side of
+  // the 12-bit displacement.
+  if (ctx.arg.isCheriot)
+    gotHeaderEntriesNum = 0;
+
   // .got.plt[0] = _dl_runtime_resolve, .got.plt[1] = link_map
   gotPltHeaderEntriesNum = 2;
 
@@ -749,8 +754,11 @@ void RISCV::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
     write32le(loc, insn | (val_high << 20) | (val_low << 7));
     break;
   }
-  case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI:
   case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_HI: {
+    // FIXME: Unrelaxed AUICGP relocation should not occur. This is path
+    // only needed to retain compatibility with object files that predate
+    // COMPARTMENT_CGP_HI relocations, and should be removed in the future.
+
     // AUICGP
     uint32_t opcode = AUICGP;
     uint32_t existingOpcode = read32le(loc) & 0x7f;
@@ -1109,33 +1117,75 @@ static void relaxHi20Lo12(Ctx &ctx, const InputSection &sec, size_t i,
 // Relax auicgp + cincoffset/memop to cincoffset/memop cgp
 static void relaxCGP(Ctx &ctx, const InputSection &sec, size_t i, uint64_t loc,
                      Relocation &r, uint32_t &remove) {
-  if (isPCCRelative(ctx, nullptr, r.sym)) return;
   uint64_t hival =
       getBiasedCGPOffset(ctx, *r.sym) - getBiasedCGPOffsetLo12(ctx, *r.sym);
-  // We can only relax when imm == 0 in auicgp rd, imm.
-  if (hival != 0) return;
+
+  if (hival != 0) {
+    if (!ctx.shouldRelaxAuicgpToCapTable)
+      return;
+    // Once we have concluded that we have no hope of bringing this CGP-relative
+    // access in-range, we instead transform the entire sequence into a load
+    // through the GOT.
+    switch (r.type) {
+    case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI: {
+      // AUICGP rd, sym --> AUIPCC rd, hi(got(sym))
+      sec.relaxAux->relocTypes[i] =
+          INTERNAL_RISCV_CHERIOT1_COMPARTMENT_PCCREL_HI;
+      uint32_t insn = read32le(sec.content().data() + r.offset);
+      uint32_t auipcc = (insn & ~0x7f) | AUIPCC;
+      sec.relaxAux->writes.push_back(auipcc);
+      break;
+    }
+    case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI_NOP: {
+      // NOP -> CLC rd, rd, lo(got(sym))
+      sec.relaxAux->relocTypes[i] =
+          INTERNAL_RISCV_CHERIOT1_COMPARTMENT_PCCREL_LO_I;
+      uint32_t insn = read32le(sec.content().data() + r.offset - 4);
+      uint32_t reg = insn & 0x00000f80;
+      uint32_t clc = CLC_64 | reg | (reg << 8);
+      sec.relaxAux->writes.push_back(clc);
+      break;
+    }
+    case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I:
+    case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S: {
+      // CLW rd, ra, lo(sym+off) -> CLW rd, ra, off
+      sec.relaxAux->relocTypes[i] = R_RISCV_32;
+      uint32_t insn = read32le(sec.content().data() + r.offset);
+      int32_t addend = r.addend;
+      addend <<= 20;
+      insn |= addend;
+      sec.relaxAux->writes.push_back(insn);
+      break;
+    }
+    }
+
+    return;
+  }
+
+  // Relax away the auicgp when imm == 0 in auicgp rd, imm.
   uint32_t insn = read32le(sec.content().data() + r.offset);
   switch (r.type) {
   case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI:
+  case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI_NOP:
   case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_HI: {
-    // Remove auicgp rd, 0.
+    // Remove auicgp rd, 0 and trailing nop4.
     sec.relaxAux->relocTypes[i] = R_RISCV_RELAX;
     remove = 4;
     break;
   }
-    case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I: {
-      // cincoffset/load rd, cs1, %lo(x) => cincoffset/load rd, cgp, %lo(x)
-      sec.relaxAux->relocTypes[i] = INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I;
-      insn = (insn & ~(31 << 15)) | (3 << 15);
-      sec.relaxAux->writes.push_back(insn);
-      break;
-    }
-    case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S:
-      // store cs2, cs1, %lo(x) => store cs2, cgp, %lo(x)
-      sec.relaxAux->relocTypes[i] = INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S;
-      insn = (insn & ~(31 << 15)) | (3 << 15);
-      sec.relaxAux->writes.push_back(insn);
-      break;
+  case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I: {
+    // cincoffset/load rd, cs1, %lo(x) => cincoffset/load rd, cgp, %lo(x)
+    sec.relaxAux->relocTypes[i] = INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I;
+    insn = (insn & ~(31 << 15)) | (3 << 15);
+    sec.relaxAux->writes.push_back(insn);
+    break;
+  }
+  case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S:
+    // store cs2, cs1, %lo(x) => store cs2, cgp, %lo(x)
+    sec.relaxAux->relocTypes[i] = INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S;
+    insn = (insn & ~(31 << 15)) | (3 << 15);
+    sec.relaxAux->writes.push_back(insn);
+    break;
   }
 }
 
@@ -1217,9 +1267,14 @@ static bool relax(Ctx &ctx, int pass, InputSection &sec) {
         relaxCGP(ctx, sec, i, loc, r, remove);
       break;
     case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI_NOP:
-      // Remove the trailing nop.
-      sec.relaxAux->relocTypes[i] = R_RISCV_RELAX;
-      remove = 4;
+      if (isPCCRelative(ctx, nullptr, r.sym)) {
+        // Always remove the trailing nop if this follows an AUIPCC
+        sec.relaxAux->relocTypes[i] = R_RISCV_RELAX;
+        remove = 4;
+        break;
+      }
+
+      relaxCGP(ctx, sec, i, loc, r, remove);
       break;
     }
 
@@ -1273,6 +1328,15 @@ bool RISCV::relaxOnce(int pass) const {
       if (sec->relaxAux)
         changed |= relax(ctx, pass, *sec);
   }
+
+  if (!changed && ctx.arg.isCheriot && !ctx.shouldRelaxAuicgpToCapTable) {
+    // Once relaxation has iterated to a fixed point, toggle the option
+    // to turn out-of-range CGP-relative accesses into captable (GOT)
+    // loads. Then iterate to a fixed point again.
+    ctx.shouldRelaxAuicgpToCapTable = true;
+    changed = true;
+  }
+
   return changed;
 }
 
@@ -1421,7 +1485,7 @@ void RISCV::finalizeRelax(int passes) const {
           continue;
 
         // Copy from last location to the current relocated location.
-        const Relocation &r = rels[i];
+        Relocation &r = rels[i];
         uint64_t size = r.offset - offset;
         memcpy(p, old.data() + offset, size);
         p += size;
@@ -1467,17 +1531,84 @@ void RISCV::finalizeRelax(int passes) const {
             skip = 4;
             write32le(p, aux.writes[writesIdx++]);
             aux.relocTypes[i] = R_RISCV_NONE;
+            if (r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I ||
+                r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S) {
+              aux.relocTypes[i] = R_RISCV_RELAX;
+            }
             break;
           case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_I:
           case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_LO_S:
             skip = 4;
             write32le(p, aux.writes[writesIdx++]);
             break;
-          case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI:
-            // Preserve the auicgp and drop the trailing nop.
-            skip = 4;
-            write32le(p, read32le(old.data() + r.offset));
+          case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_PCCREL_HI:
+            if (r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI) {
+              // In this case, we are mutating a CGP-relative access into a
+              // cap-table access.
+              skip = 4;
+              write32le(p, aux.writes[writesIdx++]);
+
+              for (auto *cmd : sec->getOutputSection()->commands) {
+                auto *isd = dyn_cast<InputSectionDescription>(cmd);
+                if (!isd)
+                  continue;
+                if (std::find(isd->sections.begin(), isd->sections.end(),
+                              sec) == isd->sections.end())
+                  continue;
+
+                // Create a GOT at the end of our OutputSection. The safety of
+                // this depends on the fact that the CHERIoT compartment linkage
+                // model does not permit any relative relocations across
+                // compartment boundaries. Otherwise adding this section could
+                // potentially invalidate earlier relocations.
+                auto *got = dyn_cast<GotSection>(isd->sections.back());
+                if (!got) {
+                  got = make<GotSection>(ctx);
+                  ctx.inputSections.push_back(got);
+                  isd->sections.push_back(got);
+                  sec->getOutputSection()->commitSection(got);
+                }
+
+                uint64_t gotOff = got->addEntry(*r.sym);
+                // FIXME: This is sketchy, but I don't know another solution.
+                got->finalizeContents();
+
+                // Construct the GOT entry for the symbol we need to access.
+                // FIXME: Deduplicate?
+                ctx.mainPart->capRelocs->addReloc(*got, gotOff, *r.sym, 0,
+                                                  R_ABS_CAP,
+                                                  *ctx.target->symbolicCapRel);
+                ctx.mainPart->capRelocs->finalizeContents();
+
+                // Construct an anonymous symbol pointing to the GOT
+                r.sym = addSyntheticLocal(ctx, "", STT_NOTYPE, 0, 0, *got);
+                r.sym->used = true;
+                r.addend = gotOff;
+                r.type = INTERNAL_RISCV_CHERIOT1_COMPARTMENT_PCCREL_HI;
+                r.expr = R_PC;
+
+                break;
+              }
+            }
             break;
+          case INTERNAL_RISCV_CHERIOT1_COMPARTMENT_PCCREL_LO_I: {
+            skip = 4;
+            write32le(p, aux.writes[writesIdx++]);
+
+            assert(r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI_NOP);
+            r.sym = nullptr;
+            // Because we are constructions a compartment_lo relocation where
+            // there wasn't one before, we need to insert an anonymous label for
+            // it to point to as the corresponding compartment_hi. Because we
+            // know that this NOP reloc was inserted following a compartment_hi
+            // one, we can just subtract for to get the right offset.
+            r.sym = addSyntheticLocal(ctx, "", STT_NOTYPE, r.offset - 4 - delta,
+                                      0, *sec);
+            assert(r.sym);
+            r.addend = 0;
+            r.expr = RE_RISCV_PC_INDIRECT;
+            break;
+          }
           default:
             llvm_unreachable("unsupported type");
           }

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -776,6 +776,9 @@ struct Ctx : CommonLinkerContext {
   // Number of Vernaux entries (needed shared object names).
   uint32_t vernauxNum = 0;
 
+  // CHERIoT - Whether we have should relax auicgp to cap table loads.
+  bool shouldRelaxAuicgpToCapTable = false;
+
   // Each symbol assignment and DEFINED(sym) reference is assigned an increasing
   // order. Each DEFINED(sym) evaluation checks whether the reference happens
   // before a possible `sym = expr;`.

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -684,12 +684,13 @@ GotSection::GotSection(Ctx &ctx)
   numEntries = ctx.target->gotHeaderEntriesNum;
 }
 
-void GotSection::addEntry(const Symbol &sym) {
+uint64_t GotSection::addEntry(const Symbol &sym) {
   // TODO: Separate out TLS IE entries for CHERI so we can pack them more
   // efficiently rather than consuming a whole capability-sized slot for an
   // integer.
   assert(sym.auxIdx == ctx.symAux.size() - 1);
   ctx.symAux.back().gotIdx = numEntries++;
+  return (numEntries - 1) * ctx.target->gotEntrySize;
 }
 
 void GotSection::addAuthEntry(const Symbol &sym) {

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -116,7 +116,7 @@ public:
   void writeTo(uint8_t *buf) override;
 
   void addConstant(Ctx &ctx, const Relocation &r) { addReloc(ctx, r); }
-  void addEntry(const Symbol &sym);
+  uint64_t addEntry(const Symbol &sym);
   void addAuthEntry(const Symbol &sym);
   bool addTlsDescEntry(const Symbol &sym);
   void addTlsDescAuthEntry();

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1606,7 +1606,12 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
   llvm::TimeTraceScope timeScope("Finalize address dependent content");
   AArch64Err843419Patcher a64p(ctx);
   ARMErr657417Patcher a32p(ctx);
-  ctx.script->assignAddresses();
+
+  // On Cheriot, we need to delay assigning addresses to linker script
+  // symbols until after relaxation, because we might add new __cap_reloc
+  // entries during the process.
+  if (!ctx.arg.isCheriot || ctx.arg.compartment)
+    ctx.script->assignAddresses();
 
   // .ARM.exidx and SHF_LINK_ORDER do not require precise addresses, but they
   // do require the relative addresses of OutputSections because linker scripts
@@ -1727,6 +1732,10 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
   if (ctx.arg.relocatable)
     for (OutputSection *sec : ctx.outputSections)
       sec->addr = 0;
+
+  // Now that relaxation is complete, assign script address on Cheriot.
+  if (ctx.arg.isCheriot && !ctx.arg.compartment)
+    ctx.script->assignAddresses();
 
   uint64_t imageBase = ctx.script->hasSectionsCommand || ctx.arg.relocatable
                            ? 0

--- a/lld/test/ELF/cheri/riscv/cheriot_compartment_lo_i.s
+++ b/lld/test/ELF/cheri/riscv/cheriot_compartment_lo_i.s
@@ -25,27 +25,29 @@ _start:                              # @_Z5entryv
 
 # CHECK:        00012000 <_start>:
 # CHECK-NEXT:   12000: 00000317      ct.auipcc       t1, 0x0
-# CHECK-NEXT:   12004: 02033303      ct.clc  t1, 0x20(t1)
+# CHECK-NEXT:   12004: 02833303      ct.clc  t1, 0x28(t1)
 
 # CHECK:        00012008 <.MID_BLOCK>:
 # CHECK-NEXT:   12008: 00001317      ct.auipcc       t1, 0x1
 # CHECK-NEXT:   1200c: 7f833303      ct.clc  t1, 0x7f8(t1)
 
-# CHECK: 00012010 <.CGP_BLOCK>:
-# CHECK-NEXT: 12010: ffffe37b      ct.auicgp       t1, 0xffffe
-# CHECK-NEXT: 12014: ffc32083      ct.clw  ra, -0x4(t1)
+# CHECK:        00012010 <.CGP_BLOCK>:
+# CHECK-NEXT:   12010: 00001317      ct.auipcc       t1, 0x1
+# CHECK-NEXT:   12014: 7f833303      ct.clc  t1, 0x7f8(t1)
+# CHECK-NEXT:   12018: 00032083      ct.clw  ra, 0x0(t1)
 
-# CHECK: 00012018 <.CGP_FAR_BLOCK>:
-# CHECK-NEXT: 12018: 0000237b      ct.auicgp       t1, 0x2
-# CHECK-NEXT: 1201c: 00032083      ct.clw  ra, 0x0(t1)
+# CHECK:        0001201c <.CGP_FAR_BLOCK>:
+# CHECK-NEXT:   1201c: 00001317      ct.auipcc       t1, 0x1
+# CHECK-NEXT:   12020: 7f433303      ct.clc  t1, 0x7f4(t1)
+# CHECK-NEXT:   12024: 00032083      ct.clw  ra, 0x0(t1)
 
 	.type	near,@function
 	.align	3
 near:
 	.word 1
 
-# CHECK:      00012020 <near>:
-# CHECK-NEXT: 12020: 01 00 00 00 .word 0x00000001
+# CHECK:      00012028 <near>:
+# CHECK-NEXT: 12028: 01 00 00 00 .word 0x00000001
 
 	.type	mid,@function
 	.align	12

--- a/lld/test/ELF/cheri/riscv/cheriot_compartment_lo_s.s
+++ b/lld/test/ELF/cheri/riscv/cheriot_compartment_lo_s.s
@@ -17,13 +17,15 @@
 	ct.auicgp.relaxable	t1, %cheriot_compartment_cgp_hi(cgp_far_label)
     ct.csw	ra, %cheriot_compartment_lo_s(.CGP_FAR_BLOCK)(t1)
 
-# CHECK: 000110f4 <.CGP_BLOCK>:
-# CHECK-NEXT: 110f4: ffffe37b      ct.auicgp       t1, 0xffffe
-# CHECK-NEXT: 110f8: fe132e23      ct.csw  ra, -0x4(t1)
-
-# CHECK: 000110fc <.CGP_FAR_BLOCK>:
-# CHECK-NEXT: 110fc: 0000237b      ct.auicgp       t1, 0x2
+# CHECK:      000110f8 <.CGP_BLOCK>:
+# CHECK-NEXT: 110f8: 00000317      ct.auipcc t1, 0x0
+# CHECK-NEXT: 110fc: 01833303      ct.clc  t1, 0x18(t1)
 # CHECK-NEXT: 11100: 00132023      ct.csw  ra, 0x0(t1)
+
+# CHECK:      00011104 <.CGP_FAR_BLOCK>:
+# CHECK-NEXT: 11104: 00000317      ct.auipcc t1, 0x0
+# CHECK-NEXT: 11108: 01433303      ct.clc  t1, 0x14(t1)
+# CHECK-NEXT: 1110c: 00132023      ct.csw  ra, 0x0(t1)
 
 .section        .data,"aw",@progbits
 .type   cgp_label,@object


### PR DESCRIPTION
This change allows both to support globals larger than 4KB, and to eliminate the AUICGP instruction, as its only use case was for materializing these out of range offsets.

The general flow adopted here changes relaxation such that:
 - First iterate "normal" relaxation to a fixed point.
 - Once that is achieved, turn remaining COMPARTMENT_CGP_HIs into cap-table loads.
 - Then iterate normal relaxation again to a new fixed point.
