### PR TITLE
Run PR builds inside the latest CHERIoT devcontainer.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,8 @@ jobs:
   build-and-test:
     name: Build and test PR
     runs-on: "cirun-gcp-aarch64--${{ github.run_id }}"
+    container:
+      image: ghcr.io/cheriot-platform/devcontainer:latest
     timeout-minutes: 360
 
     env:


### PR DESCRIPTION
The goal here is to eventually build CHERIoT RTOS as part of pre-commit tests. This step gets us access to the relevant tools and simulators for that.
