### PR TITLE
[CHERIoT] Fix issues uncovered when testing the RTOS with the AUICGP linker change.

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -1827,7 +1827,8 @@ void elf::setRISCVTargetInfo(Ctx &ctx) { ctx.target.reset(new RISCV(ctx)); }
 static bool rewriteCheriotLowRelocs(Ctx &ctx, InputSectionBase &sec) {
   bool modified = false;
   for (Relocation &r :sec.relocations ) {
-    if (r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_HI &&
+    if ((r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_HI ||
+         r.type == INTERNAL_RISCV_CHERIOT1_COMPARTMENT_CGP_HI) &&
         isPCCRelative(ctx, nullptr, r.sym)) {
       modified = true;
       r.type = INTERNAL_RISCV_CHERIOT1_COMPARTMENT_PCCREL_HI;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -2128,12 +2128,12 @@ let Predicates = [HasCheriot] in {
 // require up to 8 additional bytes.
 let Predicates = [HasCheri, IsCapMode], isCall = 1, Defs = [X1_Y],
     isCodeGenOnly = 1,
-    Size = 26 in def PseudoCompartmentCall
+    Size = 18 in def PseudoCompartmentCall
     : Pseudo<(outs), (ins cap_call_symbol:$func), []>;
 
 let Predicates = [HasCheri, IsCapMode], isCall = 1, Defs = [X1_Y],
     isCodeGenOnly = 1,
-    Size = 14 in def PseudoLibraryCall
+    Size = 10 in def PseudoLibraryCall
     : Pseudo<(outs), (ins cap_call_symbol:$func), []>;
 
 let Predicates = [HasCheri, IsCapMode, IsPureCapABI] in {


### PR DESCRIPTION
- Restore dropped handling of AUICGP relocations that end up being PCC-relative at link time.
- Restore pseudo-instruction sizes, which were changed in an intermediate version of the patch and that I missed in cleanup.
