### PR TITLE
[CHERIoT] Change an error on wrong cheriot attributes input

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3082,14 +3082,16 @@ def CHERILibCall : DeclOrTypeAttr {
 def CHERIoTMMIODevice : DeclOrTypeAttr {
   let Spellings = [GNU<"cheriot_mmio">];
   let Documentation = [CHERIoTMMIODeviceDocs];
-  let Args = [StringArgument<"DeviceName">, StringArgument<"EncodedPermissions", 1>];
+  let Args = [StringArgument<"DeviceName">,
+              StringArgument<"EncodedPermissions">];
   let Subjects = SubjectList<[GlobalVar], ErrorDiag>;
 }
 
 def CHERIoTSharedObject : DeclOrTypeAttr {
   let Spellings = [GNU<"cheriot_shared_object">];
   let Documentation = [CHERIoTSharedObjectDocs];
-  let Args = [StringArgument<"ObjectName">, StringArgument<"EncodedPermissions", 1>];
+  let Args = [StringArgument<"ObjectName">,
+              StringArgument<"EncodedPermissions">];
   let Subjects = SubjectList<[GlobalVar], ErrorDiag>;
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1619,8 +1619,6 @@ whose meaning is explained in the table below.
 Examples of valid encodings are: ``"RWcm"`` (all permissions), ``"R"`` (read
 only), etc. Note that the order in which symbols appear is not relevant: for
 example, `"RWcm"` and `"mcWR"` are both valid and entail the same permissions.
-
-**Warning**: The ``<permissions_encoding>`` parameter is optional, and if no encoding is given ``"RWcmg"`` is assumed.
   }];
 }
 
@@ -1654,8 +1652,6 @@ string of variable length. The symbols allowed in the string are ``R``, ``W``,
 Examples of valid encodings are: ``"RWcm"`` (all permissions), ``"R"`` (read
 only), etc. Note that the order in which symbols appear is not relevant: for
 example, `"RWcm"` and `"mcWR"` are both valid and entail the same permissions.
-
-**Warning**: The ``<permissions_encoding>`` parameter is optional, and if no encoding is given ``"RWcmg"`` is assumed.
   }];
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2340,10 +2340,9 @@ static void handleCHERIoTMMIODevice(Sema &S, Decl *D, const ParsedAttr &Attr,
   StringRef Permissions;
   SourceLocation PermissionsLiteralLoc;
 
-  if (Attr.getNumArgs() > 1) {
-    S.checkStringLiteralArgumentAttr(Attr, 1, Permissions,
-                                     &PermissionsLiteralLoc);
-  }
+  if (!S.checkStringLiteralArgumentAttr(Attr, 1, Permissions,
+                                        &PermissionsLiteralLoc))
+    return;
 
   std::string OwnedPermissions = Permissions.str();
 
@@ -2400,10 +2399,9 @@ static void handleCHERIoTSharedObject(Sema &S, Decl *D, const ParsedAttr &Attr,
   StringRef Permissions;
   SourceLocation PermissionsLiteralLoc;
 
-  if (Attr.getNumArgs() > 1) {
-    S.checkStringLiteralArgumentAttr(Attr, 1, Permissions,
-                                     &PermissionsLiteralLoc);
-  }
+  if (!S.checkStringLiteralArgumentAttr(Attr, 1, Permissions,
+                                        &PermissionsLiteralLoc))
+    return;
 
   std::string OwnedPermissions = Permissions.str();
 

--- a/clang/test/Sema/cheri/cheriot-cap-import-attr-ill-formed.c
+++ b/clang/test/Sema/cheri/cheriot-cap-import-attr-ill-formed.c
@@ -3,8 +3,10 @@ struct Uart {};
 
 
 
-__attribute__((cheriot_mmio("uart"))) extern volatile struct Uart uart_noperm; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: '')}}
+__attribute__((cheriot_mmio("uart"))) extern volatile struct Uart uart_noperm; // expected-error{{'cheriot_mmio' attribute requires exactly 2 arguments}}
 __attribute__((cheriot_mmio("uart", ""))) extern volatile struct Uart uart_empty; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: '')}}
