### PR TITLE
[CHERI] Prevent InstCombine from commuting sequence of indexing in consecutive GEPs when trying to merge constat indices on CHERI.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2784,8 +2784,12 @@ static Instruction *combineConstantOffsets(GetElementPtrInst &GEP,
   GEPNoWrapFlags NW = GEPNoWrapFlags::all();
   SmallVector<GetElementPtrInst *> Skipped;
   auto *InnerGEP = dyn_cast<GetElementPtrInst>(GEP.getPointerOperand());
+  bool IsCheriCap = IC.getDataLayout().isFatPointer(GEP.getType());
   while (true) {
     if (!InnerGEP)
+      return nullptr;
+
+    if (IsCheriCap && !InnerGEP->isInBounds())
       return nullptr;
 
     NW = NW.intersectForReassociate(InnerGEP->getNoWrapFlags());

--- a/llvm/test/Transforms/InstCombine/CHERI/cheri-ptr-commutative.ll
+++ b/llvm/test/Transforms/InstCombine/CHERI/cheri-ptr-commutative.ll
@@ -1,0 +1,20 @@
+; RUN: opt -S -passes=instcombine %s | FileCheck %s
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
+target triple = "riscv32-unknown-cheriotrtos"
+
+; CHECK-LABEL: define ptr addrspace(200) @test_iterator_chain_nth_back
+; CHECK: getelementptr inbounds i32, {{.*}}, i32 %count.i9.i
+; CHECK-NOT: getelementptr i8, {{.*}}, i32 20
+define ptr addrspace(200) @test_iterator_chain_nth_back(ptr addrspace(200) %xs, i32 %count.i9.i) addrspace(200) {
+start:
+  %_6.i.i3 = getelementptr i32, ptr addrspace(200) %xs, i32 6
+  %_35.i.i = getelementptr inbounds i32, ptr addrspace(200) %_6.i.i3, i32 %count.i9.i
+  %_47.i.i = getelementptr i8, ptr addrspace(200) %_35.i.i, i32 -4
+  ret ptr addrspace(200) %_47.i.i
+}
+
+!llvm.ident = !{!0}
+!llvm.module.flags = !{!1}
+
+!0 = !{!"rustc version 1.95.0-dev"}
+!1 = !{i32 1, !"target-abi", !"cheriot"}


### PR DESCRIPTION
CHERI capability arithmetic is not commutative, due to unrepresentability outside of bounds. The issue here is that InstCombine would try to turn (gep (gep (gep C1) V) C2) into (gep (gep V) C1+C2), which assumes that base+C1+V+C2 can commute to base+V+C1+C2. That won't be the case on CHERI if V has the opposite sign of the constants.

The most straightforward fix here is to only perform this transformation (for CHERI) when the entire sequence of GEPs is know to be inbounds.
