### PR TITLE
[CHERIoT] Fix type-safety bug in the CHERIoT compartment report writer.

### DIFF
--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -513,7 +513,7 @@ public:
                    uint32_t addralign)
       : InputSection(ctx.internalFile, name, type, flags, addralign,
                      /*entsize=*/0, {}, InputSectionBase::Synthetic),
-        ctx(ctx) {}
+        ctx(ctx), isMerge(false) {}
 
   virtual ~SyntheticSection() = default;
   virtual size_t getSize() const = 0;
@@ -527,6 +527,9 @@ public:
   static bool classof(const SectionBase *sec) {
     return sec->kind() == InputSectionBase::Synthetic;
   }
+
+  LLVM_PREFERRED_TYPE(bool)
+  uint8_t isMerge : 1;
 };
 
 inline bool isStaticRelSecType(uint32_t type) {

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -1110,10 +1110,17 @@ public:
   void addSection(MergeInputSection *ms);
   SmallVector<MergeInputSection *, 0> sections;
 
+  static bool classof(const SectionBase *sec) {
+    const auto *ssec = dyn_cast<SyntheticSection>(sec);
+    return ssec && ssec->isMerge;
+  }
+
 protected:
   MergeSyntheticSection(Ctx &ctx, StringRef name, uint32_t type, uint64_t flags,
                         uint32_t addralign)
-      : SyntheticSection(ctx, name, type, flags, addralign) {}
+      : SyntheticSection(ctx, name, type, flags, addralign) {
+    isMerge = true;
+  }
 };
 
 class MergeTailSection final : public MergeSyntheticSection {


### PR DESCRIPTION
MergeSyntheticSection did not previously implement classof, so the dyn_cast would always succeed for any SyntheticSection. This wasn't an issue in practice until we recently started emitting GotSection, which made these erroneous dyn_cast's now be a type-safety error that eventually led to an invalid pointer dereference and crash.
