### PR TITLE
[CHERIoT] Substantially refactor and generalize the handling of CHERIoT strict bounds in LoopStrengthResolve.

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -875,8 +875,6 @@ public:
     ConstantMask,
   };
 
-  bool isLegalBaseRegForLSR(const SCEV *, int64_t scale) const;
-
   /// Return true if the target supports masked store.
   LLVM_ABI bool
   isLegalMaskedStore(Type *DataType, Align Alignment, unsigned AddressSpace,

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -308,10 +308,6 @@ public:
     return TTI::AMK_None;
   }
 
-  virtual bool isLegalBaseRegForLSR(const SCEV *S, int64_t scale) const {
-    return true;
-  }
-
   virtual bool isLegalMaskedStore(Type *DataType, Align Alignment,
                                   unsigned AddressSpace,
                                   TTI::MaskKind MaskKind) const {

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -465,11 +465,6 @@ TargetTransformInfo::getPreferredAddressingMode(const Loop *L,
   return TTIImpl->getPreferredAddressingMode(L, SE);
 }
 
-bool TargetTransformInfo::isLegalBaseRegForLSR(const SCEV *S,
-                                               int64_t scale) const {
-  return TTIImpl->isLegalBaseRegForLSR(S, scale);
-}
-
 bool TargetTransformInfo::isLegalMaskedStore(Type *DataType, Align Alignment,
                                              unsigned AddressSpace,
                                              TTI::MaskKind MaskKind) const {

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -3200,65 +3200,6 @@ RISCVTTIImpl::getPreferredAddressingMode(const Loop *L,
   return BasicTTIImplBase::getPreferredAddressingMode(L, SE);
 }
 
-bool RISCVTTIImpl::isLegalBaseRegForLSR(const SCEV *S, int64_t scale) const {
-  if (ST->hasVendorXCheriot()) {
-    if (scale < 0)
-      return false;
-
-    // Disallow any SCEV where the base offset is negative.
-    // This is needed because CHERIoT can't represent pointers before the
-    // beginning of an array.
-    if (const auto *Cst = dyn_cast<SCEVConstant>(S)) {
-      return !Cst->getValue()->isNegative();
-    }
-
-    if (const auto *AddRec = dyn_cast<SCEVAddRecExpr>(S)) {
-      // We know that this iteration is safe if both the base increment and the
-      // step are always in the same direction.
-      auto *StartCst = dyn_cast<SCEVConstant>(AddRec->getStart());
-      auto *StepCst = dyn_cast<SCEVConstant>(AddRec->getOperand(1));
-      if (StartCst && StepCst)
-        return StartCst->getValue()->isNegative() ==
-               StepCst->getValue()->isNegative();
-      return isLegalBaseRegForLSR(AddRec->getStart(), 1);
-    }
-
-    if (const auto *A = dyn_cast<SCEVAddExpr>(S)) {
-      bool AllNonCst = true;
-      for (const auto *Op : A->operands()) {
-        const auto *OpCst = dyn_cast<SCEVConstant>(Op);
-        if (OpCst && OpCst->getValue()->isNegative())
-          return false;
-        else if (!isLegalBaseRegForLSR(Op, 1))
-          return false;
-        AllNonCst &= (OpCst == nullptr);
-      }
-      // noncst + noncst must be treated conservatively, as one of them
-      // could be negative.
-      if (AllNonCst)
-        return false;
-    } else if (const auto *M = dyn_cast<SCEVMulExpr>(S)) {
-      bool AllNonCst = true;
-      for (const auto *Op : M->operands()) {
-        const auto *OpCst = dyn_cast<SCEVConstant>(Op);
-        if (OpCst && OpCst->getValue()->isNegative())
-          return false;
-        else if (!isLegalBaseRegForLSR(Op, 1))
-          return false;
-        AllNonCst &= (OpCst == nullptr);
-      }
-      // noncst + noncst must be treated conservatively, as one of them
-      // could be negative.
-      if (AllNonCst)
-        return false;
-    }
-
-    return true;
-  }
-
-  return BasicTTIImplBase::isLegalBaseRegForLSR(S, scale);
-}
-
 bool RISCVTTIImpl::isLSRCostLess(const TargetTransformInfo::LSRCost &C1,
                                  const TargetTransformInfo::LSRCost &C2) const {
   // RISC-V specific here are "instruction number 1st priority".
@@ -3546,4 +3487,8 @@ RISCVTTIImpl::enableMemCmpExpansion(bool OptSize, bool IsZeroCmp) const {
       Options.LoadSizes.insert(Options.LoadSizes.begin(), Size);
   }
   return Options;
+}
+
+bool RISCVTTIImpl::shouldDropLSRSolutionIfLessProfitable() const {
+  return getST()->hasVendorXCheriot();
 }

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -451,8 +451,6 @@ public:
   TTI::AddressingModeKind
   getPreferredAddressingMode(const Loop *L, ScalarEvolution *SE) const override;
 
-  bool isLegalBaseRegForLSR(const SCEV *S, int64_t scale) const override;
-
   unsigned getRegisterClassForType(bool Vector,
                                    Type *Ty = nullptr) const override {
     if (Vector)
@@ -501,6 +499,8 @@ public:
 
   TTI::MemCmpExpansionOptions
   enableMemCmpExpansion(bool OptSize, bool IsZeroCmp) const override;
+
+  bool shouldDropLSRSolutionIfLessProfitable() const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -1235,7 +1235,7 @@ public:
 
   void RateFormula(const Formula &F, SmallPtrSetImpl<const SCEV *> &Regs,
                    const DenseSet<const SCEV *> &VisitedRegs, const LSRUse &LU,
-                   bool HardwareLoopProfitable,
+                   bool HardwareLoopProfitable, bool IsCheriot,
                    SmallPtrSetImpl<const SCEV *> *LoserRegs = nullptr,
                    bool IsBaseline = false);
 
@@ -1486,10 +1486,71 @@ void Cost::RatePrimaryRegister(const Formula &F, const SCEV *Reg,
   }
 }
 
+static bool IsFormulaMonotonic(const Formula &F, LSRUse::KindType UseKind) {
+  // Because CHERIoT has very tight representable bounds, we have to avoid
+  // ever taking the values out of range and then trying bring them back in.
+  // We achieve that by enforcing that a formula is monotonic, i.e. that
+  // either all of the terms are positive (or zero) or negative (or zero).
+  // What follows is a conservative approximation of that check.
+  bool SignKnown = !F.BaseOffset.isZero();
+  bool IsPositive = F.BaseOffset.isGreaterThanZero();
+
+  if (SignKnown && !F.UnfoldedOffset.isZero())
+    return IsPositive == F.BaseOffset.isGreaterThanZero();
+  if (!SignKnown) {
+    SignKnown = !F.UnfoldedOffset.isZero();
+    IsPositive = F.UnfoldedOffset.isGreaterThanZero();
+  }
+
+  if (F.Scale != 0) {
+    if (SignKnown)
+      return IsPositive == (F.Scale > 0);
+    SignKnown = F.Scale != 0;
+    IsPositive = F.Scale > 0;
+  }
+
+  if (!SignKnown) {
+    SignKnown = true;
+    IsPositive = true;
+  }
+
+  auto HasSignMismatchedAddRec = [&IsPositive](const SCEV *S) {
+    const SCEVAddRecExpr *AddRec = dyn_cast<SCEVAddRecExpr>(S);
+    if (!AddRec)
+      return false;
+    auto *StartCst = dyn_cast<SCEVConstant>(AddRec->getStart());
+    auto *StepCst = dyn_cast<SCEVConstant>(AddRec->getOperand(1));
+    if (StartCst && !StartCst->getAPInt().isZero() &&
+        IsPositive != StartCst->getAPInt().isStrictlyPositive())
+      return true;
+    if (StepCst && IsPositive != StepCst->getAPInt().isStrictlyPositive())
+      return true;
+    if (StartCst && StepCst && !StartCst->getAPInt().isZero())
+      return StartCst->getAPInt().isStrictlyPositive() !=
+             StepCst->getAPInt().isStrictlyPositive();
+    return false;
+  };
+
+  for (const auto &BaseReg : F.BaseRegs) {
+    if (BaseReg == F.ScaledReg)
+      continue;
+    if (SCEVExprContains(BaseReg, HasSignMismatchedAddRec))
+      return false;
+  }
+
+  if (F.ScaledReg) {
+    IsPositive ^= F.Scale < 0;
+    if (SCEVExprContains(F.ScaledReg, HasSignMismatchedAddRec))
+      return false;
+  }
+
+  return true;
+}
+
 void Cost::RateFormula(const Formula &F, SmallPtrSetImpl<const SCEV *> &Regs,
                        const DenseSet<const SCEV *> &VisitedRegs,
                        const LSRUse &LU, bool HardwareLoopProfitable,
-                       SmallPtrSetImpl<const SCEV *> *LoserRegs,
+                       bool IsCheriot, SmallPtrSetImpl<const SCEV *> *LoserRegs,
                        bool IsBaseline) {
   if (isLoser())
     return;
@@ -1498,12 +1559,12 @@ void Cost::RateFormula(const Formula &F, SmallPtrSetImpl<const SCEV *> &Regs,
   unsigned PrevAddRecCost = C.AddRecCost;
   unsigned PrevNumRegs = C.NumRegs;
   unsigned PrevNumBaseAdds = C.NumBaseAdds;
+  if (IsCheriot && !IsBaseline && !IsFormulaMonotonic(F, LU.Kind)) {
+    Lose();
+    return;
+  }
   if (const SCEV *ScaledReg = F.ScaledReg) {
     if (VisitedRegs.count(ScaledReg)) {
-      Lose();
-      return;
-    }
-    if (!IsBaseline && !TTI->isLegalBaseRegForLSR(ScaledReg, F.Scale)) {
       Lose();
       return;
     }
@@ -1513,10 +1574,6 @@ void Cost::RateFormula(const Formula &F, SmallPtrSetImpl<const SCEV *> &Regs,
       return;
   }
   for (const SCEV *BaseReg : F.BaseRegs) {
-    if (!IsBaseline && !TTI->isLegalBaseRegForLSR(BaseReg, 1)) {
-      Lose();
-      return;
-    }
     if (VisitedRegs.count(BaseReg)) {
       Lose();
       return;
@@ -2200,6 +2257,8 @@ class LSRInstance {
   // instructions to form LCSSA for them later.
   SmallSetVector<Instruction *, 4> InsertedNonLCSSAInsts;
 
+  bool IsCheriot = false;
+
   void OptimizeShadowIV();
   bool FindIVUserForCond(Instruction *Cond, IVStrideUse *&CondUse);
   Instruction *OptimizeMax(ICmpInst *Cond, IVStrideUse *&CondUse);
@@ -2299,7 +2358,7 @@ class LSRInstance {
 public:
   LSRInstance(Loop *L, IVUsers &IU, ScalarEvolution &SE, DominatorTree &DT,
               LoopInfo &LI, const TargetTransformInfo &TTI, AssumptionCache &AC,
-              TargetLibraryInfo &TLI, MemorySSAUpdater *MSSAU);
+              TargetLibraryInfo &TLI, MemorySSAUpdater *MSSAU, bool IsCheriot);
 
   bool getChanged() const { return Changed; }
   const SmallVectorImpl<WeakVH> &getScalarEvolutionIVs() const {
@@ -3644,7 +3703,7 @@ void LSRInstance::CollectFixupsAndInitialFormulae() {
       Formula F;
       F.initialMatch(S, L, SE);
       BaselineCost.RateFormula(F, Regs, VisitedRegs, LU, HardwareLoopProfitable,
-                               nullptr, true);
+                               IsCheriot, nullptr, true);
       VisitedLSRUse.insert(LUIdx);
     }
 
@@ -4797,7 +4856,7 @@ void LSRInstance::FilterOutUndesirableDedicatedRegisters() {
       Cost CostF(L, SE, TTI, AMK);
       Regs.clear();
       CostF.RateFormula(F, Regs, VisitedRegs, LU, HardwareLoopProfitable,
-                        &LoserRegs);
+                        IsCheriot, &LoserRegs);
       if (CostF.isLoser()) {
         // During initial formula generation, undesirable formulae are generated
         // by uses within other loops that have some non-trivial address mode or
@@ -4831,7 +4890,7 @@ void LSRInstance::FilterOutUndesirableDedicatedRegisters() {
         Cost CostBest(L, SE, TTI, AMK);
         Regs.clear();
         CostBest.RateFormula(Best, Regs, VisitedRegs, LU,
-                             HardwareLoopProfitable);
+                             HardwareLoopProfitable, IsCheriot);
         if (CostF.isLess(CostBest))
           std::swap(F, Best);
         LLVM_DEBUG(dbgs() << "  Filtering out formula "; F.print(dbgs());
@@ -5090,9 +5149,11 @@ void LSRInstance::NarrowSearchSpaceByFilterFormulaWithSameScaledReg() {
       Cost CostFA(L, SE, TTI, AMK);
       Cost CostFB(L, SE, TTI, AMK);
       Regs.clear();
-      CostFA.RateFormula(FA, Regs, VisitedRegs, LU, HardwareLoopProfitable);
+      CostFA.RateFormula(FA, Regs, VisitedRegs, LU, HardwareLoopProfitable,
+                         IsCheriot);
       Regs.clear();
-      CostFB.RateFormula(FB, Regs, VisitedRegs, LU, HardwareLoopProfitable);
+      CostFB.RateFormula(FB, Regs, VisitedRegs, LU, HardwareLoopProfitable,
+                         IsCheriot);
       return CostFA.isLess(CostFB);
     };
 
@@ -5497,7 +5558,8 @@ void LSRInstance::SolveRecurse(SmallVectorImpl<const Formula *> &Solution,
     // the current best, prune the search at that point.
     NewCost = CurCost;
     NewRegs = CurRegs;
-    NewCost.RateFormula(F, NewRegs, VisitedRegs, LU, HardwareLoopProfitable);
+    NewCost.RateFormula(F, NewRegs, VisitedRegs, LU, HardwareLoopProfitable,
+                        IsCheriot);
     if (NewCost.isLess(SolutionCost)) {
       Workspace.push_back(&F);
       if (Workspace.size() != Uses.size()) {
@@ -6166,12 +6228,14 @@ void LSRInstance::ImplementSolution(
 LSRInstance::LSRInstance(Loop *L, IVUsers &IU, ScalarEvolution &SE,
                          DominatorTree &DT, LoopInfo &LI,
                          const TargetTransformInfo &TTI, AssumptionCache &AC,
-                         TargetLibraryInfo &TLI, MemorySSAUpdater *MSSAU)
+                         TargetLibraryInfo &TLI, MemorySSAUpdater *MSSAU,
+                         bool IsCheriot)
     : IU(IU), SE(SE), DT(DT), LI(LI), AC(AC), TLI(TLI), TTI(TTI), L(L),
       MSSAU(MSSAU), AMK(PreferredAddresingMode.getNumOccurrences() > 0
                             ? PreferredAddresingMode
                             : TTI.getPreferredAddressingMode(L, &SE)),
-      Rewriter(SE, "lsr", false), BaselineCost(L, SE, TTI, AMK) {
+      Rewriter(SE, "lsr", false), BaselineCost(L, SE, TTI, AMK),
+      IsCheriot(IsCheriot) {
   // If LoopSimplify form is not available, stay out of trouble.
   if (!L->isLoopSimplifyForm())
     return;
@@ -7056,9 +7120,12 @@ static bool ReduceLoopStrength(Loop *L, IVUsers &IU, ScalarEvolution &SE,
   if (MSSA)
     MSSAU = std::make_unique<MemorySSAUpdater>(MSSA);
 
+  StringRef ABI = (*L->block_begin())->getModule()->getTargetABIFromMD();
+  bool IsCheriot = (ABI == "cheriot" || ABI == "cheriot-baremetal");
+
   // Run the main LSR transformation.
   const LSRInstance &Reducer =
-      LSRInstance(L, IU, SE, DT, LI, TTI, AC, TLI, MSSAU.get());
+      LSRInstance(L, IU, SE, DT, LI, TTI, AC, TLI, MSSAU.get(), IsCheriot);
   Changed |= Reducer.getChanged();
 
   // Remove any extra phis created by processing inner loops.

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-struct-ret.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-struct-ret.ll
@@ -514,10 +514,10 @@ entry:
 
 for.cond.for.cond.cleanup_crit_edge:              ; preds = %for.body
   ;; CHECK:  auicgp.relaxable	a2, %cheriot_compartment_cgp_hi(dummies)
-  ;; CHECK:  cincoffset	a2, a2, %cheriot_compartment_lo_i(.LBB15_5)
+  ;; CHECK:  cincoffset	a2, a2, %cheriot_compartment_lo_i(.LBB15_6)
   ;; CHECK:  ct.csetbounds	a2, a2, %cheriot_compartment_size(dummies)
 
-  ;; CHECK:  ct.cincoffset	a3, a2, s1
+  ;; CHECK:  ct.cincoffset	s1, a2, s1
   %add.le = add i32 %call1, %0
   %rem.le = urem i32 %add.le, 5
   %add.ptr.le = getelementptr inbounds nuw i32, ptr addrspace(200) @dummies, i32 %rem.le
@@ -548,7 +548,7 @@ for.cond.cleanup:                                 ; preds = %for.cond.for.cond.c
   call void @llvm.lifetime.end.p200(i64 4, ptr addrspace(200) nonnull %_)
   call void @llvm.lifetime.end.p200(i64 8, ptr addrspace(200) nonnull %args) #8
 
-  ;; CHECK:  	ct.cmove	a0, a3
+  ;; CHECK:  	ct.cmove	a0, s1
   %.fca.0.insert = insertvalue %struct.TwoPointers poison, ptr addrspace(200) %x.sroa.0.0.lcssa, 0
   %.fca.1.insert = insertvalue %struct.TwoPointers %.fca.0.insert, ptr addrspace(200) %x.sroa.4.0.lcssa, 1
 
@@ -585,9 +585,8 @@ for.cond.for.cond.cleanup_crit_edge:              ; preds = %for.body
   ;; CHECK:  	auicgp.relaxable	a2, %cheriot_compartment_cgp_hi(dummies)
   ;; CHECK:  	cincoffset	a2, a2, %cheriot_compartment_lo_i(.LBB16_6)
   ;; CHECK:  	ct.csetbounds	a2, a2, %cheriot_compartment_size(dummies)
-  ;; CHECK:  	ct.cincoffset	a0, a2, s1
-  ;; CHECK:  	ct.cincoffset	a1, a2, a1
-  ;; CHECK:  	j	.LBB16_4
+  ;; CHECK:  	ct.cincoffset	s1, a2, s1
+  ;; CHECK:  	ct.cincoffset	a1, a2, a0
   br label %for.cond.cleanup
 
 for.body:                                         ; preds = %entry, %for.body
@@ -612,10 +611,10 @@ for.cond.cleanup:                                 ; preds = %for.cond.for.cond.c
   %.fca.1.0.insert = insertvalue %struct.ParentPtr %.fca.0.insert, ptr addrspace(200) %x.sroa.4.0.lcssa, 1, 0
 
   ;; CHECK: .LBB16_4:                               # %for.cond.cleanup
-  ;; CHECK: 	ct.clc	ra, 56(sp)                    # 8-byte Folded Reload
-  ;; CHECK: 	ct.clc	s0, 48(sp)                    # 8-byte Folded Reload
-  ;; CHECK: 	ct.clc	s1, 40(sp)                    # 8-byte Folded Reload
-  ;; CHECK: 	ct.cincoffset	sp, sp, 64
+  ;; CHECK: 	ct.clc	ra, 40(sp)                    # 8-byte Folded Reload
+  ;; CHECK: 	ct.clc	s0, 32(sp)                    # 8-byte Folded Reload
+  ;; CHECK: 	ct.clc	s1, 24(sp)                    # 8-byte Folded Reload
+  ;; CHECK: 	ct.cincoffset	sp, sp, 48
   ;; CHECK: 	ct.cret
   ret %struct.ParentPtr %.fca.1.0.insert
 

--- a/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr5.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr5.ll
@@ -2,17 +2,114 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
 target triple = "riscv32cheriotv1-unknown-cheriotrtos"
 
-; CHECK-NOT: addi	a0, a0, -1
-; CHECK: addi	a0, a0, 1
-; CHECK-NOT: addi	a0, a0, -1
+; CHECK-NOT: cincoffset	{{.*}}, sp, 16
 
-define fastcc void @test() addrspace(200) {
-entry:
-  br label %for.cond
+%struct.__Sealed_____default_malloc_capability_type = type { i32, i32, %struct.AllocatorCapabilityState }
+%struct.AllocatorCapabilityState = type { i32, i32, [2 x ptr addrspace(200)] }
+%struct.Timeout = type { i32, i32 }
 
-for.cond:                                         ; preds = %for.cond, %entry
-  %storemerge = phi i32 [ 0, %entry ], [ %inc, %for.cond ]
-  %exitcond.not = icmp eq i32 %storemerge, 0
-  %inc = add i32 %storemerge, 1
-  br label %for.cond
+@.str.2 = external hidden unnamed_addr addrspace(200) constant [18 x i8], align 1
+@.str.3 = external hidden unnamed_addr addrspace(200) constant [25 x i8], align 1
+@__default_malloc_capability = external dso_local addrspace(200) global %struct.__Sealed_____default_malloc_capability_type, section ".sealed_objects", align 8 #0
+
+define hidden fastcc void @_ZN12_GLOBAL__N_124test_sub_quota_semanticsEv() unnamed_addr addrspace(200) #1 {
+for.cond5.preheader:
+  %t = alloca %struct.Timeout, align 4, addrspace(200)
+  %quotas = alloca [4 x ptr addrspace(200)], align 8, addrspace(200)
+  call addrspace(200) void @llvm.lifetime.start.p200(ptr addrspace(200) nonnull %t) #6
+  store i32 0, ptr addrspace(200) %t, align 4, !tbaa !10
+  %remaining.i = getelementptr inbounds nuw i8, ptr addrspace(200) %t, i32 4
+  store i32 -1, ptr addrspace(200) %remaining.i, align 4, !tbaa !12
+  call addrspace(200) void @llvm.lifetime.start.p200(ptr addrspace(200) nonnull %quotas) #6
+  store ptr addrspace(200) @__default_malloc_capability, ptr addrspace(200) %quotas, align 8, !tbaa !13
+  %0 = getelementptr inbounds nuw i8, ptr addrspace(200) %quotas, i32 8
+  %call = notail call cheriot_compartmentcallcc addrspace(200) ptr addrspace(200) @_Z15split_sub_quotaP7TimeoutU19__sealed_capabilityP24AllocatorCapabilityStatej(ptr addrspace(200) noundef nonnull %t, ptr addrspace(200) noundef nonnull @__default_malloc_capability, i32 noundef 528) #7
+  store ptr addrspace(200) %call, ptr addrspace(200) %0, align 8, !tbaa !13
+  %1 = getelementptr inbounds nuw i8, ptr addrspace(200) %quotas, i32 16
+  %call.1 = notail call cheriot_compartmentcallcc addrspace(200) ptr addrspace(200) @_Z15split_sub_quotaP7TimeoutU19__sealed_capabilityP24AllocatorCapabilityStatej(ptr addrspace(200) noundef nonnull %t, ptr addrspace(200) noundef %call, i32 noundef 352) #7
+  store ptr addrspace(200) %call.1, ptr addrspace(200) %1, align 8, !tbaa !13
+  %2 = getelementptr inbounds nuw i8, ptr addrspace(200) %quotas, i32 24
+  %call.2 = notail call cheriot_compartmentcallcc addrspace(200) ptr addrspace(200) @_Z15split_sub_quotaP7TimeoutU19__sealed_capabilityP24AllocatorCapabilityStatej(ptr addrspace(200) noundef nonnull %t, ptr addrspace(200) noundef %call.1, i32 noundef 176) #7
+  store ptr addrspace(200) %call.2, ptr addrspace(200) %2, align 8, !tbaa !13
+  br label %for.cond5
+
+for.cond5:                                        ; preds = %for.cond5.preheader, %_ZN12_GLOBAL__N_116ConditionalDebugIXtlNS_26DebugLevelTemplateArgumentEEEXtlNS_12DebugContextILj15EEEtlA15_cLc65ELc108ELc108ELc111ELc99ELc97ELc116ELc111ELc114ELc32ELc116ELc101ELc115ELc116EEEELb1ELb1EE9InvariantIJRjRiEEC2EbPKcS7_S8_NS_14SourceLocationE.exit
+  %storemerge = phi i32 [ %sub15, %_ZN12_GLOBAL__N_116ConditionalDebugIXtlNS_26DebugLevelTemplateArgumentEEEXtlNS_12DebugContextILj15EEEtlA15_cLc65ELc108ELc108ELc111ELc99ELc97ELc116ELc111ELc114ELc32ELc116ELc101ELc115ELc116EEEELb1ELb1EE9InvariantIJRjRiEEC2EbPKcS7_S8_NS_14SourceLocationE.exit ], [ 3, %for.cond5.preheader ]
+  %cmp6.not = icmp eq i32 %storemerge, 0
+  br i1 %cmp6.not, label %for.cond.cleanup7, label %for.body8
+
+for.cond.cleanup7:                                ; preds = %for.cond5
+  call addrspace(200) void @llvm.lifetime.end.p200(ptr addrspace(200) nonnull %quotas) #6
+  call addrspace(200) void @llvm.lifetime.end.p200(ptr addrspace(200) nonnull %t) #6
+  ret void
+
+for.body8:                                        ; preds = %for.cond5
+  %arrayidx9 = getelementptr inbounds nuw ptr addrspace(200), ptr addrspace(200) %quotas, i32 %storemerge
+  %3 = load ptr addrspace(200), ptr addrspace(200) %arrayidx9, align 8, !tbaa !13
+  %arrayidx11 = getelementptr i8, ptr addrspace(200) %arrayidx9, i32 -8
+  %4 = load ptr addrspace(200), ptr addrspace(200) %arrayidx11, align 8, !tbaa !13
+  %call12 = notail call cheriot_compartmentcallcc addrspace(200) i32 @_Z19recombine_sub_quotaU19__sealed_capabilityP24AllocatorCapabilityStateS0_(ptr addrspace(200) noundef %3, ptr addrspace(200) noundef %4) #7
+  %cmp13 = icmp eq i32 %call12, 0
+  br i1 %cmp13, label %_ZN12_GLOBAL__N_116ConditionalDebugIXtlNS_26DebugLevelTemplateArgumentEEEXtlNS_12DebugContextILj15EEEtlA15_cLc65ELc108ELc108ELc111ELc99ELc97ELc116ELc111ELc114ELc32ELc116ELc101ELc115ELc116EEEELb1ELb1EE9InvariantIJRjRiEEC2EbPKcS7_S8_NS_14SourceLocationE.exit, label %if.then.i, !prof !16
+
+if.then.i:                                        ; preds = %for.body8
+  call fastcc addrspace(200) void @_ZN12_GLOBAL__N_116ConditionalDebugIXtlNS_26DebugLevelTemplateArgumentEEEXtlNS_12DebugContextILj15EEEtlA15_cLc65ELc108ELc108ELc111ELc99ELc97ELc116ELc111ELc114ELc32ELc116ELc101ELc115ELc116EEEELb1ELb1EE14report_failureIJjiEEEvPKcS8_S8_iS8_DpT_(ptr addrspace(200) noundef nonnull @.str.2, ptr addrspace(200) noundef nonnull @.str.3, i32 noundef 1509, i32 noundef %storemerge, i32 noundef %call12) #8
+  call addrspace(200) void @llvm.trap()
+  unreachable
+
+_ZN12_GLOBAL__N_116ConditionalDebugIXtlNS_26DebugLevelTemplateArgumentEEEXtlNS_12DebugContextILj15EEEtlA15_cLc65ELc108ELc108ELc111ELc99ELc97ELc116ELc111ELc114ELc32ELc116ELc101ELc115ELc116EEEELb1ELb1EE9InvariantIJRjRiEEC2EbPKcS7_S8_NS_14SourceLocationE.exit: ; preds = %for.body8
+  %sub15 = add nsw i32 %storemerge, -1
+  br label %for.cond5, !llvm.loop !17
 }
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p200(ptr addrspace(200) captures(none)) addrspace(200) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p200(ptr addrspace(200) captures(none)) addrspace(200) #2
+
+; Function Attrs: minsize optsize
+declare dso_local cheriot_compartmentcallcc ptr addrspace(200) @_Z15split_sub_quotaP7TimeoutU19__sealed_capabilityP24AllocatorCapabilityStatej(ptr addrspace(200) noundef, ptr addrspace(200) noundef, i32 noundef) local_unnamed_addr addrspace(200) #3
+
+; Function Attrs: minsize optsize
+declare dso_local cheriot_compartmentcallcc i32 @_Z19recombine_sub_quotaU19__sealed_capabilityP24AllocatorCapabilityStateS0_(ptr addrspace(200) noundef, ptr addrspace(200) noundef) local_unnamed_addr addrspace(200) #3
+
+; Function Attrs: inlinehint minsize mustprogress nounwind optsize
+declare hidden fastcc void @_ZN12_GLOBAL__N_116ConditionalDebugIXtlNS_26DebugLevelTemplateArgumentEEEXtlNS_12DebugContextILj15EEEtlA15_cLc65ELc108ELc108ELc111ELc99ELc97ELc116ELc111ELc114ELc32ELc116ELc101ELc115ELc116EEEELb1ELb1EE14report_failureIJjiEEEvPKcS8_S8_iS8_DpT_(ptr addrspace(200) noundef, ptr addrspace(200) noundef, i32 noundef, i32 noundef, i32 noundef) unnamed_addr addrspace(200) #4 align 2
+
+; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
+declare void @llvm.trap() addrspace(200) #5
+
+attributes #0 = { "cheriot_sealed_value" }
+attributes #1 = { minsize mustprogress noinline nounwind optsize "cheri-compartment"="allocator_test" "no-builtin-longjmp" "no-builtin-printf" "no-builtin-setjmp" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+32bit,+c,+e,+m,+relax,+unaligned-scalar-mem,+xcheri,+xcheriot,+xcheripurecap,+zca,+zmmul,-a,-b,-d,-experimental-p,-experimental-smpmpmt,-experimental-svukte,-experimental-xrivosvisni,-experimental-xrivosvizip,-experimental-xsfmclic,-experimental-xsfsclic,-experimental-zibi,-experimental-zicfilp,-experimental-zicfiss,-experimental-zvbc32e,-experimental-zvfbfa,-experimental-zvfofp8min,-experimental-zvkgs,-experimental-zvqdotq,-f,-h,-i,-q,-sdext,-sdtrig,-sha,-shcounterenw,-shgatpa,-shlcofideleg,-shtvala,-shvsatpa,-shvstvala,-shvstvecd,-smaia,-smcdeleg,-smcntrpmf,-smcsrind,-smctr,-smdbltrp,-smepmp,-smmpm,-smnpm,-smrnmi,-smstateen,-ssaia,-ssccfg,-ssccptr,-sscofpmf,-sscounterenw,-sscsrind,-ssctr,-ssdbltrp,-ssnpm,-sspm,-ssqosid,-ssstateen,-ssstrict,-sstc,-sstvala,-sstvecd,-ssu64xl,-supm,-svade,-svadu,-svbare,-svinval,-svnapot,-svpbmt,-svvptc,-v,-xandesbfhcvt,-xandesperf,-xandesvbfhcvt,-xandesvdot,-xandesvpackfph,-xandesvsinth,-xandesvsintload,-xcheri-norvc,-xcvalu,-xcvbi,-xcvbitmanip,-xcvelw,-xcvmac,-xcvmem,-xcvsimd,-xmipscbop,-xmipscmov,-xmipsexectl,-xmipslsp,-xqccmp,-xqci,-xqcia,-xqciac,-xqcibi,-xqcibm,-xqcicli,-xqcicm,-xqcics,-xqcicsr,-xqciint,-xqciio,-xqcilb,-xqcili,-xqcilia,-xqcilo,-xqcilsm,-xqcisim,-xqcisls,-xqcisync,-xsfcease,-xsfmm128t,-xsfmm16t,-xsfmm32a16f,-xsfmm32a32f,-xsfmm32a8f,-xsfmm32a8i,-xsfmm32t,-xsfmm64a64f,-xsfmm64t,-xsfmmbase,-xsfvcp,-xsfvfbfexp16e,-xsfvfexp16e,-xsfvfexp32e,-xsfvfexpa,-xsfvfexpa64e,-xsfvfnrclipxfqf,-xsfvfwmaccqqq,-xsfvqmaccdod,-xsfvqmaccqoq,-xsifivecdiscarddlone,-xsifivecflushdlone,-xsmtvdot,-xtheadba,-xtheadbb,-xtheadbs,-xtheadcmo,-xtheadcondmov,-xtheadfmemidx,-xtheadmac,-xtheadmemidx,-xtheadmempair,-xtheadsync,-xtheadvdot,-xventanacondops,-xwchc,-za128rs,-za64rs,-zaamo,-zabha,-zacas,-zalasr,-zalrsc,-zama16b,-zawrs,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zcb,-zcd,-zce,-zcf,-zclsd,-zcmop,-zcmp,-zcmt,-zdinx,-zfa,-zfbfmin,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zic64b,-zicbom,-zicbop,-zicboz,-ziccamoa,-ziccamoc,-ziccif,-zicclsm,-ziccrse,-zicntr,-zicond,-zicsr,-zifencei,-zihintntl,-zihintpause,-zihpm,-zilsd,-zimop,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-ztso,-zvbb,-zvbc,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvfbfmin,-zvfbfwma,-zvfh,-zvfhmin,-zvkb,-zvkg,-zvkn,-zvknc,-zvkned,-zvkng,-zvknha,-zvknhb,-zvks,-zvksc,-zvksed,-zvksg,-zvksh,-zvkt,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b" }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { minsize optsize "cheri-compartment"="allocator" "interrupt-state"="enabled" "no-builtin-longjmp" "no-builtin-printf" "no-builtin-setjmp" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+32bit,+c,+e,+m,+relax,+unaligned-scalar-mem,+xcheri,+xcheriot,+xcheripurecap,+zca,+zmmul,-a,-b,-d,-experimental-p,-experimental-smpmpmt,-experimental-svukte,-experimental-xrivosvisni,-experimental-xrivosvizip,-experimental-xsfmclic,-experimental-xsfsclic,-experimental-zibi,-experimental-zicfilp,-experimental-zicfiss,-experimental-zvbc32e,-experimental-zvfbfa,-experimental-zvfofp8min,-experimental-zvkgs,-experimental-zvqdotq,-f,-h,-i,-q,-sdext,-sdtrig,-sha,-shcounterenw,-shgatpa,-shlcofideleg,-shtvala,-shvsatpa,-shvstvala,-shvstvecd,-smaia,-smcdeleg,-smcntrpmf,-smcsrind,-smctr,-smdbltrp,-smepmp,-smmpm,-smnpm,-smrnmi,-smstateen,-ssaia,-ssccfg,-ssccptr,-sscofpmf,-sscounterenw,-sscsrind,-ssctr,-ssdbltrp,-ssnpm,-sspm,-ssqosid,-ssstateen,-ssstrict,-sstc,-sstvala,-sstvecd,-ssu64xl,-supm,-svade,-svadu,-svbare,-svinval,-svnapot,-svpbmt,-svvptc,-v,-xandesbfhcvt,-xandesperf,-xandesvbfhcvt,-xandesvdot,-xandesvpackfph,-xandesvsinth,-xandesvsintload,-xcheri-norvc,-xcvalu,-xcvbi,-xcvbitmanip,-xcvelw,-xcvmac,-xcvmem,-xcvsimd,-xmipscbop,-xmipscmov,-xmipsexectl,-xmipslsp,-xqccmp,-xqci,-xqcia,-xqciac,-xqcibi,-xqcibm,-xqcicli,-xqcicm,-xqcics,-xqcicsr,-xqciint,-xqciio,-xqcilb,-xqcili,-xqcilia,-xqcilo,-xqcilsm,-xqcisim,-xqcisls,-xqcisync,-xsfcease,-xsfmm128t,-xsfmm16t,-xsfmm32a16f,-xsfmm32a32f,-xsfmm32a8f,-xsfmm32a8i,-xsfmm32t,-xsfmm64a64f,-xsfmm64t,-xsfmmbase,-xsfvcp,-xsfvfbfexp16e,-xsfvfexp16e,-xsfvfexp32e,-xsfvfexpa,-xsfvfexpa64e,-xsfvfnrclipxfqf,-xsfvfwmaccqqq,-xsfvqmaccdod,-xsfvqmaccqoq,-xsifivecdiscarddlone,-xsifivecflushdlone,-xsmtvdot,-xtheadba,-xtheadbb,-xtheadbs,-xtheadcmo,-xtheadcondmov,-xtheadfmemidx,-xtheadmac,-xtheadmemidx,-xtheadmempair,-xtheadsync,-xtheadvdot,-xventanacondops,-xwchc,-za128rs,-za64rs,-zaamo,-zabha,-zacas,-zalasr,-zalrsc,-zama16b,-zawrs,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zcb,-zcd,-zce,-zcf,-zclsd,-zcmop,-zcmp,-zcmt,-zdinx,-zfa,-zfbfmin,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zic64b,-zicbom,-zicbop,-zicboz,-ziccamoa,-ziccamoc,-ziccif,-zicclsm,-ziccrse,-zicntr,-zicond,-zicsr,-zifencei,-zihintntl,-zihintpause,-zihpm,-zilsd,-zimop,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-ztso,-zvbb,-zvbc,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvfbfmin,-zvfbfwma,-zvfh,-zvfhmin,-zvkb,-zvkg,-zvkn,-zvknc,-zvkned,-zvkng,-zvknha,-zvknhb,-zvks,-zvksc,-zvksed,-zvksg,-zvksh,-zvkt,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b" }
+attributes #4 = { inlinehint minsize mustprogress nounwind optsize "cheri-compartment"="allocator_test" "no-builtin-longjmp" "no-builtin-printf" "no-builtin-setjmp" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="cheriot" "target-features"="+32bit,+c,+e,+m,+relax,+unaligned-scalar-mem,+xcheri,+xcheriot,+xcheripurecap,+zca,+zmmul,-a,-b,-d,-experimental-p,-experimental-smpmpmt,-experimental-svukte,-experimental-xrivosvisni,-experimental-xrivosvizip,-experimental-xsfmclic,-experimental-xsfsclic,-experimental-zibi,-experimental-zicfilp,-experimental-zicfiss,-experimental-zvbc32e,-experimental-zvfbfa,-experimental-zvfofp8min,-experimental-zvkgs,-experimental-zvqdotq,-f,-h,-i,-q,-sdext,-sdtrig,-sha,-shcounterenw,-shgatpa,-shlcofideleg,-shtvala,-shvsatpa,-shvstvala,-shvstvecd,-smaia,-smcdeleg,-smcntrpmf,-smcsrind,-smctr,-smdbltrp,-smepmp,-smmpm,-smnpm,-smrnmi,-smstateen,-ssaia,-ssccfg,-ssccptr,-sscofpmf,-sscounterenw,-sscsrind,-ssctr,-ssdbltrp,-ssnpm,-sspm,-ssqosid,-ssstateen,-ssstrict,-sstc,-sstvala,-sstvecd,-ssu64xl,-supm,-svade,-svadu,-svbare,-svinval,-svnapot,-svpbmt,-svvptc,-v,-xandesbfhcvt,-xandesperf,-xandesvbfhcvt,-xandesvdot,-xandesvpackfph,-xandesvsinth,-xandesvsintload,-xcheri-norvc,-xcvalu,-xcvbi,-xcvbitmanip,-xcvelw,-xcvmac,-xcvmem,-xcvsimd,-xmipscbop,-xmipscmov,-xmipsexectl,-xmipslsp,-xqccmp,-xqci,-xqcia,-xqciac,-xqcibi,-xqcibm,-xqcicli,-xqcicm,-xqcics,-xqcicsr,-xqciint,-xqciio,-xqcilb,-xqcili,-xqcilia,-xqcilo,-xqcilsm,-xqcisim,-xqcisls,-xqcisync,-xsfcease,-xsfmm128t,-xsfmm16t,-xsfmm32a16f,-xsfmm32a32f,-xsfmm32a8f,-xsfmm32a8i,-xsfmm32t,-xsfmm64a64f,-xsfmm64t,-xsfmmbase,-xsfvcp,-xsfvfbfexp16e,-xsfvfexp16e,-xsfvfexp32e,-xsfvfexpa,-xsfvfexpa64e,-xsfvfnrclipxfqf,-xsfvfwmaccqqq,-xsfvqmaccdod,-xsfvqmaccqoq,-xsifivecdiscarddlone,-xsifivecflushdlone,-xsmtvdot,-xtheadba,-xtheadbb,-xtheadbs,-xtheadcmo,-xtheadcondmov,-xtheadfmemidx,-xtheadmac,-xtheadmemidx,-xtheadmempair,-xtheadsync,-xtheadvdot,-xventanacondops,-xwchc,-za128rs,-za64rs,-zaamo,-zabha,-zacas,-zalasr,-zalrsc,-zama16b,-zawrs,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zcb,-zcd,-zce,-zcf,-zclsd,-zcmop,-zcmp,-zcmt,-zdinx,-zfa,-zfbfmin,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zic64b,-zicbom,-zicbop,-zicboz,-ziccamoa,-ziccamoc,-ziccif,-zicclsm,-ziccrse,-zicntr,-zicond,-zicsr,-zifencei,-zihintntl,-zihintpause,-zihpm,-zilsd,-zimop,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-ztso,-zvbb,-zvbc,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvfbfmin,-zvfbfwma,-zvfh,-zvfhmin,-zvkb,-zvkg,-zvkn,-zvknc,-zvkned,-zvkng,-zvknha,-zvknhb,-zvks,-zvksc,-zvksed,-zvksg,-zvksh,-zvkt,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b" }
+attributes #5 = { cold noreturn nounwind memory(inaccessiblemem: write) }
+attributes #6 = { nounwind }
+attributes #7 = { minsize nounwind optsize "no-builtin-longjmp" "no-builtin-printf" "no-builtin-setjmp" }
+attributes #8 = { minsize optsize "no-builtin-longjmp" "no-builtin-printf" "no-builtin-setjmp" }
+
+!llvm.module.flags = !{!0, !1, !2, !4}
+!llvm.ident = !{!5}
+!llvm.errno.tbaa = !{!6}
+
+!0 = !{i32 1, !"wchar_size", i32 2}
+!1 = !{i32 1, !"target-abi", !"cheriot"}
+!2 = !{i32 6, !"riscv-isa", !3}
+!3 = !{!"rv32e2p0_m2p0_c2p0_zmmul1p0_zca1p0_xcheri0p0_xcheriot1p0_xcheripurecap0p0"}
+!4 = !{i32 8, !"SmallDataLimit", i32 0}
+!5 = !{!"clang version 22.1.4 (git@github.com:resistor/llvm-project-1.git 3d5dcbbd476e1402c109c6ff3b5f481e7ca00297)"}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"int", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C++ TBAA"}
+!10 = !{!11, !7, i64 0}
+!11 = !{!"_ZTS7Timeout", !7, i64 0, !7, i64 4}
+!12 = !{!11, !7, i64 4}
+!13 = !{!14, !14, i64 0}
+!14 = !{!"p1 _ZTS24AllocatorCapabilityState", !15, i64 0}
+!15 = !{!"any pointer", !8, i64 0}
+!16 = !{!"branch_weights", !"expected", i32 2000, i32 1}
+!17 = distinct !{!17, !18}
+!18 = !{!"llvm.loop.mustprogress"}

--- a/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr6.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr6.ll
@@ -1,0 +1,120 @@
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot -mattr=+xcheri,+xcheripurecap -o - %s | FileCheck %s
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32-unknown-cheriotrtos"
+
+; CHECK-LABEL: %bb14
+; CHECK-NOT: cincoffset	{{.*}}, -4
+
+@alloc_9588fd9eb89b71aecf86d2ab3280d014 = external hidden unnamed_addr addrspace(200) constant <{ ptr addrspace(200), [4 x i8], [4 x i8], [8 x i8] }>, align 8
+@alloc_45c28facb1bb8016d3ea9e1d6f907c1e = external hidden unnamed_addr addrspace(200) constant <{ ptr addrspace(200), [4 x i8], [4 x i8], [8 x i8] }>, align 8
+@alloc_a9c4d6ab0ff0d6fb90dda7bf52fd7aca = external hidden unnamed_addr addrspace(200) constant <{ ptr addrspace(200), [4 x i8], [4 x i8], [8 x i8] }>, align 8
+@alloc_6d4cd78cee70c5eec05fa83141d7b53c = external hidden unnamed_addr addrspace(200) constant <{ ptr addrspace(200), [4 x i8], [4 x i8], [8 x i8] }>, align 8
+
+; Function Attrs: minsize noinline nounwind optsize
+define hidden fastcc noundef nonnull align 4 ptr addrspace(200) @_RNvMCs2LzHmOg8pe3_8iter_revNtB2_8Big32x408mul_pow2(ptr addrspace(200) noalias noundef nonnull returned align 4 captures(ret: address, provenance) dereferenceable(164) %self, i32 noundef signext %bits) unnamed_addr addrspace(200) #0 {
+start:
+  %digits11 = lshr i32 %bits, 5
+  %bits1 = and i32 %bits, 31
+  %0 = getelementptr inbounds nuw i8, ptr addrspace(200) %self, i32 160
+  %_6 = load i32, ptr addrspace(200) %0, align 4, !noundef !2
+  %1 = add i32 %_6, %digits11
+  %_7.not = icmp eq i32 %bits1, 0
+  br i1 %_7.not, label %bb16, label %bb1
+
+bb16:                                             ; preds = %bb15, %start
+  %sz.sroa.0.0 = phi i32 [ %sz.sroa.0.1, %bb15 ], [ %1, %start ]
+  store i32 %sz.sroa.0.0, ptr addrspace(200) %0, align 4
+  ret ptr addrspace(200) %self
+
+bb1:                                              ; preds = %start
+  %_11 = add i32 %1, -1
+  %_12 = icmp ult i32 %_11, 40
+  br i1 %_12, label %bb2, label %panic
+
+bb2:                                              ; preds = %bb1
+  %2 = getelementptr inbounds nuw i32, ptr addrspace(200) %self, i32 %_11
+  %_10 = load i32, ptr addrspace(200) %2, align 4, !noundef !2
+  %_13 = sub i32 0, %bits
+  %3 = and i32 %_13, 31
+  %overflow = lshr i32 %_10, %3
+  %_14.not = icmp eq i32 %overflow, 0
+  br i1 %_14.not, label %bb5, label %bb3
+
+panic:                                            ; preds = %bb1
+  tail call addrspace(200) void @_RNvNtCsHqy3LjcUoC_4core9panicking18panic_bounds_check(i32 noundef signext %_11, i32 noundef signext 40, ptr addrspace(200) noalias noundef readonly align 8 captures(address, read_provenance) dereferenceable(24) @alloc_9588fd9eb89b71aecf86d2ab3280d014) #2
+  unreachable
+
+bb5:                                              ; preds = %bb4, %bb2
+  %sz.sroa.0.1 = phi i32 [ %5, %bb4 ], [ %1, %bb2 ]
+  %_19 = add nuw nsw i32 %digits11, 1
+  br label %bb8
+
+bb3:                                              ; preds = %bb2
+  %_15 = icmp samesign ult i32 %1, 40
+  br i1 %_15, label %bb4, label %panic2
+
+bb4:                                              ; preds = %bb3
+  %4 = getelementptr inbounds nuw i32, ptr addrspace(200) %self, i32 %1
+  store i32 %overflow, ptr addrspace(200) %4, align 4
+  %5 = add nuw nsw i32 %1, 1
+  br label %bb5
+
+panic2:                                           ; preds = %bb3
+  tail call addrspace(200) void @_RNvNtCsHqy3LjcUoC_4core9panicking18panic_bounds_check(i32 noundef signext %1, i32 noundef signext 40, ptr addrspace(200) noalias noundef readonly align 8 captures(address, read_provenance) dereferenceable(24) @alloc_45c28facb1bb8016d3ea9e1d6f907c1e) #2
+  unreachable
+
+bb8:                                              ; preds = %bb14, %bb5
+  %_26 = phi i32 [ %_10, %bb5 ], [ %_29, %bb14 ]
+  %iter.sroa.4.0 = phi i32 [ %1, %bb5 ], [ %_0.i1.i.i.i, %bb14 ]
+  %_0.i.i.i.i = icmp samesign ult i32 %_19, %iter.sroa.4.0
+  br i1 %_0.i.i.i.i, label %bb13, label %bb12
+
+bb12:                                             ; preds = %bb8
+  %_32 = icmp ult i32 %bits, 1280
+  br i1 %_32, label %bb15, label %panic3
+
+bb15:                                             ; preds = %bb12
+  %6 = getelementptr inbounds nuw i32, ptr addrspace(200) %self, i32 %digits11
+  %7 = load i32, ptr addrspace(200) %6, align 4, !noundef !2
+  %8 = shl i32 %7, %bits1
+  store i32 %8, ptr addrspace(200) %6, align 4
+  br label %bb16
+
+panic3:                                           ; preds = %bb12
+  tail call addrspace(200) void @_RNvNtCsHqy3LjcUoC_4core9panicking18panic_bounds_check(i32 noundef signext %digits11, i32 noundef signext 40, ptr addrspace(200) noalias noundef readonly align 8 captures(address, read_provenance) dereferenceable(24) @alloc_a9c4d6ab0ff0d6fb90dda7bf52fd7aca) #2
+  unreachable
+
+bb13:                                             ; preds = %bb8
+  %_30 = add nsw i32 %iter.sroa.4.0, -2
+  %_31 = icmp ult i32 %_30, 40
+  br i1 %_31, label %bb14, label %panic5
+
+bb14:                                             ; preds = %bb13
+  %_0.i1.i.i.i = add nsw i32 %iter.sroa.4.0, -1
+  %9 = getelementptr inbounds nuw i32, ptr addrspace(200) %self, i32 %_0.i1.i.i.i
+  %_25 = shl i32 %_26, %bits1
+  %10 = getelementptr inbounds nuw i32, ptr addrspace(200) %self, i32 %_30
+  %_29 = load i32, ptr addrspace(200) %10, align 4, !noundef !2
+  %_28 = lshr i32 %_29, %3
+  %11 = or i32 %_28, %_25
+  store i32 %11, ptr addrspace(200) %9, align 4
+  br label %bb8
+
+panic5:                                           ; preds = %bb13
+  tail call addrspace(200) void @_RNvNtCsHqy3LjcUoC_4core9panicking18panic_bounds_check(i32 noundef signext -1, i32 noundef signext 40, ptr addrspace(200) noalias noundef readonly align 8 captures(address, read_provenance) dereferenceable(24) @alloc_6d4cd78cee70c5eec05fa83141d7b53c) #2
+  unreachable
+}
+
+; Function Attrs: cold minsize noinline noreturn nounwind optsize
+declare dso_local void @_RNvNtCsHqy3LjcUoC_4core9panicking18panic_bounds_check(i32 noundef signext, i32 noundef signext, ptr addrspace(200) noalias noundef readonly align 8 captures(address, read_provenance) dereferenceable(24)) unnamed_addr addrspace(200) #1
+
+attributes #0 = { minsize noinline nounwind optsize "target-cpu"="cheriot" "target-features"="+32bit,+c,+zca,+e,+m,+xcheriot" }
+attributes #1 = { cold minsize noinline noreturn nounwind optsize "target-cpu"="cheriot" "target-features"="+32bit,+c,+zca,+e,+m,+xcheriot" }
+attributes #2 = { noinline noreturn nounwind }
+
+!llvm.ident = !{!0}
+!llvm.module.flags = !{!1}
+
+!0 = !{!"rustc version 1.95.0-dev"}
+!1 = !{i32 1, !"target-abi", !"cheriot"}
+!2 = !{}


### PR DESCRIPTION
This replace the previous ad-hoc logic with a coherent design intent, namely that legal LSR formulae must be monotonic, i.e. all terms in the formula must increment the pointer in the same direction. The code in this PR is a conservative approximation to that requirement.
