### PR TITLE
[CHERI] Remove AsmPrinter-level propagation of ELF alias sizes.

### DIFF
--- a/clang/test/CodeGen/alias.c
+++ b/clang/test/CodeGen/alias.c
@@ -30,20 +30,17 @@ extern const int __mod_usb_device_table __attribute__ ((alias("wacom_usb_ids")))
 // CHECKBASIC-DAG: @__mod_usb_device_table ={{.*}} alias i32, ptr @wacom_usb_ids
 // CHECKASM-DAG: .globl __mod_usb_device_table
 // CHECKASM-DAG: __mod_usb_device_table = wacom_usb_ids
-// CHECKASM-DAG: .size __mod_usb_device_table, 32
 
 extern int g1;
 extern int g1 __attribute((alias("g0")));
 // CHECKBASIC-DAG: @g1 ={{.*}} alias i32, ptr @g0
 // CHECKASM-DAG: .globl g1
 // CHECKASM-DAG: g1 = g0
-// CHECKASM-DAG: .size g1, 4
 
 extern __thread int __libc_errno __attribute__ ((alias ("TL_WITH_ALIAS")));
 // CHECKBASIC-DAG: @__libc_errno ={{.*}} thread_local alias i32, ptr @TL_WITH_ALIAS
 // CHECKASM-DAG: .globl __libc_errno
 // CHECKASM-DAG: __libc_errno = TL_WITH_ALIAS
-// CHECKASM-DAG: .size __libc_errno, 4
 
 void f0(void) { }
 extern void f1(void);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2602,33 +2602,11 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
   // other situations as the alias and aliasee having differing types but same
   // size may be intentional.
   const GlobalObject *BaseObject = GA.getAliaseeObject();
-  const MCExpr *SizeExpr = nullptr;
-  int64_t Offset = 0;
-  const DataLayout &DL = M.getDataLayout();
   if (MAI->hasDotTypeDotSizeDirective() && GA.getValueType()->isSized() &&
       (!BaseObject || BaseObject->hasPrivateLinkage())) {
+    const DataLayout &DL = M.getDataLayout();
     uint64_t Size = DL.getTypeAllocSize(GA.getValueType());
     OutStreamer->emitELFSize(Name, MCConstantExpr::create(Size, OutContext));
-  } else if (GetPointerBaseWithConstantOffset(GA.getAliasee(), Offset, DL,
-                                              false) == BaseObject) {
-    // If the base symbol has a defined ELF size and we are defining a simple
-    // alias (no non-zero GEPs), we also apply that size to the alias symbol.
-    // This is required for architectures that set bounds on globals (e.g.
-    // CHERI) and use the st_size information for those bounds.
-    if (TM.getTargetTriple().isOSBinFormatELF())
-      SizeExpr = static_cast<MCSymbolELF*>(getSymbol(BaseObject))->getSize();
-    if (SizeExpr && Offset != 0) {
-      int64_t AbsSize = 0;
-      if (SizeExpr->evaluateAsAbsolute(AbsSize)) {
-        SizeExpr = MCConstantExpr::create(AbsSize - Offset, OutContext);
-      } else {
-        SizeExpr = MCBinaryExpr::createSub(
-            SizeExpr, MCConstantExpr::create(Offset, OutContext), OutContext);
-      }
-    }
-  }
-  if (SizeExpr) {
-    OutStreamer->emitELFSize(Name, SizeExpr);
   }
 }
 

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -1064,8 +1064,6 @@ void MCAsmStreamer::emitELFSize(MCSymbol *Symbol, const MCExpr *Value) {
   OS << ", ";
   MAI->printExpr(OS, *Value);
   EmitEOL();
-  // Store the size value so that it can be re-used by aliases.
-  static_cast<MCSymbolELF*>(Symbol)->setSize(Value);
 }
 
 void MCAsmStreamer::emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,

--- a/llvm/test/CodeGen/ARM/aliases.ll
+++ b/llvm/test/CodeGen/ARM/aliases.ll
@@ -7,23 +7,18 @@
 
 ; CHECK: .globl	foo1
 ; CHECK-NEXT: foo1 = bar
-; CHECK-NEXT: .size foo1, 4
 
 ; CHECK: .globl	foo2
 ; CHECK-NEXT: foo2 = bar
-; CHECK-NEXT: .size foo2, 4
 
 ; CHECK: .weak	bar_f
 ; CHECK-NEXT: .type bar_f,%function
 ; CHECK-NEXT: bar_f = foo_f
