### PR TITLE
Port test/Codegen/Mips/cheri/libcxx-do-not-optimize-crash.ll

### DIFF
--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/libcxx-do-not-optimize-crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/libcxx-do-not-optimize-crash.ll
@@ -1,0 +1,13 @@
+; !DO NOT AUTOGEN!
+; RUN: not llc @PURECAP_HARDFLOAT_ARGS@ -verify-machineinstrs %s 2>&1 | FileCheck %s -check-prefix=ERR
+; ERR: error: couldn't allocate output register for constraint 'C'
+; Check that this results in an error instead of a crash
+
+$_Z13DoNotOptimizeIbEvRT_ = comdat any
+
+; Function Attrs: noinline nounwind optnone
+define void @_Z13DoNotOptimizeIbEvRT_() addrspace(200) #0 comdat {
+entry:
+  %0 = call i8 asm sideeffect "", "=C,0,~{memory},~{$1}"(i1 undef) #1
+  ret void
+}

--- a/llvm/test/CodeGen/CHERI-Generic/MIPS/libcxx-do-not-optimize-crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/MIPS/libcxx-do-not-optimize-crash.ll
@@ -1,0 +1,13 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/libcxx-do-not-optimize-crash.ll
+; RUN: not llc -mtriple=mips64 -mcpu=cheri128 -mattr=+cheri128 --relocation-model=pic -target-abi purecap -verify-machineinstrs %s 2>&1 | FileCheck %s -check-prefix=ERR
+; ERR: error: couldn't allocate output register for constraint 'C'
+; Check that this results in an error instead of a crash
+
+$_Z13DoNotOptimizeIbEvRT_ = comdat any
+
+; Function Attrs: noinline nounwind optnone
+define void @_Z13DoNotOptimizeIbEvRT_() addrspace(200) #0 comdat {
+entry:
+  %0 = call i8 asm sideeffect "", "=C,0,~{memory},~{$1}"(i1 undef) #1
+  ret void
+}

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32/libcxx-do-not-optimize-crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32/libcxx-do-not-optimize-crash.ll
@@ -1,4 +1,5 @@
-; RUN: not %cheri_purecap_llc -verify-machineinstrs %s 2>&1 | FileCheck %s -check-prefix=ERR
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/libcxx-do-not-optimize-crash.ll
+; RUN: not llc -mtriple=riscv32 --relocation-model=pic -target-abi il32pc64f -mattr=+xcheri,+xcheripurecap,+f -verify-machineinstrs %s 2>&1 | FileCheck %s -check-prefix=ERR
 ; ERR: error: couldn't allocate output register for constraint 'C'
 ; Check that this results in an error instead of a crash
 

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64/libcxx-do-not-optimize-crash.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64/libcxx-do-not-optimize-crash.ll
@@ -1,0 +1,13 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/libcxx-do-not-optimize-crash.ll
+; RUN: not llc -mtriple=riscv64 --relocation-model=pic -target-abi l64pc128d -mattr=+xcheri,+xcheripurecap,+f,+d -verify-machineinstrs %s 2>&1 | FileCheck %s -check-prefix=ERR
+; ERR: error: couldn't allocate output register for constraint 'C'
+; Check that this results in an error instead of a crash
+
+$_Z13DoNotOptimizeIbEvRT_ = comdat any
+
+; Function Attrs: noinline nounwind optnone
+define void @_Z13DoNotOptimizeIbEvRT_() addrspace(200) #0 comdat {
+entry:
+  %0 = call i8 asm sideeffect "", "=C,0,~{memory},~{$1}"(i1 undef) #1
+  ret void
+}


### PR DESCRIPTION
This test checks that invalid CHERI inline asm (a capability output
constraint (`=C`) tied to a non-capability i1 input) produces a clean
diagnostic instead of crashing the compiler.

The test was introduced in be3700db4289. The diagnostic
"couldn't allocate output register for constraint 'C'" is emitted from
target-independent SelectionDAGBuilder.cpp, so the scenario is generic.

Ported to CHERI-Generic as a purecap-only, `!DO NOT AUTOGEN!` test,
added `-verify-machineinstrs` explicitly since `@PURECAP_HARDFLOAT_ARGS@`
does not have it.