+__attribute__((cheriot_mmio("uart", 12))) int *uart_number; // expected-error{{expected string literal as argument of 'cheriot_mmio' attribute}}
+__attribute__((cheriot_mmio("uart", RW))) int *uart_ident; // expected-error{{expected string literal as argument of 'cheriot_mmio' attribute}}
 __attribute__((cheriot_mmio("uart", "xyz"))) extern struct Uart uart; // expected-error{{the permissions in 'cheriot_mmio' contain unknown permission symbols: 'xyz' (value: 'xyz')}} expected-warning{{global variable definition 'uart' has attribute 'cheriot_mmio' but is not qualified as `volatile`}}
 __attribute__((cheriot_mmio("uart", "RR"))) extern volatile struct Uart uart1; // expected-warning{{the permissions in 'cheriot_mmio' contain a duplicate permission symbol: 'R' (value: 'RR')}}
 __attribute__((cheriot_mmio("uart", "m"))) extern volatile struct Uart uart2; // expected-error{{the permissions in 'cheriot_mmio' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: 'm')}} 
@@ -14,6 +16,9 @@ __attribute__((cheriot_mmio("uart", "R"))) volatile struct Uart uart3; // no war
 __attribute__((cheriot_mmio("uart", "R"))) volatile struct Uart uart4 = {};  // expected-error{{global variable definition 'uart4' with attribute 'cheriot_mmio' cannot have an initializer}}
 __attribute__((cheriot_mmio("uart", "R"))) volatile struct {int k;} uart5 = {10};  // expected-error{{global variable definition 'uart5' with attribute 'cheriot_mmio' cannot have an initializer}}
 __attribute__((cheriot_mmio("uart", "R"))) extern volatile struct Uart *uart6; /* no warnings or errors*/
+__attribute__((cheriot_shared_object("exampleK"))) extern int so_noperm; // expected-error{{'cheriot_shared_object' attribute requires exactly 2 arguments}}
+__attribute__((cheriot_shared_object("exampleK", 12))) int *so_number; // expected-error{{expected string literal as argument of 'cheriot_shared_object' attribute}}
+__attribute__((cheriot_shared_object("exampleK", RW))) int *so_ident; // expected-error{{expected string literal as argument of 'cheriot_shared_object' attribute}}
 __attribute__((cheriot_shared_object("exampleK", "RR"))) extern int exampleK; // expected-warning{{the permissions in 'cheriot_shared_object' contain a duplicate permission symbol: 'R' (value: 'RR')}}
 __attribute__((cheriot_shared_object("exampleK", "m"))) extern int exampleK; // expected-error{{the permissions in 'cheriot_shared_object' contain ill-formed dependencies: does not contain either read (R) or write (W) (value: 'm')}}
 __attribute__((cheriot_shared_object("exampleK", "Wm"))) extern int exampleK; // expected-error{{the permissions in 'cheriot_shared_object' contain ill-formed dependencies: contains mut (m) but does not have both read (R) and cap (c) (value: 'Wm')}}
@@ -21,4 +26,4 @@ __attribute__((cheriot_shared_object("exampleK", "g"))) extern int exampleK; // 
 __attribute__((cheriot_shared_object("exampleK", "Wg"))) extern int exampleK; // expected-error{{the permissions in 'cheriot_shared_object' contain ill-formed dependencies: contains load global (g) but does not have both read (R) and cap (c) (value: 'Wg')}}
 __attribute__((cheriot_shared_object("exampleK", "R"))) int exampleK; // no warnings or errors, extern is implied 
 __attribute__((cheriot_shared_object("exampleK", "R"))) int exampleK2 = 10; // expected-error{{global variable definition 'exampleK2' with attribute 'cheriot_shared_object' cannot have an initializer}}
-__attribute__((cheriot_shared_object("exampleK", "R"))) int *exampleK3; /* no warnings or errors */ 
+__attribute__((cheriot_shared_object("exampleK", "R"))) int *exampleK3; /* no warnings or errors */

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -1415,7 +1415,6 @@ public:
   /// ReadPermission  := `ReadPermissionSymbol` | "-"
   /// WritePermission := `WritePermissionSymbol` | "-"
   /// CapPermission   := `CapPermissionSymbol` | "-"
-  /// WritePermission := `WritePermissionSymbol` | "-"
   /// LoadMutablePermission  := `LoadMutablePermissionSymbol` | "-"
   /// LoadGlobalPermission  := `LoadGlobalPermissionSymbol` | "-"
   /// ```


### PR DESCRIPTION
When not giving a permission in a `cheriot_mmio` or `cheriot_shared_object` attribute, the error will return `... requires exactly 2 arguments` instead of `... contains ill-formed dependencies`, helping developers diagnose said error. In any case, both empty permission string and no permission string will error out, but now with different errors.

Also changed obsolete documentation in comments.