### PR TITLE
[CHERI] Fix an uninitialized local variable that sometimes causes AsmParser errors depending on host architecture, optimization settings, etc.

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -936,7 +936,7 @@ public:
   bool isUImm12() const {
     if (!isImm())
       return false;
-    RISCV::Specifier VK;
+    RISCV::Specifier VK = RISCV::S_None;
     int64_t Imm;
     bool IsValid;
     bool IsConstantImm = evaluateConstantExpr(getExpr(), Imm);


### PR DESCRIPTION
I probably broke this during an upstream merge. Unfortunately obvious tools like sanitizers did not easily catch it. I have audited all the other similar locals in RISCVAsmParser to ensure that there are no other instances of the same issue.
