### PR TITLE
Rewrite the cheriot_sealed attr to work on vars rather than types

### DIFF
--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -1145,10 +1145,6 @@ public:
   /// Return true if this is a trivially copyable type
   bool isTriviallyCopyConstructibleType(const ASTContext &Context) const;
 
-  /// Return true if this QualType has the attribute signaling that it
-  /// references a sealed type in CHERIoT.
-  bool hasCHERIoTSealedAttr() const;
-
   /// Returns true if it is a class and it might be dynamic.
   bool mayBeDynamicClass() const;
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -471,6 +471,7 @@ def TargetAMDGPU : TargetArch<["amdgcn", "r600"]>;
 def TargetAnyArm : TargetArch<!listconcat(TargetARM.Arches, TargetAArch64.Arches)>;
 def TargetAVR : TargetArch<["avr"]>;
 def TargetBPF : TargetArch<["bpfel", "bpfeb"]>;
+def TargetCHERIoT : TargetSpec { let OSes = ["CheriotRTOS"]; }
 def TargetLoongArch : TargetArch<["loongarch32", "loongarch64"]>;
 def TargetMips32 : TargetArch<["mips", "mipsel"]>;
 def TargetAnyMips : TargetArch<["mips", "mipsel", "mips64", "mips64el"]>;
@@ -3095,12 +3096,18 @@ def CHERIoTSharedObject : DeclOrTypeAttr {
   let Subjects = SubjectList<[GlobalVar], ErrorDiag>;
 }
 
-def CHERIoTSealedType : TypeAttr {
+def CHERIoTSealedObject : InheritableAttr, TargetSpecificAttr<TargetCHERIoT> {
   let Spellings = [C23<"cheriot", "sealed">, CXX11<"cheriot", "sealed">,
                    GNU<"cheriot_sealed">];
+  let Subjects = SubjectList<[GlobalVar], ErrorDiag>;
   let Documentation = [CHERIoTSealedTypeDocs];
   let Args = [StringArgument<"CompartmentName">,
               StringArgument<"SealingTypeName">];
+
+  let AdditionalMembers = [{
+public:
+  std::string getSealingKeyName() { return ("sealing_type." + getCompartmentName() + "." + getSealingTypeName()).str(); }
+  }];
 }
 
 def CHERINoSubobjectBounds : DeclOrTypeAttr {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15729,6 +15729,16 @@ public:
 
   void performFunctionEffectAnalysis(TranslationUnitDecl *TU);
 
+  /* CHERIoT-specific helpers. */
+public:
+  /// Check if the given statement contains any "unguarded" use of sealed
+  /// variables in the given expression.
+  ///
+  /// Unguarded, in this context, means used in an expression without being part
+  /// of an unary expression to get its address. This function will also report
+  /// the errors.
+  bool CheckUnguardedCHERIoTSealedVarUse(const Expr *S);
+
   ///@}
 };
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -129,29 +129,6 @@ const IdentifierInfo *QualType::getBaseTypeIdentifier() const {
   return nullptr;
 }
 
-bool QualType::hasCHERIoTSealedAttr() const {
-  if (isNull()) {
-    return false;
-  }
-
-  const auto *T = getTypePtr();
-
-  if (!T) {
-    return false;
-  }
-
-  if (T->hasAttr(attr::Kind::CHERIoTSealedType)) {
-    return true;
-  }
-
-  if (const auto *TT = T->getAs<TagType>()) {
-    auto *Decl = TT->getDecl();
-    return Decl && Decl->hasAttr<CHERIoTSealedTypeAttr>();
-  }
-
-  return false;
-}
-
 bool QualType::mayBeDynamicClass() const {
   const auto *ClassDecl = getTypePtr()->getPointeeCXXRecordDecl();
   return ClassDecl && ClassDecl->mayBeDynamicClass();

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2122,9 +2122,6 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case attr::CHERIoTSharedObject:
     OS << "cheriot_shared_object";
     break;
-  case attr::CHERIoTSealedType:
-    OS << "cheriot_sealed";
-    break;
   case attr::FastCall: OS << "fastcall"; break;
   case attr::StdCall: OS << "stdcall"; break;
   case attr::ThisCall: OS << "thiscall"; break;

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5602,6 +5602,13 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName, llvm::Type *Ty,
 
   auto DAddrSpace = GetGlobalVarAddressSpace(D);
 
+  // CHERIoT-specific: if the global variable has the cheriot_sealed attribute
+  // and is not a definition, its type should have the shape of a sealed
+  // value.
+  if (D && D->hasAttr<CHERIoTSealedObjectAttr>() && !D->hasDefinition()) {
+    Ty = getCHERIoTSealedStructType(D->getType());
+  }
+
   auto *GV = new llvm::GlobalVariable(
       getModule(), Ty, false, llvm::GlobalValue::ExternalLinkage, nullptr,
       MangledName, nullptr, llvm::GlobalVariable::NotThreadLocal,
@@ -5717,6 +5724,11 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName, llvm::Type *Ty,
       }
     }
   }
+
+  // CHERIoT-specific check: if the original declaration has the cheriot_sealed
+  // attribute, we keep it when generating the global variable in LLVM.
+  if (D && D->hasAttr<CHERIoTSealedObjectAttr>())
+    GV->addAttribute(llvm::CHERIoTSealedValueAttr::getAttrName());
 
   if (D &&
       D->isThisDeclarationADefinition(Context) == VarDecl::DeclarationOnly) {
@@ -6200,47 +6212,34 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
   }
 
   llvm::Type* InitType = Init->getType();
