### PR TITLE
Port test/Codegen/Mips/cheri/cheri_case_file_crash.ll

### DIFF
--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/cheri_case_file_crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/cheri_case_file_crash.ll
@@ -1,0 +1,89 @@
+; !DO NOT AUTOGEN!
+; RUN: llc @PURECAP_HARDFLOAT_ARGS@ %s -o /dev/null
+
+declare i32 @__gxx_personality_v0(...) addrspace(200)
+
+declare void @b()
+
+define void @c() personality ptr addrspace(200) @__gxx_personality_v0 {
+  invoke void @d()
+          to label %1 unwind label %4
+
+; <label>:1:                                      ; preds = %0
+  invoke void @e()
+          to label %2 unwind label %4
+
+; <label>:2:                                      ; preds = %1
+  invoke void @f()
+          to label %3 unwind label %4
+
+; <label>:3:                                      ; preds = %2
+  invoke void @g()
+          to label %6 unwind label %14
+
+; <label>:4:                                      ; preds = %2, %1, %0
+  %5 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  resume { ptr addrspace(200), i32 } undef
+
+; <label>:6:                                      ; preds = %3
+  invoke void @g()
+          to label %7 unwind label %14
+
+; <label>:7:                                      ; preds = %6
+  invoke void @g()
+          to label %8 unwind label %14
+
+; <label>:8:                                      ; preds = %7
+  invoke void @g()
+          to label %9 unwind label %14
+
+; <label>:9:                                      ; preds = %8
+  invoke void @g()
+          to label %10 unwind label %14
+
+; <label>:10:                                     ; preds = %9
+  invoke void @g()
+          to label %11 unwind label %14
+
+; <label>:11:                                     ; preds = %10
+  invoke void @g()
+          to label %12 unwind label %14
+
+; <label>:12:                                     ; preds = %11
+  invoke void @h()
+          to label %13 unwind label %14
+
+; <label>:13:                                     ; preds = %12
+  invoke void (ptr addrspace(200), i32, ...) @i(ptr addrspace(200) undef, i32 0)
+          to label %19 unwind label %14
+
+; <label>:14:                                     ; preds = %13, %12, %11, %10, %9, %8, %7, %6, %3
+  %15 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  resume { ptr addrspace(200), i32 } undef
+
+; <label>:16:                                     ; preds = %19
+  %17 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  br label %18
+
+; <label>:18:                                     ; preds = %18, %16
+  br label %18
+
+; <label>:19:                                     ; preds = %19, %13
+  invoke void @b()
+          to label %19 unwind label %16
+}
+
+declare void @i(i8 addrspace(200)*, i32, ...)
+
+declare void @h()
+
+declare void @d()
+
+declare void @e()
+
+declare void @f()
+
+declare void @g()

