### PR TITLE
Port test/CodeGen/Mips/cheri/load-store-unaligned.ll

### DIFF
--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/load-store-unaligned.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/load-store-unaligned.ll
@@ -1,0 +1,59 @@
+; !DO NOT AUTOGEN!
+; Check that expanding unaligned capability loads and stores works (but generates a warning)
+; RUN: rm -f %t.dbg
+; RUN: llc @PURECAP_HARDFLOAT_ARGS@ -verify-machineinstrs %s -o /dev/null -collect-csetbounds-stats=csv 2>%t.dbg
+; RUN: FileCheck %s -input-file=%t.dbg -check-prefix=DBG
+
+define ptr addrspace(200) @load_unaligned(ptr addrspace(200) %unaligned) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  %r.0.copyload = load ptr addrspace(200), ptr addrspace(200) %r.0..sroa_cast, align 4
+  ret ptr addrspace(200) %r.0.copyload
+}
+
+define void @store_unaligned(ptr addrspace(200) %unused, ptr addrspace(200) %unaligned, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  store ptr addrspace(200) %value, ptr addrspace(200) %r.0..sroa_cast, align 4, !dbg !11
+  ret void
+}
+
+; This should be turned into a memmove:
+define void @store_of_unaligned_load(ptr addrspace(200) %src, ptr addrspace(200) %dest, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %src_cast = bitcast ptr addrspace(200) %src to ptr addrspace(200)
+  %dest_cast = bitcast ptr addrspace(200) %dest to ptr addrspace(200)
+  %unaligned_load = load ptr addrspace(200), ptr addrspace(200) %src_cast, align 4
+  store ptr addrspace(200) %unaligned_load, ptr addrspace(200) %dest_cast, align 8
+  ret void
+}
+
+declare ptr addrspace(200) @llvm.cheri.cap.offset.set.i64(ptr addrspace(200), i64) addrspace(200)
+
+declare i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200)) addrspace(200)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !8, isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/some/dir")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "store_unaligned", scope: !8, file: !8, line: 7, scopeLine: 7, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!8 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/foo")
+!11 = !DILocation(line: 9, column: 3, scope: !7)
+
+; DBG: warning: <unknown>:0:0: in function load_unaligned ptr addrspace(200) (ptr addrspace(200)): found underaligned load of capability type (aligned to 4 bytes instead of @CAP_BYTES@). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: sroa-libunwind.cxx:9:3: in function store_unaligned void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of capability type (aligned to 4 bytes instead of @CAP_BYTES@). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+@IFNOT-RISCV32@; DBG-NEXT: warning: <unknown>:0:0: in function store_of_unaligned_load void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of underaligned load of capability type (aligned to 8 bytes instead of @CAP_BYTES@). Will use memmove() to preserve tags if it is aligned correctly at runtime
+@IF-RISCV32@; DBG-NEXT: warning: <unknown>:0:0: in function store_of_unaligned_load void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned load of capability type (aligned to 4 bytes instead of @CAP_BYTES@). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load stack destination"
+; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load memcpy source"
+; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store stack source"
+; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store memcpy destination"
+@IFNOT-RISCV32@; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability store+load memmove src"
+@IFNOT-RISCV32@; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability store+load memmove dest"
+@IF-RISCV32@; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability load stack destination"
+@IF-RISCV32@; DBG-NEXT: @CAP_BYTES_P2@,@CAP_BYTES@,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability load memcpy source"
+; DBG-EMPTY:

--- a/llvm/test/CodeGen/CHERI-Generic/MIPS/load-store-unaligned.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/MIPS/load-store-unaligned.ll
@@ -1,0 +1,56 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/load-store-unaligned.ll
+; Check that expanding unaligned capability loads and stores works (but generates a warning)
+; RUN: rm -f %t.dbg
+; RUN: llc -mtriple=mips64 -mcpu=cheri128 -mattr=+cheri128 --relocation-model=pic -target-abi purecap -verify-machineinstrs %s -o /dev/null -collect-csetbounds-stats=csv 2>%t.dbg
+; RUN: FileCheck %s -input-file=%t.dbg -check-prefix=DBG
+
+define ptr addrspace(200) @load_unaligned(ptr addrspace(200) %unaligned) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  %r.0.copyload = load ptr addrspace(200), ptr addrspace(200) %r.0..sroa_cast, align 4
+  ret ptr addrspace(200) %r.0.copyload
+}
+
+define void @store_unaligned(ptr addrspace(200) %unused, ptr addrspace(200) %unaligned, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  store ptr addrspace(200) %value, ptr addrspace(200) %r.0..sroa_cast, align 4, !dbg !11
+  ret void
+}
+
+; This should be turned into a memmove:
+define void @store_of_unaligned_load(ptr addrspace(200) %src, ptr addrspace(200) %dest, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %src_cast = bitcast ptr addrspace(200) %src to ptr addrspace(200)
+  %dest_cast = bitcast ptr addrspace(200) %dest to ptr addrspace(200)
+  %unaligned_load = load ptr addrspace(200), ptr addrspace(200) %src_cast, align 4
+  store ptr addrspace(200) %unaligned_load, ptr addrspace(200) %dest_cast, align 8
+  ret void
+}
+
+declare ptr addrspace(200) @llvm.cheri.cap.offset.set.i64(ptr addrspace(200), i64) addrspace(200)
+
+declare i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200)) addrspace(200)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !8, isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/some/dir")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "store_unaligned", scope: !8, file: !8, line: 7, scopeLine: 7, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!8 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/foo")
+!11 = !DILocation(line: 9, column: 3, scope: !7)
+
+; DBG: warning: <unknown>:0:0: in function load_unaligned ptr addrspace(200) (ptr addrspace(200)): found underaligned load of capability type (aligned to 4 bytes instead of 16). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: sroa-libunwind.cxx:9:3: in function store_unaligned void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of capability type (aligned to 4 bytes instead of 16). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: <unknown>:0:0: in function store_of_unaligned_load void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of underaligned load of capability type (aligned to 8 bytes instead of 16). Will use memmove() to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: 4,16,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load stack destination"
+; DBG-NEXT: 4,16,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load memcpy source"
+; DBG-NEXT: 4,16,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store stack source"
+; DBG-NEXT: 4,16,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store memcpy destination"
+; DBG-NEXT: 4,16,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability store+load memmove src"
+; DBG-NEXT: 4,16,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability store+load memmove dest"
+; DBG-EMPTY:

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32/load-store-unaligned.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32/load-store-unaligned.ll
@@ -1,0 +1,56 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/load-store-unaligned.ll
+; Check that expanding unaligned capability loads and stores works (but generates a warning)
+; RUN: rm -f %t.dbg
+; RUN: llc -mtriple=riscv32 --relocation-model=pic -target-abi il32pc64f -mattr=+xcheri,+xcheripurecap,+f -verify-machineinstrs %s -o /dev/null -collect-csetbounds-stats=csv 2>%t.dbg
+; RUN: FileCheck %s -input-file=%t.dbg -check-prefix=DBG
+
+define ptr addrspace(200) @load_unaligned(ptr addrspace(200) %unaligned) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  %r.0.copyload = load ptr addrspace(200), ptr addrspace(200) %r.0..sroa_cast, align 4
+  ret ptr addrspace(200) %r.0.copyload
+}
+
+define void @store_unaligned(ptr addrspace(200) %unused, ptr addrspace(200) %unaligned, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  store ptr addrspace(200) %value, ptr addrspace(200) %r.0..sroa_cast, align 4, !dbg !11
+  ret void
+}
+
+; This should be turned into a memmove:
+define void @store_of_unaligned_load(ptr addrspace(200) %src, ptr addrspace(200) %dest, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %src_cast = bitcast ptr addrspace(200) %src to ptr addrspace(200)
+  %dest_cast = bitcast ptr addrspace(200) %dest to ptr addrspace(200)
+  %unaligned_load = load ptr addrspace(200), ptr addrspace(200) %src_cast, align 4
+  store ptr addrspace(200) %unaligned_load, ptr addrspace(200) %dest_cast, align 8
+  ret void
+}
+
+declare ptr addrspace(200) @llvm.cheri.cap.offset.set.i64(ptr addrspace(200), i64) addrspace(200)
+
+declare i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200)) addrspace(200)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !8, isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/some/dir")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "store_unaligned", scope: !8, file: !8, line: 7, scopeLine: 7, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!8 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/foo")
+!11 = !DILocation(line: 9, column: 3, scope: !7)
+
+; DBG: warning: <unknown>:0:0: in function load_unaligned ptr addrspace(200) (ptr addrspace(200)): found underaligned load of capability type (aligned to 4 bytes instead of 8). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: sroa-libunwind.cxx:9:3: in function store_unaligned void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of capability type (aligned to 4 bytes instead of 8). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: <unknown>:0:0: in function store_of_unaligned_load void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned load of capability type (aligned to 4 bytes instead of 8). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: 3,8,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load stack destination"
+; DBG-NEXT: 3,8,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load memcpy source"
+; DBG-NEXT: 3,8,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store stack source"
+; DBG-NEXT: 3,8,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store memcpy destination"
+; DBG-NEXT: 3,8,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability load stack destination"
+; DBG-NEXT: 3,8,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability load memcpy source"
+; DBG-EMPTY:

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64/load-store-unaligned.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64/load-store-unaligned.ll
@@ -1,0 +1,56 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/load-store-unaligned.ll
+; Check that expanding unaligned capability loads and stores works (but generates a warning)
+; RUN: rm -f %t.dbg
+; RUN: llc -mtriple=riscv64 --relocation-model=pic -target-abi l64pc128d -mattr=+xcheri,+xcheripurecap,+f,+d -verify-machineinstrs %s -o /dev/null -collect-csetbounds-stats=csv 2>%t.dbg
+; RUN: FileCheck %s -input-file=%t.dbg -check-prefix=DBG
+
+define ptr addrspace(200) @load_unaligned(ptr addrspace(200) %unaligned) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  %r.0.copyload = load ptr addrspace(200), ptr addrspace(200) %r.0..sroa_cast, align 4
+  ret ptr addrspace(200) %r.0.copyload
+}
+
+define void @store_unaligned(ptr addrspace(200) %unused, ptr addrspace(200) %unaligned, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %r.0..sroa_cast = bitcast ptr addrspace(200) %unaligned to ptr addrspace(200)
+  store ptr addrspace(200) %value, ptr addrspace(200) %r.0..sroa_cast, align 4, !dbg !11
+  ret void
+}
+
+; This should be turned into a memmove:
+define void @store_of_unaligned_load(ptr addrspace(200) %src, ptr addrspace(200) %dest, ptr addrspace(200) %value) local_unnamed_addr addrspace(200) nounwind {
+entry:
+  %src_cast = bitcast ptr addrspace(200) %src to ptr addrspace(200)
+  %dest_cast = bitcast ptr addrspace(200) %dest to ptr addrspace(200)
+  %unaligned_load = load ptr addrspace(200), ptr addrspace(200) %src_cast, align 4
+  store ptr addrspace(200) %unaligned_load, ptr addrspace(200) %dest_cast, align 8
+  ret void
+}
+
+declare ptr addrspace(200) @llvm.cheri.cap.offset.set.i64(ptr addrspace(200), i64) addrspace(200)
+
+declare i64 @llvm.cheri.cap.offset.get.i64(ptr addrspace(200)) addrspace(200)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !8, isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/some/dir")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "store_unaligned", scope: !8, file: !8, line: 7, scopeLine: 7, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!8 = !DIFile(filename: "sroa-libunwind.cxx", directory: "/foo")
+!11 = !DILocation(line: 9, column: 3, scope: !7)
+
+; DBG: warning: <unknown>:0:0: in function load_unaligned ptr addrspace(200) (ptr addrspace(200)): found underaligned load of capability type (aligned to 4 bytes instead of 16). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: sroa-libunwind.cxx:9:3: in function store_unaligned void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of capability type (aligned to 4 bytes instead of 16). Will use memcpy() instead of capability load to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: warning: <unknown>:0:0: in function store_of_unaligned_load void (ptr addrspace(200), ptr addrspace(200), ptr addrspace(200)): found underaligned store of underaligned load of capability type (aligned to 8 bytes instead of 16). Will use memmove() to preserve tags if it is aligned correctly at runtime
+; DBG-NEXT: 4,16,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load stack destination"
+; DBG-NEXT: 4,16,s,"<somewhere in load_unaligned>","expanding unaligned capability load/store","expanding unaligned capability load memcpy source"
+; DBG-NEXT: 4,16,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store stack source"
+; DBG-NEXT: 4,16,s,"sroa-libunwind.cxx:9:3","expanding unaligned capability load/store","expanding unaligned capability store memcpy destination"
+; DBG-NEXT: 4,16,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability store+load memmove src"
+; DBG-NEXT: 4,16,s,"<somewhere in store_of_unaligned_load>","expanding unaligned capability load/store","expanding unaligned capability store+load memmove dest"
+; DBG-EMPTY:


### PR DESCRIPTION
This test checks the underaligned-capability load/store expansion: a
cap load/store through an under-aligned pointer is expanded to
memcpy/memmove (with a warning + a csetbounds-stats CSV row) so tags
survive if the pointer is aligned at runtime. The expansion is in
target-independent SelectionDAG code, so it runs on every CHERI
backend.

The store path is also covered by the ported memcpy-unaligned.ll test,
but the load->memcpy and store-of-load->memmove paths are not covered
by any test on RISC-V.

Ported to CHERI-Generic as a DBG/CSV-only test. It asserts only the
expansion trigger (the warnings + csetbounds-stats CSV rows), but not
the resulting asm. The memcpy/memmove call asm is already covered by
memcpy-unaligned.ll, and the csetbounds-before-the-call is already
recorded in the CSV.

I've ran into an issue when trying to enable autogen: the IR's debug
metadata (needed for the source location in the `store_unaligned`
warning) makes the MIPS function asm unmatchable by
update_llc_test_checks.