-; CHECK-NEXT: .size bar_f, .Lfunc_end0-foo_f
 
 ; CHECK: bar_i = bar
-; CHECK-NEXT: .size bar_i, 4
 
 ; CHECK: .globl	A
 ; CHECK-NEXT: A = bar
-; CHECK-NEXT: .size A, 4
 
 ; CHECK: .globl elem0
 ; CHECK-NEXT: elem0 = .Lstructvar

--- a/llvm/test/CodeGen/CHERI-Generic/MIPS/function-alias-size.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/MIPS/function-alias-size.ll
@@ -34,7 +34,6 @@ define void @_ZN3fooD2Ev() addrspace(200) nounwind {
 ; ASM-LABEL: .globl _ZN3fooD1Ev
 ; ASM-NEXT: .type _ZN3fooD1Ev,@function
 ; ASM-NEXT: _ZN3fooD1Ev = _ZN3fooD2Ev
-; ASM-NEXT: .size _ZN3fooD1Ev, .Lfunc_end0-_ZN3fooD2Ev
 
 ; But for the aliases using a GEP, we have to subtract the offset:
 ; ASM-LABEL: .globl elem0

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32/function-alias-size.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32/function-alias-size.ll
@@ -33,7 +33,6 @@ define void @_ZN3fooD2Ev() addrspace(200) nounwind {
 ; ASM-LABEL: .globl _ZN3fooD1Ev
 ; ASM-NEXT: .type _ZN3fooD1Ev,@function
 ; ASM-NEXT: _ZN3fooD1Ev = _ZN3fooD2Ev
-; ASM-NEXT: .size _ZN3fooD1Ev, .Lfunc_end0-_ZN3fooD2Ev
 
 ; But for the aliases using a GEP, we have to subtract the offset:
 ; ASM-LABEL: .globl elem0

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64/function-alias-size.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64/function-alias-size.ll
@@ -33,7 +33,6 @@ define void @_ZN3fooD2Ev() addrspace(200) nounwind {
 ; ASM-LABEL: .globl _ZN3fooD1Ev
 ; ASM-NEXT: .type _ZN3fooD1Ev,@function
 ; ASM-NEXT: _ZN3fooD1Ev = _ZN3fooD2Ev
-; ASM-NEXT: .size _ZN3fooD1Ev, .Lfunc_end0-_ZN3fooD2Ev
 
 ; But for the aliases using a GEP, we have to subtract the offset:
 ; ASM-LABEL: .globl elem0

--- a/llvm/test/CodeGen/X86/linux-preemption.ll
+++ b/llvm/test/CodeGen/X86/linux-preemption.ll
@@ -286,24 +286,17 @@ define dso_local ptr @comdat_any_local() comdat {
 
 ; COMMON:      .globl strong_default_alias
 ; COMMON-NEXT: strong_default_alias = aliasee
-; COMMON-NEXT: .size strong_default_alias, 4
 ; COMMON-NEXT: .globl strong_hidden_alias
 ; COMMON-NEXT: .hidden strong_hidden_alias
 ; COMMON-NEXT: strong_hidden_alias = aliasee
-; COMMON-NEXT: .size strong_hidden_alias, 4
 ; COMMON-NEXT: .weak weak_default_alias
 ; COMMON-NEXT: weak_default_alias = aliasee
-; COMMON-NEXT: .size weak_default_alias, 4
 ; COMMON-NEXT: .globl strong_local_alias
 ; COMMON-NEXT: strong_local_alias = aliasee
 ; CHECK-NEXT:  .Lstrong_local_alias$local = aliasee
-; COMMON-NEXT: .size strong_local_alias, 4
 ; COMMON-NEXT: .weak weak_local_alias
 ; COMMON-NEXT: weak_local_alias = aliasee
-; COMMON-NEXT: .size weak_local_alias, 4
 ; COMMON-NEXT: .globl strong_preemptable_alias
 ; COMMON-NEXT: strong_preemptable_alias = aliasee
-; COMMON-NEXT: .size strong_preemptable_alias, 4
 ; COMMON-NEXT: .weak weak_preemptable_alias
 ; COMMON-NEXT: weak_preemptable_alias = aliasee
-; COMMON-NEXT: .size weak_preemptable_alias, 4


### PR DESCRIPTION
Upstream now implements the same feature at the ELFObjectWriter layer, so this divergence is no longer required.
