### PR TITLE
Remove test/MC/Mips/cheri/elf_eflags_cheri.s

### DIFF
--- a/llvm/test/MC/Mips/cheri/elf_eflags_cheri.s
+++ b/llvm/test/MC/Mips/cheri/elf_eflags_cheri.s
@@ -1,6 +1,0 @@
-# RUN: llvm-mc -triple=mips64-unknown-freebsd -mcpu=cheri128 -filetype=obj %s -o - | llvm-readobj -h - | FileCheck --check-prefix=CHERI128-NO-ABI %s
-# CHERI128-NO-ABI: Flags [ (0x30C10004)
-# RUN: llvm-mc -triple=mips64-unknown-freebsd -mcpu=cheri128 -filetype=obj -target-abi n64 %s -o - | llvm-readobj -h - | FileCheck --check-prefix=CHERI128-N64 %s
-# CHERI128-N64: Flags [ (0x30C10004)
-# RUN: llvm-mc -triple=mips64-unknown-freebsd -mcpu=cheri128 -position-independent -filetype=obj -target-abi purecap %s -o - | llvm-readobj -h - | FileCheck --check-prefix=CHERI128-PURECAP %s
-# CHERI128-PURECAP: Flags [ (0x30C1C006)


### PR DESCRIPTION
This MC test asserts MIPS+CHERI128 ELF `e_flags` via llvm-mc.

The general scenario of this test is covered on RISC-V by
test/CodeGen/RISCV/cheri/cheriot-elf-flags.ll. On RISC-V these flags have
no assembler-time freedom - llvm-mc and llc both run
`RISCVELFStreamer::emitTargetAttributes` - so an MC test only re-runs
the path already covered in codegen.