-  if (ASTTy.hasCHERIoTSealedAttr()) {
+  if (D && D->hasAttr<CHERIoTSealedObjectAttr>()) {
     // In this case, the global variable refers to a to-be-sealed value of type
-    // <T>. We need to:
-    // 1. Get (or create) the type of the sealed pointer, which has a fixed
-    // shape: `__Sealed_<T> {uint32_t sealing_key_ptr; uint32_t padding; <T>
-    // body}`;
-    // 2. Change the type of the global variable to `__Sealed_<T>`;
-    // 3. Create the initializer for the global variable.
+    // <T>.
+    //  We need to:
+    // * Get (or create) the type of the sealed pointer;
+    // * Change the type of the global variable to `__Sealed_<T>`;
+    // * Create the initializer for the global variable.
 
     auto *Module = &getModule();
     auto *Ctxt = &getLLVMContext();
     auto *Int32Ty = llvm::Type::getInt32Ty(*Ctxt);
-    CHERIoTSealedTypeAttr *Attr = nullptr;
-    std::string TypeName;
+    CHERIoTSealedObjectAttr *Attr = D->getAttr<CHERIoTSealedObjectAttr>();
+    llvm::StructType *SealedStructType = getCHERIoTSealedStructType(ASTTy);
 
-    if (auto *TT = ASTTy->getAsTagDecl();
-        TT && TT->hasAttr<CHERIoTSealedTypeAttr>()) {
-      Attr = TT->getAttr<CHERIoTSealedTypeAttr>();
-      TypeName = TT->getNameAsString();
-    }
+    // Get the global with the new type.
+    llvm::Constant *Entry =
+        GetAddrOfGlobalVar(D, SealedStructType, ForDefinition_t(!IsTentative));
+    auto *GV = dyn_cast<llvm::GlobalVariable>(Entry);
+    GV->addAttribute(llvm::CHERIoTSealedValueAttr::getAttrName());
+    GV->setSection(".sealed_objects");
+    GV->setDSOLocal(true);
+    GV->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
+    GV->setAlignment(getContext().getDeclAlign(D).getAsAlign());
 
-    if (const auto *TT = ASTTy->getAs<TypedefType>();
-        TT && TT->getDecl() &&
-        TT->getDecl()->hasAttr<CHERIoTSealedTypeAttr>()) {
-      auto *TD = TT->getDecl();
-      Attr = TD->getAttr<CHERIoTSealedTypeAttr>();
-      TypeName = TD->getNameAsString();
-    }
-
-    llvm::Comdat *C = Module->getOrInsertComdat(D->getName());
-    C->setSelectionKind(llvm::Comdat::Any);
-
-    llvm::Type *SealedStructElements[] = {Int32Ty, Int32Ty, Init->getType()};
-    auto *SealedStructType = llvm::StructType::create(
-        *Ctxt, SealedStructElements, ("struct.__Sealed_" + TypeName));
-
-    auto SealingKeyName =
-        ("__export.sealing_type." + Attr->getCompartmentName() + "." +
-         Attr->getSealingTypeName())
-            .str();
-
+    // This sealed value depends on a sealing key with a specific name and shape
+    // that will be generated later. We use the shape of this sealing key to
+    // generate, now, the type of the sealed value.
+    auto SealingKeyName = ("__export." + Attr->getSealingKeyName());
     auto *SealingKeyRef = Module->getGlobalVariable(SealingKeyName);
 
     if (!SealingKeyRef) {
@@ -6253,25 +6252,17 @@ void CodeGenModule::EmitGlobalVarDefinition(const VarDecl *D,
       assert(SealingKeyRef && "is supposed to exist now!");
     }
 
-    auto *CastedPointer =
-        llvm::ConstantExpr::getPointerCast(SealingKeyRef, Int32Ty);
-
-    llvm::Constant *Values[] = {CastedPointer,
-                                llvm::ConstantInt::get(Int32Ty, 0), Init};
-
     // Create the initializer.
+    llvm::Constant *Values[] = {
+        llvm::ConstantExpr::getPointerCast(SealingKeyRef, Int32Ty),
+        llvm::ConstantInt::get(Int32Ty, 0), Init};
     auto *Init = llvm::ConstantStruct::get(SealedStructType, Values);
 
-    llvm::Constant *Entry =
-        GetAddrOfGlobalVar(D, Init->getType(), ForDefinition_t(!IsTentative));
-    auto *GV = dyn_cast<llvm::GlobalVariable>(Entry);
-    GV->setSection(".sealed_objects");
-    GV->setDSOLocal(true);
-    GV->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
-    GV->setAlignment(getContext().getDeclAlign(D).getAsAlign());
+    llvm::Comdat *C = Module->getOrInsertComdat(D->getName());
+    C->setSelectionKind(llvm::Comdat::Any);
+
     GV->setComdat(C);
     GV->setInitializer(Init);
-    GV->addAttribute(llvm::CHERIoTSealedValueAttr::getAttrName());
 
     addCompilerUsedGlobal(GV);
 

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -2105,6 +2105,35 @@ private:
 
   llvm::Metadata *CreateMetadataIdentifierImpl(QualType T, MetadataTypeMap &Map,
                                                StringRef Suffix);
+
+  /* CHERIoT-specific helpers */
+
+  /// Create an instance of the struct type that sealed values actually have,
+  /// which is of a fixed shape, parametric in the underlying type.
+  /// The shape of the type is the following:
+  /// ```
+  /// __Sealed_<T> {
+  ///    uint32_t sealing_key_ptr;
+  ///    uint32_t padding;
+  ///    <T> body;
+  /// }
+  /// ```
+  llvm::StructType *getCHERIoTSealedStructType(QualType BaseType) {
+    llvm::Module &Mod = getModule();
+    llvm::Type *Int32Ty = llvm::Type::getInt32Ty(Mod.getContext());
+    llvm::Type *LLVMBaseType = getTypes().ConvertType(BaseType);
+
+    std::string TypeName = BaseType.getCanonicalType().getAsString();
+
+    std::replace(TypeName.begin(), TypeName.end(), ':', '_');
+    std::replace(TypeName.begin(), TypeName.end(), ' ', '_');
+    std::replace(TypeName.begin(), TypeName.end(), '<', '_');
+    std::replace(TypeName.begin(), TypeName.end(), '>', '_');
+
+    llvm::Type *SealedStructElements[] = {Int32Ty, Int32Ty, LLVMBaseType};
+    return llvm::StructType::create(Mod.getContext(), SealedStructElements,
+                                    ("struct.__Sealed_" + TypeName));
+  }
 };
 
 }  // end namespace CodeGen

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2435,11 +2435,12 @@ static void handleCHERIoTSharedObject(Sema &S, Decl *D, const ParsedAttr &Attr,
       S.Context, Attr, ObjectName, OwnedPermissions));
 }
 