--- a/llvm/test/CodeGen/CHERI-Generic/MIPS/cheri_case_file_crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/MIPS/cheri_case_file_crash.ll
@@ -1,0 +1,89 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/cheri_case_file_crash.ll
+; RUN: llc -mtriple=mips64 -mcpu=cheri128 -mattr=+cheri128 --relocation-model=pic -target-abi purecap %s -o /dev/null
+
+declare i32 @__gxx_personality_v0(...) addrspace(200)
+
+declare void @b()
+
+define void @c() personality ptr addrspace(200) @__gxx_personality_v0 {
+  invoke void @d()
+          to label %1 unwind label %4
+
+; <label>:1:                                      ; preds = %0
+  invoke void @e()
+          to label %2 unwind label %4
+
+; <label>:2:                                      ; preds = %1
+  invoke void @f()
+          to label %3 unwind label %4
+
+; <label>:3:                                      ; preds = %2
+  invoke void @g()
+          to label %6 unwind label %14
+
+; <label>:4:                                      ; preds = %2, %1, %0
+  %5 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  resume { ptr addrspace(200), i32 } undef
+
+; <label>:6:                                      ; preds = %3
+  invoke void @g()
+          to label %7 unwind label %14
+
+; <label>:7:                                      ; preds = %6
+  invoke void @g()
+          to label %8 unwind label %14
+
+; <label>:8:                                      ; preds = %7
+  invoke void @g()
+          to label %9 unwind label %14
+
+; <label>:9:                                      ; preds = %8
+  invoke void @g()
+          to label %10 unwind label %14
+
+; <label>:10:                                     ; preds = %9
+  invoke void @g()
+          to label %11 unwind label %14
+
+; <label>:11:                                     ; preds = %10
+  invoke void @g()
+          to label %12 unwind label %14
+
+; <label>:12:                                     ; preds = %11
+  invoke void @h()
+          to label %13 unwind label %14
+
+; <label>:13:                                     ; preds = %12
+  invoke void (ptr addrspace(200), i32, ...) @i(ptr addrspace(200) undef, i32 0)
+          to label %19 unwind label %14
+
+; <label>:14:                                     ; preds = %13, %12, %11, %10, %9, %8, %7, %6, %3
+  %15 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  resume { ptr addrspace(200), i32 } undef
+
+; <label>:16:                                     ; preds = %19
+  %17 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  br label %18
+
+; <label>:18:                                     ; preds = %18, %16
+  br label %18
+
+; <label>:19:                                     ; preds = %19, %13
+  invoke void @b()
+          to label %19 unwind label %16
+}
+
+declare void @i(i8 addrspace(200)*, i32, ...)
+
+declare void @h()
+
+declare void @d()
+
+declare void @e()
+
+declare void @f()
+
+declare void @g()

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32/cheri_case_file_crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32/cheri_case_file_crash.ll
@@ -1,0 +1,89 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/cheri_case_file_crash.ll
+; RUN: llc -mtriple=riscv32 --relocation-model=pic -target-abi il32pc64f -mattr=+xcheri,+xcheripurecap,+f %s -o /dev/null
+
+declare i32 @__gxx_personality_v0(...) addrspace(200)
+
+declare void @b()
+
+define void @c() personality ptr addrspace(200) @__gxx_personality_v0 {
+  invoke void @d()
+          to label %1 unwind label %4
+
+; <label>:1:                                      ; preds = %0
+  invoke void @e()
+          to label %2 unwind label %4
+
+; <label>:2:                                      ; preds = %1
+  invoke void @f()
+          to label %3 unwind label %4
+
+; <label>:3:                                      ; preds = %2
+  invoke void @g()
+          to label %6 unwind label %14
+
+; <label>:4:                                      ; preds = %2, %1, %0
+  %5 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  resume { ptr addrspace(200), i32 } undef
+
+; <label>:6:                                      ; preds = %3
+  invoke void @g()
+          to label %7 unwind label %14
+
+; <label>:7:                                      ; preds = %6
+  invoke void @g()
+          to label %8 unwind label %14
+
+; <label>:8:                                      ; preds = %7
+  invoke void @g()
+          to label %9 unwind label %14
+
+; <label>:9:                                      ; preds = %8
+  invoke void @g()
+          to label %10 unwind label %14
+
+; <label>:10:                                     ; preds = %9
+  invoke void @g()
+          to label %11 unwind label %14
+
+; <label>:11:                                     ; preds = %10
+  invoke void @g()
+          to label %12 unwind label %14
+
+; <label>:12:                                     ; preds = %11
+  invoke void @h()
+          to label %13 unwind label %14
+
+; <label>:13:                                     ; preds = %12
+  invoke void (ptr addrspace(200), i32, ...) @i(ptr addrspace(200) undef, i32 0)
+          to label %19 unwind label %14
+
+; <label>:14:                                     ; preds = %13, %12, %11, %10, %9, %8, %7, %6, %3
+  %15 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  resume { ptr addrspace(200), i32 } undef
+
+; <label>:16:                                     ; preds = %19
+  %17 = landingpad { ptr addrspace(200), i32 }
+          cleanup
+  br label %18
+
+; <label>:18:                                     ; preds = %18, %16
+  br label %18
+
+; <label>:19:                                     ; preds = %19, %13
+  invoke void @b()
+          to label %19 unwind label %16
+}
+
+declare void @i(i8 addrspace(200)*, i32, ...)
+
+declare void @h()
+
+declare void @d()
+
+declare void @e()
+
+declare void @f()
+
+declare void @g()

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64/cheri_case_file_crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64/cheri_case_file_crash.ll
@@ -1,7 +1,5 @@
-; RUN: %cheri_purecap_llc -cheri-cap-table-abi=pcrel %s -o /dev/null
-; ModuleID = '<stdin>'
-source_filename = "bugpoint-output-4bb8cd9.bc"
-target triple = "cheri-unknown-freebsd"
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/cheri_case_file_crash.ll
+; RUN: llc -mtriple=riscv64 --relocation-model=pic -target-abi l64pc128d -mattr=+xcheri,+xcheripurecap,+f,+d %s -o /dev/null
 
 declare i32 @__gxx_personality_v0(...) addrspace(200)
 


### PR DESCRIPTION
The test is a crash-only regression test (no CHECK lines)
on exception-handling IR: nested invoke chain, nine invokes
sharing one landingpad, `resume undef`, a self-looping block.

Moved to CHERI-Generic/ to get RISC-V coverage.

Added `!DO NOT AUTOGEN!` since it's a crash-only test (assertions
are not needed). The same marker is used by other crash-only tests
(e.g. global-capinit-hybrid.ll).
