### PR TITLE
[CHERIoT] Changed Attributes Permissions default

### DIFF
--- a/clang/test/CodeGen/cheri/riscv/cheriot-cap-import-attr.c
+++ b/clang/test/CodeGen/cheri/riscv/cheriot-cap-import-attr.c
@@ -2,24 +2,17 @@
 
 struct Uart {};
 
-// No specific perm encoding means "RWcmg".
-// CHECK: @uart = external addrspace(200) global %struct.Uart, align 1 #0 
-__attribute__((cheriot_mmio("uart"))) extern volatile struct Uart uart;
-
-// CHECK: @uart_WcmRg = external addrspace(200) global %struct.Uart, align 1 #0 
+// CHECK: @uart_WcmRg = external addrspace(200) global %struct.Uart, align 1 #0
 __attribute__((cheriot_mmio("uart", "WcmRg"))) volatile struct Uart uart_WcmRg;
 
-// CHECK: @uart_cmRWg = external addrspace(200) global %struct.Uart, align 1 #0 
+// CHECK: @uart_cmRWg = external addrspace(200) global %struct.Uart, align 1 #0
 __attribute__((cheriot_mmio("uart", "cmRWg"))) volatile struct Uart uart_cmRWg;
 
-// CHECK: @uart_RmcWg = external addrspace(200) global %struct.Uart, align 1 #0 
+// CHECK: @uart_RmcWg = external addrspace(200) global %struct.Uart, align 1 #0
 __attribute__((cheriot_mmio("uart", "RmcWg"))) volatile struct Uart uart_RmcWg;
 
-// CHECK: @uart_RmcWg2 = external addrspace(200) global %struct.Uart, align 1 #0 
+// CHECK: @uart_RmcWg2 = external addrspace(200) global %struct.Uart, align 1 #0
 __attribute__((cheriot_mmio("uart", "RmcWg"))) volatile struct Uart uart_RmcWg2;
-
-// CHECK: @SO = external addrspace(200) global i32, align 4 #1
-__attribute__((cheriot_shared_object("SO"))) int SO;
 
 // CHECK: @SO_RWcmg = external addrspace(200) global i32, align 4 #1
 __attribute__((cheriot_shared_object("SO", "RWcmg"))) extern int SO_RWcmg;
@@ -151,26 +144,24 @@ __attribute__((cheriot_shared_object("SO", "cgR"))) extern int SO_cgR;
 __attribute__((cheriot_shared_object("SO", "gcR"))) extern int SO_gcR;
 
 // CHECK: @SO_gRc = external addrspace(200) global i32, align 4 #15
-__attribute__((cheriot_shared_object("SO", "gcR"))) extern int SO_gRc;
+__attribute__((cheriot_shared_object("SO", "gRc"))) extern int SO_gRc;
 
 
 struct MMIOWithField { int field; };
 
 // CHECK: @mmio = external addrspace(200) global %struct.MMIOWithField, align 4 #16
