### PR TITLE
[CHERIoT] Further tighten monotonicity checking in LSR.

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -1495,16 +1495,17 @@ static bool IsFormulaMonotonic(const Formula &F, LSRUse::KindType UseKind) {
   bool SignKnown = !F.BaseOffset.isZero();
   bool IsPositive = F.BaseOffset.isGreaterThanZero();
 
-  if (SignKnown && !F.UnfoldedOffset.isZero())
-    return IsPositive == F.BaseOffset.isGreaterThanZero();
+  if (SignKnown && !F.UnfoldedOffset.isZero() &&
+      IsPositive != F.BaseOffset.isGreaterThanZero())
+    return false;
   if (!SignKnown) {
     SignKnown = !F.UnfoldedOffset.isZero();
     IsPositive = F.UnfoldedOffset.isGreaterThanZero();
   }
 
-  if (F.Scale != 0) {
-    if (SignKnown)
-      return IsPositive == (F.Scale > 0);
+  if (SignKnown && F.Scale != 0 && IsPositive != (F.Scale > 0))
+    return false;
+  if (!SignKnown) {
     SignKnown = F.Scale != 0;
     IsPositive = F.Scale > 0;
   }
@@ -1513,6 +1514,22 @@ static bool IsFormulaMonotonic(const Formula &F, LSRUse::KindType UseKind) {
     SignKnown = true;
     IsPositive = true;
   }
+
+  // Search SCEV for any expression of the form %val + -C
+  auto HasNegativeBaseOffset = [](const SCEV *S) {
+    const auto *Add = dyn_cast<SCEVAddExpr>(S);
+    if (!Add)
+      return false;
+    auto *LHSCSt = dyn_cast<SCEVConstant>(Add->getOperand(0));
+    auto *RHSUnknown = dyn_cast<SCEVUnknown>(Add->getOperand(1));
+    if (LHSCSt && RHSUnknown && LHSCSt->getAPInt().isNegative())
+      return true;
+    auto *LHSUnknown = dyn_cast<SCEVUnknown>(Add->getOperand(0));
+    auto *RHSCSt = dyn_cast<SCEVConstant>(Add->getOperand(1));
+    if (LHSUnknown && RHSCSt && RHSCSt->getAPInt().isNegative())
+      return true;
+    return false;
+  };
 
   auto HasSignMismatchedAddRec = [&IsPositive](const SCEV *S) {
     const SCEVAddRecExpr *AddRec = dyn_cast<SCEVAddRecExpr>(S);
@@ -1528,18 +1545,41 @@ static bool IsFormulaMonotonic(const Formula &F, LSRUse::KindType UseKind) {
     if (StartCst && StepCst && !StartCst->getAPInt().isZero())
       return StartCst->getAPInt().isStrictlyPositive() !=
              StepCst->getAPInt().isStrictlyPositive();
+    if (const auto *StartAdd = dyn_cast<SCEVAddExpr>(AddRec->getStart())) {
+      // {(-1 + %1),+,1}
+      auto *StartOffCst = dyn_cast<SCEVConstant>(StartAdd->getOperand(0));
+      if (StartOffCst &&
+          IsPositive != StartOffCst->getAPInt().isStrictlyPositive())
+        return true;
+      StartOffCst = dyn_cast<SCEVConstant>(StartAdd->getOperand(1));
+      if (StartOffCst &&
+          IsPositive != StartOffCst->getAPInt().isStrictlyPositive())
+        return true;
+    }
     return false;
   };
 
   for (const auto &BaseReg : F.BaseRegs) {
-    if (BaseReg == F.ScaledReg)
-      continue;
+    // BaseReg has an implicit scale of +1
+    if (!IsPositive)
+      return false;
+    auto *CstReg = dyn_cast<SCEVConstant>(BaseReg);
+    if (CstReg && !CstReg->getAPInt().isZero() &&
+        IsPositive != CstReg->getAPInt().isStrictlyPositive())
+      return false;
+    if (SCEVExprContains(BaseReg, HasNegativeBaseOffset))
+      return false;
     if (SCEVExprContains(BaseReg, HasSignMismatchedAddRec))
       return false;
   }
 
   if (F.ScaledReg) {
     IsPositive ^= F.Scale < 0;
+    auto *CstReg = dyn_cast<SCEVConstant>(F.ScaledReg);
+    if (CstReg && !CstReg->getAPInt().isZero() &&
+        IsPositive != CstReg->getAPInt().isStrictlyPositive())
+      if (SCEVExprContains(F.ScaledReg, HasNegativeBaseOffset))
+        return false;
     if (SCEVExprContains(F.ScaledReg, HasSignMismatchedAddRec))
       return false;
   }

--- a/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr7.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/cheriot-lsr7.ll
@@ -1,0 +1,32 @@
+; RUN: llc --filetype=asm --mcpu=cheriot --mtriple=riscv32-unknown-unknown -target-abi cheriot -mattr=+xcheri,+xcheripurecap -o - %s | FileCheck %s
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32-unknown-cheriotrtos"
+
+; CHECK-NOT: cincoffset   {{.}}, {{.*}}, -1
+define i32 @test_hash() addrspace(200) {
+  %1 = call addrspace(200) ptr addrspace(200) @llvm.cheri.bounded.stack.cap.i32(ptr addrspace(200) null, i32 1)
+  br label %2
+
+2:                                                ; preds = %2, %0
+  %3 = phi ptr addrspace(200) [ %5, %2 ], [ %1, %0 ]
+  %4 = phi i64 [ %8, %2 ], [ 0, %0 ]
+  %5 = getelementptr i8, ptr addrspace(200) %3, i32 1
+  %6 = load i8, ptr addrspace(200) %3, align 1
+  %7 = zext i8 %6 to i64
+  %8 = or i64 1, %7
+  %9 = icmp eq ptr addrspace(200) %3, null
+  br i1 %9, label %10, label %2
+
+10:                                               ; preds = %2
+  store i64 %4, ptr addrspace(200) null, align 8
+  ret i32 0
+}
+
+; Function Attrs: nounwind willreturn memory(none)
+declare ptr addrspace(200) @llvm.cheri.bounded.stack.cap.i32(ptr addrspace(200), i32) addrspace(200) #0
+
+attributes #0 = { nounwind willreturn memory(none) }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 1, !"target-abi", !"cheriot"}


### PR DESCRIPTION
LSR formulae appear not to be canonicalized as well as one might hope, so we need to check several more variations of expressing the save algebraic relationship to make sure we catch them all.
