### PR TITLE
Bump __CHERIOT__ and __CHERIOT_BAREMETAL__ versions

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -316,9 +316,9 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
 
     // Macros for CHERIoT in the default and bare-metal ABIs.
     if (ABI == "cheriot" || ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT__", "20260429");
+      Builder.defineMacro("__CHERIOT__", "20260806");
     if (ABI == "cheriot-baremetal")
-      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20260429");
+      Builder.defineMacro("__CHERIOT_BAREMETAL__", "20260806");
 
     Builder.defineMacro("__riscv_clen", Twine(getCHERICapabilityWidth()));
     // TODO: _MIPS_CAP_ALIGN_MASK equivalent?

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -391,8 +391,8 @@
 // Check for CHERIoT-specific defines
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot" -E -dM < /dev/null | FileCheck -check-prefix CHERIOT %s
 // RUN: %clang_cc1 %s -o - "-triple" "riscv32-unknown-unknown" "-mframe-pointer=none" "-mcmodel=small" "-target-cpu" "cheriot" "-target-feature" "+xcheri" "-target-feature" "-64bit" "-target-feature" "-relax" "-target-feature" "-xcheri-rvc" "-target-feature" "-save-restore" "-target-abi" "cheriot-baremetal" -E -dM < /dev/null | FileCheck -check-prefixes CHERIOT,CHERIOT-BAREMETAL %s
-// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20260429
-// CHERIOT: #define __CHERIOT__ 20260429
+// CHERIOT-BAREMETAL: #define __CHERIOT_BAREMETAL__ 20260806
+// CHERIOT: #define __CHERIOT__ 20260806
 
 
 // RUN: %cheri128_cc1 -fgnuc-version=4.2.1 -E -dM -ffreestanding < /dev/null | FileCheck -check-prefixes CHERI-COMMON,CHERI-MIPS,CHERI128 %s


### PR DESCRIPTION
We want to be able to gate usage of the `cheriot_sealed` attribute.