### PR TITLE
[AST] Preserve PointerInterpretationKind in getCommonNonSugarTypeNode

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -14234,6 +14234,13 @@ static QualType getCommonPointeeType(const ASTContext &Ctx, const T *X,
 }
 
 template <class T>
+static PointerInterpretationKind getCommonPointerInterpretation(const T *X,
+                                                                const T *Y) {
+  assert(X->getPointerInterpretation() == Y->getPointerInterpretation());
+  return X->getPointerInterpretation();
+}
+
+template <class T>
 static auto *getCommonSizeExpr(const ASTContext &Ctx, T *X, T *Y) {
   assert(Ctx.hasSameExpr(X->getSizeExpr(), Y->getSizeExpr()));
   return X->getSizeExpr();
@@ -14439,7 +14446,8 @@ static QualType getCommonNonSugarTypeNode(const ASTContext &Ctx, const Type *X,
   }
   case Type::Pointer: {
     const auto *PX = cast<PointerType>(X), *PY = cast<PointerType>(Y);
-    return Ctx.getPointerType(getCommonPointeeType(Ctx, PX, PY));
+    auto PIK = getCommonPointerInterpretation(PX, PY);
+    return Ctx.getPointerType(getCommonPointeeType(Ctx, PX, PY), PIK);
   }
   case Type::BlockPointer: {
     const auto *PX = cast<BlockPointerType>(X), *PY = cast<BlockPointerType>(Y);
@@ -14463,16 +14471,18 @@ static QualType getCommonNonSugarTypeNode(const ASTContext &Ctx, const Type *X,
   case Type::LValueReference: {
     const auto *PX = cast<LValueReferenceType>(X),
                *PY = cast<LValueReferenceType>(Y);
+    auto PIK = getCommonPointerInterpretation(PX, PY);
     // FIXME: Preserve PointeeTypeAsWritten.
-    return Ctx.getLValueReferenceType(getCommonPointeeType(Ctx, PX, PY),
-                                      PX->isSpelledAsLValue() ||
-                                          PY->isSpelledAsLValue());
+    return Ctx.getLValueReferenceType(
+        getCommonPointeeType(Ctx, PX, PY),
+        PX->isSpelledAsLValue() || PY->isSpelledAsLValue(), PIK);
   }
   case Type::RValueReference: {
     const auto *PX = cast<RValueReferenceType>(X),
                *PY = cast<RValueReferenceType>(Y);
+    auto PIK = getCommonPointerInterpretation(PX, PY);
     // FIXME: Preserve PointeeTypeAsWritten.
-    return Ctx.getRValueReferenceType(getCommonPointeeType(Ctx, PX, PY));
+    return Ctx.getRValueReferenceType(getCommonPointeeType(Ctx, PX, PY), PIK);
   }
   case Type::DependentAddressSpace: {
     const auto *PX = cast<DependentAddressSpaceType>(X),

--- a/clang/test/Sema/cheri/common-type-pik.c
+++ b/clang/test/Sema/cheri/common-type-pik.c
@@ -1,0 +1,23 @@
+// RUN: %cheri_cc1 -fsyntax-only -verify %s
+
+/// Verify that the PointerInterpretationKind is preserved for non-canonical
+/// pointer types in barCommonNonSugarTypeNode. Previousy it would be lost and
+/// hit:
+///
+///   clang::QualType clang::ASTContext::barCommonSugaredType(clang::QualType, clang::QualType, bool): Assertion `Unqualified ? hasSameUnqualifiedType(R, X) : hasSameType(R, X)' failed.
+///
+/// (or just proceed with the non-capability type if assertions were disabled).
+
+struct foo {
+  void *(*bar)(void __attribute__((btf_type_tag("tag"))) * __capability);
+};
+
+void *bar_ptr(void __attribute__((btf_type_tag("tag"))) *);
+void *bar_cap(void __attribute__((btf_type_tag("tag"))) * __capability);
+
+struct foo baz[] = {
+  { 0 ? bar_ptr : bar_ptr }, // expected-error {{incompatible function pointer types initializing 'void *(*)(void  __attribute__((btf_type_tag("tag")))* __capability)' (aka 'void *(*)(void * __capability)') with an expression of type 'void *(*)(void  __attribute__((btf_type_tag("tag")))*)' (aka 'void *(*)(void *)')}}
+  { 0 ? bar_ptr : bar_cap }, // expected-warning {{pointer type mismatch ('void *(*)(void  __attribute__((btf_type_tag("tag")))*)' (aka 'void *(*)(void *)') and 'void *(*)(void  __attribute__((btf_type_tag("tag")))* __capability)' (aka 'void *(*)(void * __capability)'))}}
+  { 0 ? bar_cap : bar_ptr }, // expected-warning {{pointer type mismatch ('void *(*)(void  __attribute__((btf_type_tag("tag")))* __capability)' (aka 'void *(*)(void * __capability)') and 'void *(*)(void  __attribute__((btf_type_tag("tag")))*)' (aka 'void *(*)(void *)'))}}
+  { 0 ? bar_cap : bar_cap },
+};


### PR DESCRIPTION
Although this affects references I'm not sure how to trigger this case
from C++, as btf_type_tag is C-only and none of the other attributes
I've tried end up hitting this.

Fixes: https://github.com/CTSRD-CHERI/llvm-project/issues/816
