### PR TITLE
[CHERI] Disable (gep addr, (add off1, off2)) -> (gep (gep addr, off1), off2) transformation in InstCombine for CHERI.

### DIFF
--- a/clang/test/CodeGen/cheri/builtin-align-asm.c
+++ b/clang/test/CodeGen/cheri/builtin-align-asm.c
@@ -29,15 +29,15 @@ _Bool is_aligned(void *ptr, long align) {
 // CHECK-LABEL: define {{[^@]+}}@align_up
 // CHECK-SAME: (ptr addrspace(200) noundef readnone [[PTR:%.*]], i64 noundef signext [[ALIGN:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR2:[0-9]+]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[GEP0:%.*]] = getelementptr i8, ptr addrspace(200) [[PTR]], i64 [[ALIGN]]
-// CHECK-NEXT:    [[OVER_BOUNDARY:%.*]] = getelementptr i8, ptr addrspace(200) [[GEP0]], i64 -1
+// CHECK-NEXT:    [[MASK:%.*]] = add i64 [[ALIGN]], -1
+// CHECK-NEXT:    [[OVER_BOUNDARY:%.*]] = getelementptr inbounds i8, ptr addrspace(200) [[PTR]], i64 [[MASK]]
 // CHECK-NEXT:    [[INVERTED_MASK:%.*]] = sub i64 0, [[ALIGN]]
 // CHECK-NEXT:    [[ALIGNED_RESULT:%.*]] = tail call addrspace(200) ptr addrspace(200) @llvm.ptrmask.p200.i64(ptr addrspace(200) [[OVER_BOUNDARY]], i64 [[INVERTED_MASK]])
 // CHECK-NEXT:    ret ptr addrspace(200) [[ALIGNED_RESULT]]
 void* align_up(void *ptr, long align) {
   // ASM-LABEL: align_up:
-  // PURECAP-ASM:      cincoffset $c1, $c3, $4
-  // PURECAP-ASM-NEXT: cincoffset $c1, $c1, -1
+  // PURECAP-ASM:      daddiu $1, $4, -1
+  // PURECAP-ASM-NEXT: cincoffset $c1, $c3, $1
   // PURECAP-ASM-NEXT: dnegu $1, $4
   // PURECAP-ASM-NEXT: cjr $c17
   // PURECAP-ASM-NEXT: candaddr $c3, $c1, $1

--- a/clang/test/CodeGen/cheri/builtin-align-macro.c
+++ b/clang/test/CodeGen/cheri/builtin-align-macro.c
@@ -146,8 +146,8 @@ int *align_up_macro(int *ptr, ptraddr_t align) {
 // PURECAP-LABEL: define {{[^@]+}}@align_up_builtin
 // PURECAP-SAME: (ptr addrspace(200) noundef readnone [[PTR:%.*]], i64 noundef signext [[ALIGN:%.*]]) local_unnamed_addr addrspace(200) #[[ATTR2:[0-9]+]] {
 // PURECAP-NEXT:  entry:
-// PURECAP-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr addrspace(200) [[PTR]], i64 [[ALIGN]]
-// PURECAP-NEXT:    [[OVER_BOUNDARY:%.*]] = getelementptr i8, ptr addrspace(200) [[TMP0]], i64 -1
+// PURECAP-NEXT:    [[MASK:%.*]] = add i64 [[ALIGN]], -1
+// PURECAP-NEXT:    [[OVER_BOUNDARY:%.*]] = getelementptr inbounds i8, ptr addrspace(200) [[PTR]], i64 [[MASK]]
 // PURECAP-NEXT:    [[INVERTED_MASK:%.*]] = sub i64 0, [[ALIGN]]
 // PURECAP-NEXT:    [[ALIGNED_RESULT:%.*]] = tail call addrspace(200) ptr addrspace(200) @llvm.ptrmask.p200.i64(ptr addrspace(200) [[OVER_BOUNDARY]], i64 [[INVERTED_MASK]])
 // PURECAP-NEXT:    ret ptr addrspace(200) [[ALIGNED_RESULT]]

--- a/clang/test/CodeGen/cheri/cheri-vla.c
+++ b/clang/test/CodeGen/cheri/cheri-vla.c
@@ -13,8 +13,8 @@ extern void test(const char*);
 // CHECK-NEXT:    [[I_04:%.*]] = phi i64 [ 1, [[ENTRY:%.*]] ], [ [[INC:%.*]], [[FOR_BODY]] ]
 // CHECK-NEXT:    [[TMP0:%.*]] = call addrspace(200) ptr addrspace(200) @llvm.stacksave.p200()
 // CHECK-NEXT:    [[VLA:%.*]] = alloca i8, i64 [[I_04]], align 1, addrspace(200)
-// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr addrspace(200) [[VLA]], i64 [[I_04]]
-// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i8, ptr addrspace(200) [[TMP1]], i64 -1
+// CHECK-NEXT:    [[SUB:%.*]] = add nsw i64 [[I_04]], -1
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds i8, ptr addrspace(200) [[VLA]], i64 [[SUB]]
 // CHECK-NEXT:    store i8 0, ptr addrspace(200) [[ARRAYIDX]], align 1, !tbaa [[TBAA6:![0-9]+]]
 // CHECK-NEXT:    call addrspace(200) void @test(ptr addrspace(200) noundef nonnull [[VLA]]) #[[ATTR3:[0-9]+]]
 // CHECK-NEXT:    call addrspace(200) void @llvm.stackrestore.p200(ptr addrspace(200) [[TMP0]])

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -3552,7 +3552,8 @@ Instruction *InstCombinerImpl::visitGetElementPtrInst(GetElementPtrInst &GEP) {
     // Try to replace ADD + GEP with GEP + GEP.
     Value *Idx1, *Idx2;
     if (match(GEP.getOperand(1),
-              m_OneUse(m_AddLike(m_Value(Idx1), m_Value(Idx2))))) {
+              m_OneUse(m_AddLike(m_Value(Idx1), m_Value(Idx2)))) &&
+        !DL.isFatPointer(GEP.getType())) {
       //   %idx = add i64 %idx1, %idx2
       //   %gep = getelementptr i32, ptr %ptr, i64 %idx
       // as:

--- a/llvm/test/Transforms/InstCombine/CHERI/cheri-ptr-commutative.ll
+++ b/llvm/test/Transforms/InstCombine/CHERI/cheri-ptr-commutative.ll
@@ -2,15 +2,31 @@
 target datalayout = "e-m:e-p:32:32-i64:64-n32-S128-pf200:64:64:64:32-A200-P200-G200"
 target triple = "riscv32-unknown-cheriotrtos"
 
-; CHECK-LABEL: define ptr addrspace(200) @test_iterator_chain_nth_back
+; CHECK-LABEL: define ptr addrspace(200) @test1
 ; CHECK: getelementptr inbounds i32, {{.*}}, i32 %count.i9.i
 ; CHECK-NOT: getelementptr i8, {{.*}}, i32 20
-define ptr addrspace(200) @test_iterator_chain_nth_back(ptr addrspace(200) %xs, i32 %count.i9.i) addrspace(200) {
+define ptr addrspace(200) @test1(ptr addrspace(200) %xs, i32 %count.i9.i) addrspace(200) {
 start:
   %_6.i.i3 = getelementptr i32, ptr addrspace(200) %xs, i32 6
   %_35.i.i = getelementptr inbounds i32, ptr addrspace(200) %_6.i.i3, i32 %count.i9.i
   %_47.i.i = getelementptr i8, ptr addrspace(200) %_35.i.i, i32 -4
   ret ptr addrspace(200) %_47.i.i
+}
+
+; CHECK-LABEL: define void @test2
+; CHECK: getelementptr
+; CHECK-NOT: getelementptr
+define void @test2(ptr addrspace(200) noalias noundef nonnull align 8 captures(none) dereferenceable(8) %self, i32 noundef signext range(i32 1, 4) %data) unnamed_addr addrspace(200) {
+start:
+  %_5 = load ptr addrspace(200), ptr addrspace(200) %self, align 8
+  %0 = ptrtoint ptr addrspace(200) %_5 to i32
+  %_8 = and i32 %0, -4
+  %.neg = sub i32 0, %0
+  %_7 = add i32 %.neg, %data
+  %_0.i = add i32 %_7, %_8
+  %1 = getelementptr i8, ptr addrspace(200) %_5, i32 %_0.i
+  store ptr addrspace(200) %1, ptr addrspace(200) %self, align 8
+  ret void
 }
 
 !llvm.ident = !{!0}


### PR DESCRIPTION
This transformation is potentially unsafe for CHERI, as the reassociated offsetting maybe take the pointer outside of representable bounds, causing a tag violation on dereference. This case is easier to hit on CHERIoT where representable bounds are tighter, but it does affect other CHERI formats as well.
