### PR TITLE
[CHERIoT] Fix an issue where RISCVCheriCleanup would lose a constant offset into a global.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVCheriCleanup.cpp
+++ b/llvm/lib/Target/RISCV/RISCVCheriCleanup.cpp
@@ -47,7 +47,7 @@ public:
 };
 
 static bool rewriteMemoryReference(MachineOperand &Op,
-                                   const MachineOperand &Src,
+                                   const MachineOperand &Src, size_t Offset,
                                    MachineRegisterInfo &MRI,
                                    const TargetInstrInfo *TII) {
   // Update the opcode to an appropriate CLLC pseudo which will get expanded
@@ -124,8 +124,9 @@ static bool rewriteMemoryReference(MachineOperand &Op,
                   /*isKill=*/false, /*isDead=*/true, /*isUndef=*/false,
                   /*isEarlyClobber=*/true));
   }
-  II.addOperand(MachineOperand::CreateGA(Src.getGlobal(), Src.getOffset(),
-                                         Src.getTargetFlags()));
+
+  II.addOperand(
+      MachineOperand::CreateGA(Src.getGlobal(), Offset, Src.getTargetFlags()));
 
   return true;
 }
@@ -147,6 +148,9 @@ bool RISCVCheriCleanupOpt::runOnMachineFunction(MachineFunction &MF) {
         if (!MI.getOperand(1).isGlobal())
           continue;
         uint32_t SafeSize = 0;
+        // When there is only a single derefence, keep track of its offset for
+        // emitting the optimized sequence.
+        size_t Offset = 0;
         // If this is the definition of a global, then we know the size.  Allow
         // any loads in that size to be safe.
         bool HasCheriotImportAttr = false;
@@ -194,7 +198,7 @@ bool RISCVCheriCleanupOpt::runOnMachineFunction(MachineFunction &MF) {
             OpSize = 16;
             break;
           }
-          size_t Offset = UI.getOperand(2).getImm();
+          Offset = UI.getOperand(2).getImm();
           if (Offset == 0)
             continue;
           if (Offset + OpSize <= SafeSize)
@@ -215,7 +219,7 @@ bool RISCVCheriCleanupOpt::runOnMachineFunction(MachineFunction &MF) {
             // If there is only a single inbounds use, then we can fold the low
             // bits of the address computation into the load/store itself.
             MachineOperand &UOp = *MRI.use_begin(MI.getOperand(0).getReg());
-            if (rewriteMemoryReference(UOp, MI.getOperand(1), MRI, TII))
+            if (rewriteMemoryReference(UOp, MI.getOperand(1), Offset, MRI, TII))
               ToDelete.push_back(&MI);
           }
           Modified = true;

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-global-singleuse-offset.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-global-singleuse-offset.ll
@@ -1,0 +1,14 @@
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-cheriotrtos -target-abi cheriot  %s -mattr=+xcheri,+xcheripurecap,+xcheriot -verify-machineinstrs -o - | FileCheck %s
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32-unknown-cheriotrtos"
+
+@glob = addrspace(200) constant <{ ptr addrspace(200), [4 x i8], [4 x i8] }> <{ ptr addrspace(200) null, [4 x i8] c"\0B\00\00\00", [4 x i8] undef }>
+
+; Verify that the +8 offset to @glob is preserved
+; CHECK-LABEL: test:
+; CHECK: auipcc {{.*}}, %cheriot_compartment_hi(glob+8)
+define ptr addrspace(200) @test() addrspace(200) {
+start:
+  %a = load ptr addrspace(200), ptr addrspace(200) getelementptr inbounds nuw (i8, ptr addrspace(200) @glob, i32 8), align 8
+  ret ptr addrspace(200) %a
+}


### PR DESCRIPTION
During this pass, we were attempting to fuse global access sequences into more efficient inbounds sequences, but in the process we would lose track of any constant offset applied to the global's address prior to dereferencing it.