-static void handleCHERIoTSealedType(Sema &S, Decl *D, const ParsedAttr &Attr,
-                                    Sema::DeclAttributeLocation DAL) {
+static void handleCHERIoTSealedObject(Sema &S, Decl *D, const ParsedAttr &Attr,
+                                      Sema::DeclAttributeLocation DAL) {
 
-  auto *TDecl = dyn_cast<TypeDecl>(D);
-  if (TDecl) {
+  auto *VDecl = dyn_cast<VarDecl>(D);
+
+  if (VDecl && VDecl->hasGlobalStorage() && VDecl->isFileVarDecl()) {
     StringRef CompartmentName;
     SourceLocation CompartmentNameLiteralLoc;
     if (!S.checkStringLiteralArgumentAttr(Attr, 0, CompartmentName,
@@ -2453,10 +2454,13 @@ static void handleCHERIoTSealedType(Sema &S, Decl *D, const ParsedAttr &Attr,
       return;
 
     // Here we simply copy the attribute.
-    TDecl->addAttr(::new (S.Context) CHERIoTSealedTypeAttr(
+    D->addAttr(::new (S.Context) CHERIoTSealedObjectAttr(
         S.Context, Attr, CompartmentName, SealingTypeName));
-  } else // Ignore if it's not a type definition.
-    S.Diag(Attr.getLoc(), diag::warn_attribute_ignored) << Attr.getAttrName();
+    return;
+  }
+
+  // Ignore if it's not a global variable definition.
+  S.Diag(Attr.getLoc(), diag::warn_attribute_ignored) << Attr.getAttrName();
 }
 
 static void handleCHERICompartmentName(Sema &S, Decl *D, const ParsedAttr &Attr,
@@ -8107,8 +8111,8 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   case ParsedAttr::AT_CHERIoTSharedObject:
     handleCHERIoTSharedObject(S, D, AL, DAL);
     break;
-  case ParsedAttr::AT_CHERIoTSealedType:
-    handleCHERIoTSealedType(S, D, AL, DAL);
+  case ParsedAttr::AT_CHERIoTSealedObject:
+    handleCHERIoTSealedObject(S, D, AL, DAL);
     break;
   case ParsedAttr::AT_InterruptState:
     handleInterruptState(S, D, AL);

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -16265,6 +16265,18 @@ ExprResult Sema::BuildCXXConstructExpr(
     bool HadMultipleCandidates, bool IsListInitialization,
     bool IsStdInitListInitialization, bool RequiresZeroInit,
     CXXConstructionKind ConstructKind, SourceRange ParenRange) {
+  // CHERIoT-specific check: in some cases the default constructor implicitly
+  // takes a reference to a sealed value to copy the underlying memory: this is
+  // unallowed, because the data contained in a sealed value cannot be observed
+  // without unsealing the pointer.
+  if (!isUnevaluatedContext() &&
+      Context.getTargetInfo().getABI() == "cheriot" &&
+      (FoundDecl && FoundDecl->isImplicit())) {
+    for (Expr *E : ExprArgs)
+      if (CheckUnguardedCHERIoTSealedVarUse(E))
+        return ExprError();
+  }
+
   bool Elidable = false;
 
   // C++0x [class.copy]p34:

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -32,6 +32,9 @@
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/AttrKinds.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/PartialDiagnostic.h"
@@ -683,6 +686,11 @@ static void DiagnoseDirectIsaAccess(Sema &S, const ObjCIvarRefExpr *OIRE,
 }
 
 ExprResult Sema::DefaultLvalueConversion(Expr *E) {
+  // CHERIoT-specific check: use of unguarded sealed variables is not allowed.
+  if (!isUnevaluatedContext() && Context.getTargetInfo().getABI() == "cheriot")
+    if (CheckUnguardedCHERIoTSealedVarUse(E))
+      return ExprError();
+
   if (E->getType().getQualifiers().hasOutput()) {
     return ExprError(Diag(E->getExprLoc(), diag::err_typecheck_read_output)
       << E->getSourceRange());
@@ -702,12 +710,6 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
 
   QualType T = E->getType();
   assert(!T.isNull() && "r-value conversion on typeless expression?");
-
-  // CHERIoT-specific check.
-  if (T.hasCHERIoTSealedAttr() && !isUnevaluatedContext()) {
-    return ExprError(
-        Diag(E->getExprLoc(), diag::err_cheriot_non_addr_of_expr_on_sealed));
-  }
 
   // lvalue-to-rvalue conversion cannot be applied to types that decay to
   // pointers (i.e. function or array types).
@@ -5003,12 +5005,6 @@ ExprResult Sema::ActOnArraySubscriptExpr(Scope *S, Expr *base,
                                          SourceLocation lbLoc,
                                          MultiExprArg ArgExprs,
                                          SourceLocation rbLoc) {
-
-  // CHERIoT-specific check.
-  if (base->getType().hasCHERIoTSealedAttr() && !isUnevaluatedContext()) {
-    return ExprError(Diag(lbLoc, diag::err_cheriot_non_addr_of_expr_on_sealed));
-  }
-
   if (base && !base->getType().isNull() &&
       base->hasPlaceholderType(BuiltinType::ArraySection)) {
     auto *AS = cast<ArraySectionExpr>(base);
@@ -8812,22 +8808,6 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
                                         ExprResult &RHS, ExprValueKind &VK,
                                         ExprObjectKind &OK,
                                         SourceLocation QuestionLoc) {
-
-  // CHERIoT-specific check.
-  if (!isUnevaluatedContext()) {
-    if (LHS.get()->getType().hasCHERIoTSealedAttr()) {
-      Diag(LHS.get()->getExprLoc(),
-           diag::err_cheriot_non_addr_of_expr_on_sealed);
-      return QualType();
-    }
-
-    if (RHS.get()->getType().hasCHERIoTSealedAttr()) {
-      Diag(RHS.get()->getExprLoc(),
-           diag::err_cheriot_non_addr_of_expr_on_sealed);
-      return QualType();
-    }
-  }
-
   ExprResult LHSResult = CheckPlaceholderExpr(LHS.get());
   if (!LHSResult.isUsable()) return QualType();
   LHS = LHSResult;
@@ -14534,6 +14514,12 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
                                        SourceLocation Loc,
                                        QualType CompoundType,
                                        BinaryOperatorKind Opc) {
+  // CHERIoT-specific check: use of unguarded sealed variables is not allowed.
+  if (!isUnevaluatedContext() && Context.getTargetInfo().getABI() == "cheriot")
+    if (CheckUnguardedCHERIoTSealedVarUse(LHSExpr) ||
+        CheckUnguardedCHERIoTSealedVarUse(RHS.get()))
+      return QualType();
+
   assert(!LHSExpr->hasPlaceholderType(BuiltinType::PseudoObject));
 
   // Verify that LHS is a modifiable lvalue, and emit error if not.
@@ -15243,7 +15229,7 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
   CheckAddressOfPackedMember(op);
 
   PointerInterpretationKind PIK = PointerInterpretationForBaseExpr(op);
-  if (op->getType().hasCHERIoTSealedAttr()) {
+  if (dcl && dcl->getAttr<CHERIoTSealedObjectAttr>()) {
     PIK = PIK_SealedCapability;
   }
   return Context.getPointerType(op->getType(), PIK);
@@ -16113,19 +16099,6 @@ ExprResult Sema::BuildBinOp(Scope *S, SourceLocation OpLoc,
   if (!LHSExpr || !RHSExpr)
     return ExprError();
 
-  // CHERIoT-specific check.
-  if (!isUnevaluatedContext()) {
-    if (LHSExpr->getType().hasCHERIoTSealedAttr()) {
-      return ExprError(Diag(LHSExpr->getExprLoc(),
-                            diag::err_cheriot_non_addr_of_expr_on_sealed));
-    }
-
-    if (RHSExpr->getType().hasCHERIoTSealedAttr()) {
-      return ExprError(Diag(RHSExpr->getExprLoc(),
-                            diag::err_cheriot_non_addr_of_expr_on_sealed));
-    }
-  }
-
   // We want to end up calling one of SemaPseudoObject::checkAssignment
   // (if the LHS is a pseudo-object), BuildOverloadedBinOp (if
   // both expressions are overloadable or either is type-dependent),
@@ -16585,12 +16558,6 @@ bool Sema::isQualifiedMemberAccess(Expr *E) {
 ExprResult Sema::BuildUnaryOp(Scope *S, SourceLocation OpLoc,
                               UnaryOperatorKind Opc, Expr *Input,
                               bool IsAfterAmp) {
-  // CHERIoT-specific check.
-  if (Input->getType().hasCHERIoTSealedAttr() && (Opc != UO_AddrOf) &&
-      !isUnevaluatedContext()) {
-    return ExprError(Diag(OpLoc, diag::err_cheriot_non_addr_of_expr_on_sealed));
-  }
-
   // First things first: handle placeholders so that the
   // overloaded-operator check considers the right type.
   if (const BuiltinType *pty = Input->getType()->getAsPlaceholderType()) {
@@ -22214,4 +22181,29 @@ ExprResult Sema::CreateRecoveryExpr(SourceLocation Begin, SourceLocation End,
     T = Context.DependentTy;
 
   return RecoveryExpr::Create(Context, T, Begin, End, SubExprs);
+}
+
+bool Sema::CheckUnguardedCHERIoTSealedVarUse(const Expr *E) {
+  if (!E)
+    return false;
+
+  using namespace ast_matchers;
+
+  auto Uses = match(
+      expr(ignoringParenImpCasts(
+          declRefExpr(to(decl(hasAttr(attr::Kind::CHERIoTSealedObject))),
+                      unless(hasParent(unaryOperator(hasOperatorName("&")))))
+              .bind("unguardedUse"))),
+      *E, Context);
+  if (Uses.empty())
+    return false;
+
+  for (auto U : Uses) {
+
+    const DeclRefExpr *E = U.getNodeAs<DeclRefExpr>("unguardedUse");
+
+    Diag(E->getExprLoc(), diag::err_cheriot_non_addr_of_expr_on_sealed);
+  }
+
+  return true;
 }

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5851,21 +5851,6 @@ QualType Sema::CXXCheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
                                            ExprResult &RHS, ExprValueKind &VK,
                                            ExprObjectKind &OK,
                                            SourceLocation QuestionLoc) {
-  // CHERIoT-specific check.
-  if (!isUnevaluatedContext()) {
-    if (LHS.get()->getType().hasCHERIoTSealedAttr()) {
-      Diag(LHS.get()->getExprLoc(),
-           diag::err_cheriot_non_addr_of_expr_on_sealed);
-      return QualType();
-    }
-
-    if (RHS.get()->getType().hasCHERIoTSealedAttr()) {
-      Diag(RHS.get()->getExprLoc(),
-           diag::err_cheriot_non_addr_of_expr_on_sealed);
-      return QualType();
-    }
-  }
-
   // FIXME: Handle C99's complex types, block pointers and Obj-C++ interface
   // pointers.
 

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -893,11 +893,6 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
                                     R.getLookupNameInfo(), TemplateArgs);
 
   QualType BaseType = BaseExprType;
-  // CHERIoT-specific check.
-  if (BaseType.hasCHERIoTSealedAttr() && !isUnevaluatedContext()) {
-    return ExprError(Diag(OpLoc, diag::err_cheriot_non_addr_of_expr_on_sealed));
-  }
-
   if (IsArrow) {
     assert(BaseType->isPointerType());
     BaseType = BaseType->castAs<PointerType>()->getPointeeType();

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9027,28 +9027,6 @@ static bool HandleCHERIPointerQualifier(QualType &CurType,
   return true;
 }
 
-static Attr *HandleCHERIoTSealedType(QualType &T, TypeProcessingState &State,
-                                     TypeAttrLocation TAL, ParsedAttr &attr) {
-  auto *S = &State.getSema();
-
-  StringRef CompartmentName;
-  SourceLocation CompartmentNameLiteralLoc;
-  if (!S->checkStringLiteralArgumentAttr(attr, 0, CompartmentName,
-                                         &CompartmentNameLiteralLoc))
-    return nullptr;
-
-  StringRef SealingTypeName;
-  SourceLocation SealingTypeNameLiteralLoc;
-
-  if (!S->checkStringLiteralArgumentAttr(attr, 1, SealingTypeName,
-                                         &SealingTypeNameLiteralLoc))
-    return nullptr;
-
-  attr.setUsedAsTypeAttr();
-  return ::new (S->Context)
-      CHERIoTSealedTypeAttr(S->Context, attr, CompartmentName, SealingTypeName);
-}
-
 static void handleCheriNoProvenanceAttr(QualType &T, TypeProcessingState &State,
                                         TypeAttrLocation TAL,
                                         ParsedAttr &Attr) {
@@ -9466,11 +9444,6 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
         if (type->isReferenceType())
           state.getSema().Diag(attr.getLoc(), diag::err_sealed_reference)
               << type;
-      }
-      break;
-    case ParsedAttr::AT_CHERIoTSealedType:
-      if (auto *Attr = HandleCHERIoTSealedType(type, state, TAL, attr)) {
-        type = state.getAttributedType(Attr, type, type);
       }
       break;
     case ParsedAttr::AT_CHERICapability:

--- a/clang/test/CodeGen/cheri/riscv/cheriot-static-sealed-value-attr.c
+++ b/clang/test/CodeGen/cheri/riscv/cheriot-static-sealed-value-attr.c
@@ -1,56 +1,51 @@
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32cheriot-unknown-cheriotrtos" "-emit-llvm" "-mframe-pointer=none" "-mcmodel=small" "-target-abi" "cheriot" "-Oz" "-Werror" "-target-feature" "+xcheriot" -std=c2x | FileCheck %s
 
-// CHECK: %struct.__Sealed_SealedStructObj = type { i32, i32, %struct.SealedStructObj }
-// CHECK: %struct.SealedStructObj = type { i32 }
-struct __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) SealedStructObj { int val; };
+// Test that sealed variables behave like we expect them to.
+// In this test we have two global variables that refer to sealed values.
 
-// CHECK: %struct.__Sealed_SealedInt = type { i32, i32, i32 }
-typedef int SealedInt __attribute((cheriot_sealed("MyCompartment", "MyKeyName")));
+// CHECK: %struct.__Sealed_const_int = type { i32, i32, i32 }
+// CHECK: %struct.__Sealed_int = type { i32, i32, i32 }
 
-// Objects are marked as used. 
-//
-// CHECK: $Obj1 = comdat any
-// CHECK: $Obj2 = comdat any
-//
-// There's only an exported sealing key for each combination.
-//
+// CHECK: $MyHereInt = comdat any
+// CHECK: @MyHereInt = linkonce_odr dso_local addrspace(200) constant %struct.__Sealed_const_int { i32 ptrtoint (ptr addrspace(200) @__export.sealing_type.MyCompartment.MyKeyName to i32), i32 0, i32 0 }, section ".sealed_objects", comdat, align 4 #0
+const int __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyHereInt = 0;
+
 // CHECK: @__export.sealing_type.MyCompartment.MyKeyName = external dso_local addrspace(200) global i32, align 4
-//
-// CHECK: @Obj1 = linkonce_odr dso_local addrspace(200) global %struct.__Sealed_SealedStructObj { i32 ptrtoint (ptr addrspace(200) @__export.sealing_type.MyCompartment.MyKeyName to i32), i32 0, %struct.SealedStructObj { i32 10 } }, section ".sealed_objects", comdat, align 4 #0
-struct SealedStructObj Obj1 = {10};
 
-// CHECK: @Obj2 = linkonce_odr dso_local addrspace(200) global %struct.__Sealed_SealedInt { i32 ptrtoint (ptr addrspace(200) @__export.sealing_type.MyCompartment.MyKeyName to i32), i32 0, i32 10 }, section ".sealed_objects", comdat, align 4 #0
-SealedInt Obj2 = 10;
+// CHECK: @MyExternInt = external addrspace(200) global %struct.__Sealed_int, align 4 #0
+extern int __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyExternInt;
 
-// CHECK: @llvm.compiler.used = appending addrspace(200) global [2 x ptr addrspace(200)] [ptr addrspace(200) @Obj1, ptr addrspace(200) @Obj2], section "llvm.metadata"
+// Mark `MyHereInt` as used, so it can't be optimised away.
+// CHECK: @llvm.compiler.used = appending addrspace(200) global [1 x ptr addrspace(200)] [ptr addrspace(200) @MyHereInt], section "llvm.metadata"
 
-void doSomething(struct SealedStructObj *__sealed_capability obj);
+void doSomethingWithSealed(const int* __sealed_capability);
 void doSomethingWithAddr(int addr);
-void doSomething2(SealedInt *__sealed_capability obj);
 
-// CHECK: ; Function Attrs: minsize nounwind optsize
-// CHECK: define dso_local void @func() local_unnamed_addr addrspace(200) #1 {
 void func() {
-// CHECK: entry:
-// CHECK: 	tail call addrspace(200) void @doSomething(ptr addrspace(200) noundef nonnull @Obj1) #5
-  doSomething(&Obj1);
 
-// Verify that observing the address of a sealed global value is done through a call to the launder built-in, so that 
-// the KnownBits optimisation pass can't assume anything about the value of the pointer, specifically nothing about the alignment of the pointer.
-// This is because the CHERIoT RTOS uses the lower bits of the address to store the permissions of the sealed capability, and KnownBits can in turn 
-// optimise away logical computations on lower parts of the address.
+  // CHECK: tail call addrspace(200) void @doSomethingWithSealed(ptr addrspace(200) noundef nonnull @MyHereInt) #5
+  doSomethingWithSealed(&MyHereInt);
 
-// CHECK:  %0 = tail call addrspace(200) ptr addrspace(200) @llvm.launder.alignment.p200(ptr addrspace(200) nonnull @Obj1)
-// CHECK:  %1 = tail call addrspace(200) i32 @llvm.cheri.cap.address.get.i32(ptr addrspace(200) nonnull %0)
-// CHECK:  tail call addrspace(200) void @doSomethingWithAddr(i32 noundef %1) #5
-  doSomethingWithAddr(__builtin_cheri_address_get(&Obj1));
+  // CHECK: tail call addrspace(200) void @doSomethingWithSealed(ptr addrspace(200) noundef nonnull @MyExternInt) #5
+  doSomethingWithSealed(&MyExternInt);
 
-// CHECK: 	tail call addrspace(200) void @doSomething2(ptr addrspace(200) noundef nonnull @Obj2) #5
-  doSomething2(&Obj2);
+  // Verify that observing the address of a sealed global value is done through a call to the launder built-in, so that 
+  // the KnownBits optimisation pass can't assume anything about the value of the pointer, specifically nothing about the alignment of the pointer.
+  // This is because the CHERIoT RTOS uses the lower bits of the address to store the permissions of the sealed capability, and KnownBits can in turn 
+  // optimise away logical computations on lower parts of the address.
+  
+  // CHECK: %0 = tail call addrspace(200) ptr addrspace(200) @llvm.launder.alignment.p200(ptr addrspace(200) nonnull @MyHereInt)
+  // CHECK: %1 = tail call addrspace(200) i32 @llvm.cheri.cap.address.get.i32(ptr addrspace(200) nonnull %0)
+  // CHECK: tail call addrspace(200) void @doSomethingWithAddr(i32 noundef %1) #5
+  doSomethingWithAddr(__builtin_cheri_address_get(&MyHereInt));
+
+  /// Same with an extern declaration.
+  // CHECK: %2 = tail call addrspace(200) ptr addrspace(200) @llvm.launder.alignment.p200(ptr addrspace(200) nonnull @MyExternInt)
+  // CHECK: %3 = tail call addrspace(200) i32 @llvm.cheri.cap.address.get.i32(ptr addrspace(200) nonnull %2)
+  // CHECK: tail call addrspace(200) void @doSomethingWithAddr(i32 noundef %3) #5
+  doSomethingWithAddr(__builtin_cheri_address_get(&MyExternInt));
+
+  // CHECK: ret void
 }
 
-// CHECK: declare void @doSomething(ptr addrspace(200) noundef) local_unnamed_addr addrspace(200) #2
-// CHECK: declare void @doSomethingWithAddr(i32 noundef) local_unnamed_addr addrspace(200) #2
-// CHECK: declare ptr addrspace(200) @llvm.launder.alignment.p200(ptr addrspace(200)) addrspace(200) #3
-// CHECK: declare i32 @llvm.cheri.cap.address.get.i32(ptr addrspace(200)) addrspace(200) #4
-// CHECK: declare void @doSomething2(ptr addrspace(200) noundef) local_unnamed_addr addrspace(200) #2
+// CHECK:  attributes #0 = { "cheriot_sealed_value" }

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -38,6 +38,7 @@
 // CHECK-NEXT: CHERILibCall (SubjectMatchRule_function)
 // CHECK-NEXT: CHERISubobjectBoundsUseRemainingSize (SubjectMatchRule_field, SubjectMatchRule_record)
 // CHECK-NEXT: CHERIoTMMIODevice (SubjectMatchRule_variable_is_global)
+// CHECK-NEXT: CHERIoTSealedObject (SubjectMatchRule_variable_is_global)
 // CHECK-NEXT: CHERIoTSharedObject (SubjectMatchRule_variable_is_global)
 // CHECK-NEXT: CPUDispatch (SubjectMatchRule_function)
 // CHECK-NEXT: CPUSpecific (SubjectMatchRule_function)

--- a/clang/test/Sema/cheri/cheriot-static-sealed-value-attr.c
+++ b/clang/test/Sema/cheri/cheriot-static-sealed-value-attr.c
@@ -1,55 +1,71 @@
-// RUN: %riscv32_cheri_cc1 "-triple" "riscv32cheriot-unknown-unknown" "-target-abi" "cheriot" -verify %s 
+// RUN: %riscv32_cheri_cc1 "-triple" "riscv32cheriot-unknown-cheriotrtos" "-target-abi" "cheriot" -verify %s 
 
-struct PlainObj {int val;};
-struct __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyObj { int val; };
+struct MyObj { int val; };
 
-struct MyObj Obj = {10};
+static struct MyObj __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyObjInitAndSeal  = { 0 };
+extern struct MyObj __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyObjExtSeal;
 
-typedef int MyObj2 [[cheriot::sealed("MyCompartment", "MyKeyName")]];
-typedef int MyObj3 __attribute__((cheriot_sealed("MyCompartment", "MyKeyName")));
-MyObj2 Obj2 = 10;
-MyObj3 Obj3 = 10;
+void useMyObj(struct MyObj x);
+void useRefToMyObj(struct MyObj* x);
+void useSealedMyObj(struct MyObj* __sealed_capability  x);
+
+struct MyObj returnMyObjInitAndSeal() {
+  return MyObjInitAndSeal;  // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
+
+struct MyObj returnMyObjExtSeal() {
+  return MyObjExtSeal;  // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
 
 
-typedef int MyObj4[4] __attribute__((cheriot_sealed("MyCompartment", "MyKeyName")));
-typedef struct PlainObj *MyObj5 __attribute__((cheriot_sealed("MyCompartment", "MyKeyName")));
+static int* __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) IntPtrInitAndSeal = 0; 
 
-MyObj4 Obj4 = {0, 0, 0, 0};
+void useIntPtr(int* x);
+void useRefToIntPtr(int** x);
+void useSealedIntPtr(int** __sealed_capability  x);
 
-struct PlainObj plainObj = {10};
-MyObj5 Obj5 = &plainObj;
-extern MyObj5 Obj6; // No warnings here, it is allowed to declare it `extern`.
+int* returnIntPtrInitAndSeal() {
+  return IntPtrInitAndSeal;  // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
 
-void useStruct(struct MyObj x);
-void useStructSealedCap(struct MyObj *__sealed_capability x);
+static int __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) IntInitAndSeal = 42; 
+
 void useInt(int x);
-void useIntSealedCap(int *__sealed_capability x);
+void useRefToInt(int* x);
+void useSealedInt(int* __sealed_capability  x);
+
+int returnIntInitAndSeal() {
+  return IntInitAndSeal; // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
+
+void useBool(int b);
+
 
 void func() {
-  struct MyObj* __sealed_capability ptr = &Obj;
-  int eq = (&Obj == &Obj);
-  int _eq = (Obj == Obj); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  int leq = (&Obj < &Obj);
-  int or = ((int) &Obj | (int) &Obj);
-  int lor = ((int) &Obj || (int) &Obj);
-  Obj.val; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj2 + 1); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj3 - 1); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj2 * 10); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj3 * 10); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj4[0]); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj5->val); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  useStruct(Obj);  // expected-error{{the only valid operation on a sealed value is to take its address}}
-  useInt(Obj2); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  useStructSealedCap(&Obj); 
-  useIntSealedCap(&Obj2);
-  int _ = sizeof(*(&Obj));
-  int size = sizeof(*(&Obj5->val));
-  Obj2++; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  -Obj2; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  Obj2 += 1; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  float x = (float) Obj2; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useMyObj(MyObjInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToMyObj(&MyObjInitAndSeal); // expected-error{{converting sealed type 'struct MyObj * __sealed_capability' to non-sealed type 'struct MyObj *' without an explicit unsealing}}
+  useSealedMyObj(&MyObjInitAndSeal);
+  useBool(&MyObjInitAndSeal == &MyObjInitAndSeal);
 
-  int k1 = Obj3 ; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  int y = 1 ? Obj3 : Obj2; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useMyObj(MyObjExtSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToMyObj(&MyObjExtSeal); // expected-error{{converting sealed type 'struct MyObj * __sealed_capability' to non-sealed type 'struct MyObj *' without an explicit unsealing}}
+  useSealedMyObj(&MyObjExtSeal);
+  useBool(&MyObjExtSeal == &MyObjExtSeal);
+
+  useIntPtr(IntPtrInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToIntPtr(&IntPtrInitAndSeal); // expected-error{{converting sealed type 'int ** __sealed_capability' to non-sealed type 'int **' without an explicit unsealing}}
+  int* ShouldFail1 = &(*IntPtrInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useSealedIntPtr(&IntPtrInitAndSeal);
+
+  useInt(IntInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToInt(&IntInitAndSeal); // expected-error{{converting sealed type 'int * __sealed_capability' to non-sealed type 'int *' without an explicit unsealing}}
+  int ShouldFail2 = IntInitAndSeal + 10; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail3 = (0 == 0) ? IntInitAndSeal : 0; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail4 = (0 == 0) ? 0 : IntInitAndSeal; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail5 = IntInitAndSeal ? 0 : 1; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail6 = IntInitAndSeal < 0; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail7 = 0 < IntInitAndSeal; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  IntInitAndSeal = 0; // expected-error{{the only valid operation on a sealed value is to take its address}}  
+
+  useSealedInt(&IntInitAndSeal);
 }

--- a/clang/test/SemaCXX/cheri/cheriot-static-sealed-value-attr.cpp
+++ b/clang/test/SemaCXX/cheri/cheriot-static-sealed-value-attr.cpp
@@ -1,59 +1,74 @@
-// RUN: %riscv32_cheri_cc1 "-triple" "riscv32cheriot-unknown-unknown" "-target-abi" "cheriot" -verify %s 
+// RUN: %riscv32_cheri_cc1 "-triple" "riscv32cheriot-unknown-cheriotrtos" "-target-abi" "cheriot" -verify %s 
 
-struct PlainObj {int val;};
-struct __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyObj { int val; }; // expected-error{{the only valid operation on a sealed value is to take its address}}
+struct MyObj {
+  public: 
+    int val;
+};
 
-struct MyObj Obj = {10};
+static struct MyObj __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyObjInitAndSeal  = { 0 };
+extern struct MyObj __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) MyObjExtSeal;
 
-typedef int MyObj2 [[cheriot::sealed("MyCompartment", "MyKeyName")]];
-typedef int MyObj3 __attribute__((cheriot_sealed("MyCompartment", "MyKeyName")));
-MyObj2 Obj2 = 10;
-MyObj3 Obj3 = 10;
+void useMyObj(struct MyObj x);
+void useRefToMyObj(struct MyObj* x);
+void useSealedMyObj(struct MyObj* __sealed_capability  x);
 
-typedef int MyObj4[4] __attribute__((cheriot_sealed("MyCompartment", "MyKeyName")));
-typedef struct PlainObj *MyObj5 __attribute__((cheriot_sealed("MyCompartment", "MyKeyName")));
+struct MyObj returnMyObjInitAndSeal() {
+  return MyObjInitAndSeal;  // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
 
-MyObj4 Obj4 = {0, 0, 0, 0};
+struct MyObj returnMyObjExtSeal() {
+  return MyObjExtSeal;  // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
 
-struct PlainObj plainObj = {10};
-MyObj5 Obj5 = &plainObj;
-extern MyObj5 Obj6; // No warnings here, it is allowed to declare it `extern`. 
-					
-void useStruct(struct MyObj x);
-void useStructSealedCap(struct MyObj *__sealed_capability x);
+
+static int* __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) IntPtrInitAndSeal = 0; 
+
+void useIntPtr(int* x);
+void useRefToIntPtr(int** x);
+void useSealedIntPtr(int** __sealed_capability  x);
+
+int* returnIntPtrInitAndSeal() {
+  return IntPtrInitAndSeal;  // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
+
+static int __attribute__((cheriot_sealed("MyCompartment", "MyKeyName"))) IntInitAndSeal = 42; 
+
 void useInt(int x);
-void useIntSealedCap(int *__sealed_capability x);
+void useRefToInt(int* x);
+void useSealedInt(int* __sealed_capability  x);
+
+int returnIntInitAndSeal() {
+  return IntInitAndSeal; // expected-error{{the only valid operation on a sealed value is to take its address}}
+}
+
+void useBool(int b);
+
 
 void func() {
-  struct MyObj* __sealed_capability ptr = &Obj;
-  int eq = (&Obj == &Obj);
-  int _eq = (Obj == Obj); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  int leq = (&Obj < &Obj);
-  int _or = ((int) &Obj | (int) &Obj);
-  int lor = ((int) &Obj || (int) &Obj);
-  Obj.val; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj2 + 1); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj3 - 1); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj2 * 10); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj3 * 10); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj4[0]); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  (Obj5->val); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  useStruct(Obj);  // expected-note{{in implicit copy constructor for 'MyObj' first required here}}
-  useInt(Obj2); // expected-error{{the only valid operation on a sealed value is to take its address}}
-  useStructSealedCap(&Obj); 
-  useIntSealedCap(&Obj2);
-  auto _ = sizeof(*(&Obj)); 
-  int x = 10;
-  decltype(*(&Obj2)) y = x;
+  useMyObj(MyObjInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToMyObj(&MyObjInitAndSeal); // expected-error{{converting sealed type 'struct MyObj * __sealed_capability' to non-sealed type 'MyObj *' without an explicit unsealing}}
+  useSealedMyObj(&MyObjInitAndSeal);
+  useBool(&MyObjInitAndSeal == &MyObjInitAndSeal);
 
-  // Valid in unevaluated contexts.
-  auto size = sizeof(Obj5->val); 
+  useMyObj(MyObjExtSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToMyObj(&MyObjExtSeal); // expected-error{{converting sealed type 'struct MyObj * __sealed_capability' to non-sealed type 'MyObj *' without an explicit unsealing}}
+  useSealedMyObj(&MyObjExtSeal);
+  useBool(&MyObjExtSeal == &MyObjExtSeal);
 
-  Obj2++; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  -Obj2; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  Obj2 += 1; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  float f = (float) Obj2; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useIntPtr(IntPtrInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToIntPtr(&IntPtrInitAndSeal); // expected-error{{converting sealed type 'int ** __sealed_capability' to non-sealed type 'int **' without an explicit unsealing}}
+  int* ShouldFail1 = &(*IntPtrInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useSealedIntPtr(&IntPtrInitAndSeal);
 
-  int k1 = Obj3 ; // expected-error{{the only valid operation on a sealed value is to take its address}}
-  int k = 1 ? Obj3 : Obj2; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useInt(IntInitAndSeal); // expected-error{{the only valid operation on a sealed value is to take its address}}
+  useRefToInt(&IntInitAndSeal); // expected-error{{converting sealed type 'int * __sealed_capability' to non-sealed type 'int *' without an explicit unsealing}}
+  int ShouldFail2 = IntInitAndSeal + 10; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail3 = (0 == 0) ? IntInitAndSeal : 0; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail4 = (0 == 0) ? 0 : IntInitAndSeal; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail5 = IntInitAndSeal ? 0 : 1; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail6 = IntInitAndSeal < 0; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  int ShouldFail7 = 0 < IntInitAndSeal; // expected-error{{the only valid operation on a sealed value is to take its address}}
+  IntInitAndSeal = 0; // expected-error{{the only valid operation on a sealed value is to take its address}}  
+
+  useSealedInt(&IntInitAndSeal);
 }

--- a/llvm/test/CodeGen/RISCV/cheri/cheriot-sealed-attr.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/cheriot-sealed-attr.ll
@@ -31,7 +31,37 @@ entry:
 ;; CHECK-NEXT:  	  clc	  t2, %cheriot_compartment_lo_i(.LBB0_2)(t2)
 ;; CHECK-NEXT:  	  cjalr	  t2
   %call = notail call cheriot_compartmentcallcc noundef i32 @test_static_sealed_object(ptr addrspace(200) @test) #2
+
+;; CHECK:        .LBB0_4:                                # %entry
+;; CHECK-NEXT:                                           # Label of block must be emitted
+;; CHECK-NEXT:           ct.auipcc       a0, %cheriot_compartment_code_hi(__import.sealed_object.__default_malloc_capability)
+;; CHECK-NEXT:           ct.clc  a0, %cheriot_compartment_lo_i(.LBB0_4)(a0)
+;; CHECK-NEXT:   .LBB0_6:                                # %entry
+;; CHECK-NEXT:                                           # Label of block must be emitted
+;; CHECK-NEXT:           ct.auipcc       t1, %cheriot_compartment_code_hi(__import_static_sealing_inner_test_static_sealed_object)
+;; CHECK-NEXT:           ct.clc  t1, %cheriot_compartment_lo_i(.LBB0_6)(t1)
+;; CHECK-NEXT:   .LBB0_5:                                # %entry
+;; CHECK-NEXT:                                           # Label of block must be emitted
+;; CHECK-NEXT:           ct.auipcc       t2, %cheriot_compartment_code_hi(.compartment_switcher)
+;; CHECK-NEXT:           ct.clc  t2, %cheriot_compartment_lo_i(.LBB0_5)(t2)
+;; CHECK-NEXT:           ct.cjalr        t2
   %call2 = notail call cheriot_compartmentcallcc noundef i32 @test_static_sealed_object(ptr addrspace(200) @__default_malloc_capability) #2
+
+;; CHECK:        .LBB0_7:                                # %entry
+;; CHECK-NEXT:                                           # Label of block must be emitted
+;; CHECK-NEXT:           ct.auipcc       a0, %cheriot_compartment_code_hi(__import.sealed_object.MyExtern)
+;; CHECK-NEXT:           ct.clc  a0, %cheriot_compartment_lo_i(.LBB0_7)(a0)
+;; CHECK-NEXT:   .LBB0_9:                                # %entry
+;; CHECK-NEXT:                                           # Label of block must be emitted
+;; CHECK-NEXT:           ct.auipcc       t1, %cheriot_compartment_code_hi(__import_static_sealing_inner_test_static_sealed_object)
+;; CHECK-NEXT:           ct.clc  t1, %cheriot_compartment_lo_i(.LBB0_9)(t1)
+;; CHECK-NEXT:   .LBB0_8:                                # %entry
+;; CHECK-NEXT:                                           # Label of block must be emitted
+;; CHECK-NEXT:           ct.auipcc       t2, %cheriot_compartment_code_hi(.compartment_switcher)
+;; CHECK-NEXT:           ct.clc  t2, %cheriot_compartment_lo_i(.LBB0_8)(t2)
+;; CHECK-NEXT:           ct.cjalr        t2
+  %call3 = notail call cheriot_compartmentcallcc noundef i32 @test_static_sealed_object(ptr addrspace(200) @MyExtern) #2
+
   ret i32 %call2
 }
 
@@ -72,11 +102,8 @@ $__default_malloc_capability = comdat any
 ;; CHECK-NEXT:  .zero   16
 ;; CHECK-NEXT:  .size   __default_malloc_capability, 32
 @__default_malloc_capability = linkonce_odr dso_local addrspace(200) global
-%struct.SealedAllocatorCapabilityState { i32 ptrtoint (ptr
-addrspace(200) @__export.sealing_type.allocator.MallocKey to i32), i32 0,
-%struct.AllocatorCapabilityState { i32 1048576, i32 0, [2 x ptr addrspace(200)]
-zeroinitializer } }, section ".sealed_objects", comdat, align 8 "cheriot_sealed_value"
-
+%struct.SealedAllocatorCapabilityState { i32 ptrtoint (ptr addrspace(200) @__export.sealing_type.allocator.MallocKey to i32), i32 0, %struct.AllocatorCapabilityState { i32 1048576, i32 0, [2 x ptr addrspace(200)] zeroinitializer } }, section ".sealed_objects", comdat, align 8 "cheriot_sealed_value"
+@MyExtern = external dso_local addrspace(200) global %struct.SealedTestType, align 4 "cheriot_sealed_value"
 @llvm.compiler.used = appending addrspace(200) global [2 x ptr addrspace(200)] [ptr addrspace(200) @test, ptr addrspace(200) @__default_malloc_capability], section "llvm.metadata"
 
 
@@ -98,7 +125,14 @@ zeroinitializer } }, section ".sealed_objects", comdat, align 8 "cheriot_sealed_
 ;; CHECK-NEXT:	  .word	__default_malloc_capability
 ;; CHECK-NEXT:	  .word
 ;; CHECK-NEXT:	  .size	__import.sealed_object.__default_malloc_capability, 8
-
+ ;; CHECK:         .section        .compartment_imports.MyExtern,"awG",@progbits,__import.sealed_object.MyExtern
+;; CHECK-NEXT:    .type   __import.sealed_object.MyExtern,@object
+;; CHECK-NEXT:    .weak   __import.sealed_object.MyExtern
+;; CHECK-NEXT:    .p2align        3, 0x0
+;; CHECK-NEXT: __import.sealed_object.MyExtern:
+;; CHECK-NEXT:    .word   MyExtern
+;; CHECK-NEXT:    .word   12
+;; CHECK-NEXT:    .size   __import.sealed_object.MyExtern, 8
 
 !0 = !{i32 1, !"wchar_size", i32 2}
 !1 = !{i32 1, !"target-abi", !"cheriot"}


### PR DESCRIPTION
Previously, the `cheriot_sealed` attribute was attached to types. We recently wanted to change this, making attribute on variables rather than types. This PR does that, and also makes the attribute work properly on `extern` global variables.