-__attribute__((cheriot_mmio("mmio"))) extern volatile struct MMIOWithField mmio;
+__attribute__((cheriot_mmio("mmio", "R"))) extern volatile struct MMIOWithField mmio;
 
 void doSomethingWithUart(volatile struct Uart *uart);
 void doSomethingWithSO(int *SO);
 void doSomethingWithField(int);
 
 void func() {
-  doSomethingWithUart(&uart);
   doSomethingWithUart(&uart_WcmRg);
   doSomethingWithUart(&uart_cmRWg);
   doSomethingWithUart(&uart_RmcWg);
   doSomethingWithUart(&uart_RmcWg2);
 
-  doSomethingWithSO(&SO);
   doSomethingWithSO(&SO_RWcmg);
   doSomethingWithSO(&SO_RWmcg);
   doSomethingWithSO(&SO_RmcWg);
@@ -251,7 +242,7 @@ void func() {
 // CHECK: attributes #13 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,-Wc--" }
 // CHECK: attributes #14 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,RWc--" }
 // CHECK: attributes #15 = { "cheriot_global_cap_import"="cheriot_shared_object,SO,R-c-g" }
-// CHECK: attributes #16 = { "cheriot_global_cap_import"="mem,mmio,RWcmg" }
+// CHECK: attributes #16 = { "cheriot_global_cap_import"="mem,mmio,R----" }
 // CHECK: attributes #17 = { minsize nounwind optsize "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+32bit,+c,+e,+m,+xcheri,+xcheriot,+xcheripurecap,+zca,+zmmul" }
 // CHECK: attributes #18 = { minsize optsize "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+32bit,+c,+e,+m,+xcheri,+xcheriot,+xcheripurecap,+zca,+zmmul" }
 // CHECK: attributes #19 = { minsize nounwind optsize }

--- a/clang/test/Sema/cheri/cheriot-cap-import-attr-ill-formed.c
+++ b/clang/test/Sema/cheri/cheriot-cap-import-attr-ill-formed.c
@@ -1,14 +1,18 @@
 // RUN: %riscv32_cheri_cc1 "-triple" "riscv32cheriot-unknown-unknown" "-target-abi" "cheriot" -verify %s 
 struct Uart {};
 
+
+
+__attribute__((cheriot_mmio("uart"))) extern volatile struct Uart uart_noperm; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: '')}}
+__attribute__((cheriot_mmio("uart", ""))) extern volatile struct Uart uart_empty; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: '')}}
 __attribute__((cheriot_mmio("uart", "xyz"))) extern struct Uart uart; // expected-error{{the permissions in 'cheriot_mmio' contain unknown permission symbols: 'xyz' (value: 'xyz')}} expected-warning{{global variable definition 'uart' has attribute 'cheriot_mmio' but is not qualified as `volatile`}}
 __attribute__((cheriot_mmio("uart", "RR"))) extern volatile struct Uart uart1; // expected-warning{{the permissions in 'cheriot_mmio' contain a duplicate permission symbol: 'R' (value: 'RR')}}
 __attribute__((cheriot_mmio("uart", "m"))) extern volatile struct Uart uart2; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: 'm')}} 
 __attribute__((cheriot_mmio("uart", "g"))) extern volatile struct Uart uart2; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: 'g')}} 
 __attribute__((cheriot_mmio("uart", "Wg"))) extern volatile struct Uart uart2; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: contains load global (g) but does not have both read (R) and cap (c) (value: 'Wg')}}
 __attribute__((cheriot_mmio("uart", "R"))) volatile struct Uart uart3; // no warnings or errors, extern is implied 
-__attribute__((cheriot_mmio("uart"))) volatile struct Uart uart4 = {};  // expected-error{{global variable definition 'uart4' with attribute 'cheriot_mmio' cannot have an initializer}}
-__attribute__((cheriot_mmio("uart"))) volatile struct {int k;} uart5 = {10};  // expected-error{{global variable definition 'uart5' with attribute 'cheriot_mmio' cannot have an initializer}}
+__attribute__((cheriot_mmio("uart", "R"))) volatile struct Uart uart4 = {};  // expected-error{{global variable definition 'uart4' with attribute 'cheriot_mmio' cannot have an initializer}}
+__attribute__((cheriot_mmio("uart", "R"))) volatile struct {int k;} uart5 = {10};  // expected-error{{global variable definition 'uart5' with attribute 'cheriot_mmio' cannot have an initializer}}
 __attribute__((cheriot_mmio("uart", "R"))) extern volatile struct Uart *uart6; /* no warnings or errors*/
 __attribute__((cheriot_shared_object("exampleK", "RR"))) extern int exampleK; // expected-warning{{the permissions in 'cheriot_shared_object' contain a duplicate permission symbol: 'R' (value: 'RR')}}
 __attribute__((cheriot_shared_object("exampleK", "m"))) extern int exampleK; // expected-error{{the permissions in 'cheriot_shared_object' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: 'm')}}

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -1621,13 +1621,7 @@ public:
   }
 
   /// Returns the default permissions.
-  static const std::string defaultPermissions() {
-    return std::string(ReadPermissionSymbol) +
-           std::string(WritePermissionSymbol) +
-           std::string(CapPermissionSymbol) +
-           std::string(LoadMutablePermissionSymbol) +
-           std::string(LoadGlobalPermissionSymbol);
-  }
+  static const std::string defaultPermissions() { return std::string(); }
 
   ImportKind ImportKind;
   StringRef Domain;


### PR DESCRIPTION
`cheriot_mmio` and `cheriot_shared_object` Permissions will now fall-back to none instead of all when an empty string is given. This will also fail the semantic checks and error-out (see the tests).

Tested on the RTOS test suite.

Should fix #349 