### PR TITLE
Port test/Codegen/Mips/cheri/memcpy-nobuiltin.ll

### DIFF
--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/memcpy-nobuiltin.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/memcpy-nobuiltin.ll
@@ -1,0 +1,141 @@
+; !DO NOT AUTOGEN!
+; Check that llvm.memcpy() and llvm.memmove() intrinisics with must_preserve_cheri_tags
+; attribute are always lowered to libcalls
+; RUN: llc @PURECAP_HARDFLOAT_ARGS@ -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,PURECAP
+; RUN: llc @HYBRID_HARDFLOAT_ARGS@ -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,HYBRID
+
+declare void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) noalias nocapture writeonly, ptr addrspace(200) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memmove.p200.p200.i64(ptr addrspace(200) nocapture writeonly, ptr addrspace(200) nocapture readonly, i64, i1 immarg)
+
+define void @memcpy_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 2048, i1 false)
+  ret void
+  ; CHECK-LABEL: memcpy_too_big_unaligned:
+@IF-MIPS@  ; PURECAP: clcbi $c12, %capcall20(memcpy)
+@IF-MIPS@  ; HYBRID: ld $25, %call16(memcpy_c)($gp)
+@IF-RISCV@  ; PURECAP: ccall memcpy
+@IF-RISCV@  ; HYBRID: call memcpy_c
+}
+
+define void @memcpy_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align @CAP_BYTES@ %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 @CAP_BYTES@, i1 false)
+  ret void
+  ; This can be inlined;
+  ; CHECK-LABEL: memcpy_aligned:
+@IF-MIPS@  ; CHECK: # %bb.0:
+@IF-MIPS@  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+@IF-MIPS@  ; PURECAP-NEXT: cjr $c17
+@IF-MIPS@  ; HYBRID-NEXT: jr $ra
+@IF-MIPS@  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+@IF-RISCV@  ; PURECAP: # %bb.0:
+@IF-RISCV@  ; PURECAP-NEXT: clc a1, 0(a1)
+@IF-RISCV@  ; PURECAP-NEXT: csc a1, 0(a0)
+@IF-RISCV@  ; PURECAP-NEXT: cret
+@IF-RISCV@  ; HYBRID: # %bb.0:
+@IF-RISCV@  ; HYBRID-NEXT: lc.cap a1, (a1)
+@IF-RISCV@  ; HYBRID-NEXT: sc.cap a1, (a0)
+@IF-RISCV@  ; HYBRID-NEXT: ret
+}
+
+define void @memcpy_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align @CAP_BYTES@ %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 @CAP_BYTES@, i1 false) must_preserve_cheri_tags
+  ret void
+  ; Correctly aligned -> no need for libcall (even with attribute)
+  ; CHECK-LABEL: memcpy_aligned_must_preserve_tags:
+@IF-MIPS@  ; CHECK: # %bb.0:
+@IF-MIPS@  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+@IF-MIPS@  ; PURECAP-NEXT: cjr $c17
+@IF-MIPS@  ; HYBRID-NEXT: jr $ra
+@IF-MIPS@  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+@IF-RISCV@  ; PURECAP: # %bb.0:
+@IF-RISCV@  ; PURECAP-NEXT: clc a1, 0(a1)
+@IF-RISCV@  ; PURECAP-NEXT: csc a1, 0(a0)
+@IF-RISCV@  ; PURECAP-NEXT: cret
+@IF-RISCV@  ; HYBRID: # %bb.0:
+@IF-RISCV@  ; HYBRID-NEXT: lc.cap a1, (a1)
+@IF-RISCV@  ; HYBRID-NEXT: sc.cap a1, (a0)
+@IF-RISCV@  ; HYBRID-NEXT: ret
+}
+
+define void @memcpy_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align @CAP_RANGE_BYTES@ %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 @CAP_BYTES@, i1 false) must_preserve_cheri_tags
+  ret void
+  ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
+  ; CHECK-LABEL: memcpy_underaligned_must_preserve_tags:
+@IF-MIPS@  ; PURECAP: clcbi $c12, %capcall20(memcpy)
+@IF-MIPS@  ; HYBRID: ld $25, %call16(memcpy_c)($gp)
+@IF-RISCV@  ; PURECAP: ccall memcpy
+@IF-RISCV@  ; HYBRID: call memcpy_c
+}
+
+
+; Same again in hybrid:
+
+define void @memmove_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 2048, i1 false)
+  ret void
+  ; CHECK-LABEL: memmove_too_big_unaligned:
+@IF-MIPS@  ; PURECAP: clcbi $c12, %capcall20(memmove)
+@IF-MIPS@  ; HYBRID: ld $25, %call16(memmove_c)($gp)
+@IF-RISCV@  ; PURECAP: ccall memmove
+@IF-RISCV@  ; HYBRID: call memmove_c
+}
+
+define void @memmove_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align @CAP_BYTES@ %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 @CAP_BYTES@, i1 false)
+  ret void
+  ; This can be inlined;
+  ; CHECK-LABEL: memmove_aligned:
+@IF-MIPS@  ; CHECK: # %bb.0:
+@IF-MIPS@  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+@IF-MIPS@  ; PURECAP-NEXT: cjr $c17
+@IF-MIPS@  ; HYBRID-NEXT: jr $ra
+@IF-MIPS@  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+@IF-RISCV@  ; PURECAP: # %bb.0:
+@IF-RISCV@  ; PURECAP-NEXT: clc a1, 0(a1)
+@IF-RISCV@  ; PURECAP-NEXT: csc a1, 0(a0)
+@IF-RISCV@  ; PURECAP-NEXT: cret
+@IF-RISCV@  ; HYBRID: # %bb.0:
+@IF-RISCV@  ; HYBRID-NEXT: lc.cap a1, (a1)
+@IF-RISCV@  ; HYBRID-NEXT: sc.cap a1, (a0)
+@IF-RISCV@  ; HYBRID-NEXT: ret
+}
+
+define void @memmove_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align @CAP_RANGE_BYTES@ %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 @CAP_BYTES@, i1 false) must_preserve_cheri_tags
+  ret void
+  ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
+  ; CHECK-LABEL: memmove_underaligned_must_preserve_tags:
+@IF-MIPS@  ; PURECAP: clcbi $c12, %capcall20(memmove)
+@IF-MIPS@  ; HYBRID: ld $25, %call16(memmove_c)($gp)
+@IF-RISCV@  ; PURECAP: ccall memmove
+@IF-RISCV@  ; HYBRID: call memmove_c
+}
+
+define void @memmove_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align @CAP_BYTES@ %dst, ptr addrspace(200) align @CAP_BYTES@ %src, i64 @CAP_BYTES@, i1 false) must_preserve_cheri_tags
+  ret void
+  ; Correctly aligned -> no need for libcall (even with attribute)
+  ; CHECK-LABEL: memmove_aligned_must_preserve_tags:
+@IF-MIPS@  ; CHECK: # %bb.0:
+@IF-MIPS@  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+@IF-MIPS@  ; PURECAP-NEXT: cjr $c17
+@IF-MIPS@  ; HYBRID-NEXT: jr $ra
+@IF-MIPS@  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+@IF-RISCV@  ; PURECAP: # %bb.0:
+@IF-RISCV@  ; PURECAP-NEXT: clc a1, 0(a1)
+@IF-RISCV@  ; PURECAP-NEXT: csc a1, 0(a0)
+@IF-RISCV@  ; PURECAP-NEXT: cret
+@IF-RISCV@  ; HYBRID: # %bb.0:
+@IF-RISCV@  ; HYBRID-NEXT: lc.cap a1, (a1)
+@IF-RISCV@  ; HYBRID-NEXT: sc.cap a1, (a0)
+@IF-RISCV@  ; HYBRID-NEXT: ret
+}

--- a/llvm/test/CodeGen/CHERI-Generic/MIPS/memcpy-nobuiltin.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/MIPS/memcpy-nobuiltin.ll
@@ -1,0 +1,101 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/memcpy-nobuiltin.ll
+; Check that llvm.memcpy() and llvm.memmove() intrinisics with must_preserve_cheri_tags
+; attribute are always lowered to libcalls
+; RUN: llc -mtriple=mips64 -mcpu=cheri128 -mattr=+cheri128 --relocation-model=pic -target-abi purecap -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,PURECAP
+; RUN: llc -mtriple=mips64 -mcpu=cheri128 -mattr=+cheri128 --relocation-model=pic -target-abi n64 -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,HYBRID
+
+declare void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) noalias nocapture writeonly, ptr addrspace(200) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memmove.p200.p200.i64(ptr addrspace(200) nocapture writeonly, ptr addrspace(200) nocapture readonly, i64, i1 immarg)
+
+define void @memcpy_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align 16 %src, i64 2048, i1 false)
+  ret void
+  ; CHECK-LABEL: memcpy_too_big_unaligned:
+  ; PURECAP: clcbi $c12, %capcall20(memcpy)
+  ; HYBRID: ld $25, %call16(memcpy_c)($gp)
+}
+
+define void @memcpy_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false)
+  ret void
+  ; This can be inlined;
+  ; CHECK-LABEL: memcpy_aligned:
+  ; CHECK: # %bb.0:
+  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+  ; PURECAP-NEXT: cjr $c17
+  ; HYBRID-NEXT: jr $ra
+  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+}
+
+define void @memcpy_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
+  ret void
+  ; Correctly aligned -> no need for libcall (even with attribute)
+  ; CHECK-LABEL: memcpy_aligned_must_preserve_tags:
+  ; CHECK: # %bb.0:
+  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+  ; PURECAP-NEXT: cjr $c17
+  ; HYBRID-NEXT: jr $ra
+  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+}
+
+define void @memcpy_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
+  ret void
+  ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
+  ; CHECK-LABEL: memcpy_underaligned_must_preserve_tags:
+  ; PURECAP: clcbi $c12, %capcall20(memcpy)
+  ; HYBRID: ld $25, %call16(memcpy_c)($gp)
+}
+
+
+; Same again in hybrid:
+
+define void @memmove_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align 16 %src, i64 2048, i1 false)
+  ret void
+  ; CHECK-LABEL: memmove_too_big_unaligned:
+  ; PURECAP: clcbi $c12, %capcall20(memmove)
+  ; HYBRID: ld $25, %call16(memmove_c)($gp)
+}
+
+define void @memmove_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false)
+  ret void
+  ; This can be inlined;
+  ; CHECK-LABEL: memmove_aligned:
+  ; CHECK: # %bb.0:
+  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+  ; PURECAP-NEXT: cjr $c17
+  ; HYBRID-NEXT: jr $ra
+  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+}
+
+define void @memmove_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
+  ret void
+  ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
+  ; CHECK-LABEL: memmove_underaligned_must_preserve_tags:
+  ; PURECAP: clcbi $c12, %capcall20(memmove)
+  ; HYBRID: ld $25, %call16(memmove_c)($gp)
+}
+
+define void @memmove_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
+  ret void
+  ; Correctly aligned -> no need for libcall (even with attribute)
+  ; CHECK-LABEL: memmove_aligned_must_preserve_tags:
+  ; CHECK: # %bb.0:
+  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
+  ; PURECAP-NEXT: cjr $c17
+  ; HYBRID-NEXT: jr $ra
+  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+}

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32/memcpy-nobuiltin.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32/memcpy-nobuiltin.ll
@@ -1,0 +1,113 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/memcpy-nobuiltin.ll
+; Check that llvm.memcpy() and llvm.memmove() intrinisics with must_preserve_cheri_tags
+; attribute are always lowered to libcalls
+; RUN: llc -mtriple=riscv32 --relocation-model=pic -target-abi il32pc64f -mattr=+xcheri,+xcheripurecap,+f -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,PURECAP
+; RUN: llc -mtriple=riscv32 --relocation-model=pic -target-abi ilp32f -mattr=+xcheri,+f -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,HYBRID
+
+declare void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) noalias nocapture writeonly, ptr addrspace(200) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memmove.p200.p200.i64(ptr addrspace(200) nocapture writeonly, ptr addrspace(200) nocapture readonly, i64, i1 immarg)
+
+define void @memcpy_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align 8 %src, i64 2048, i1 false)
+  ret void
+  ; CHECK-LABEL: memcpy_too_big_unaligned:
+  ; PURECAP: ccall memcpy
+  ; HYBRID: call memcpy_c
+}
+
+define void @memcpy_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 8 %src, i64 8, i1 false)
+  ret void
+  ; This can be inlined;
+  ; CHECK-LABEL: memcpy_aligned:
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
+}
+
+define void @memcpy_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 8 %src, i64 8, i1 false) must_preserve_cheri_tags
+  ret void
+  ; Correctly aligned -> no need for libcall (even with attribute)
+  ; CHECK-LABEL: memcpy_aligned_must_preserve_tags:
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
+}
+
+define void @memcpy_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 4 %dst, ptr addrspace(200) align 8 %src, i64 8, i1 false) must_preserve_cheri_tags
+  ret void
+  ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
+  ; CHECK-LABEL: memcpy_underaligned_must_preserve_tags:
+  ; PURECAP: ccall memcpy
+  ; HYBRID: call memcpy_c
+}
+
+
+; Same again in hybrid:
+
+define void @memmove_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align 8 %src, i64 2048, i1 false)
+  ret void
+  ; CHECK-LABEL: memmove_too_big_unaligned:
+  ; PURECAP: ccall memmove
+  ; HYBRID: call memmove_c
+}
+
+define void @memmove_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 8 %src, i64 8, i1 false)
+  ret void
+  ; This can be inlined;
+  ; CHECK-LABEL: memmove_aligned:
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
+}
+
+define void @memmove_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 4 %dst, ptr addrspace(200) align 8 %src, i64 8, i1 false) must_preserve_cheri_tags
+  ret void
+  ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
+  ; CHECK-LABEL: memmove_underaligned_must_preserve_tags:
+  ; PURECAP: ccall memmove
+  ; HYBRID: call memmove_c
+}
+
+define void @memmove_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
+entry:
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 8 %src, i64 8, i1 false) must_preserve_cheri_tags
+  ret void
+  ; Correctly aligned -> no need for libcall (even with attribute)
+  ; CHECK-LABEL: memmove_aligned_must_preserve_tags:
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
+}

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64/memcpy-nobuiltin.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64/memcpy-nobuiltin.ll
@@ -1,18 +1,19 @@
+; DO NOT EDIT -- This file was generated from test/CodeGen/CHERI-Generic/Inputs/memcpy-nobuiltin.ll
 ; Check that llvm.memcpy() and llvm.memmove() intrinisics with must_preserve_cheri_tags
 ; attribute are always lowered to libcalls
-; RUN: %cheri128_purecap_llc %s -o - | FileCheck %s -check-prefixes=CHECK,PURECAP
-; RUN: %cheri128_llc %s -o - | FileCheck %s -check-prefixes=CHECK,HYBRID
+; RUN: llc -mtriple=riscv64 --relocation-model=pic -target-abi l64pc128d -mattr=+xcheri,+xcheripurecap,+f,+d -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,PURECAP
+; RUN: llc -mtriple=riscv64 --relocation-model=pic -target-abi lp64d -mattr=+xcheri,+f,+d -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,HYBRID
 
-declare void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) noalias nocapture writeonly, ptr addrspace(200) noalias nocapture readonly, i64, i1 immarg) #1
-declare void @llvm.memmove.p200.p200.i64(ptr addrspace(200) nocapture writeonly, ptr addrspace(200) nocapture readonly, i64, i1 immarg) #1
+declare void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) noalias nocapture writeonly, ptr addrspace(200) noalias nocapture readonly, i64, i1 immarg)
+declare void @llvm.memmove.p200.p200.i64(ptr addrspace(200) nocapture writeonly, ptr addrspace(200) nocapture readonly, i64, i1 immarg)
 
 define void @memcpy_too_big_unaligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
 entry:
   call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align 16 %src, i64 2048, i1 false)
   ret void
   ; CHECK-LABEL: memcpy_too_big_unaligned:
-  ; PURECAP: clcbi $c12, %capcall20(memcpy)
-  ; HYBRID: jal	memcpy_c
+  ; PURECAP: ccall memcpy
+  ; HYBRID: call memcpy_c
 }
 
 define void @memcpy_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
@@ -21,34 +22,40 @@ entry:
   ret void
   ; This can be inlined;
   ; CHECK-LABEL: memcpy_aligned:
-  ; CHECK: # %bb.0:
-  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
-  ; PURECAP-NEXT: cjr $c17
-  ; HYBRID-NEXT:  jr $ra
-  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
 }
 
 define void @memcpy_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
 entry:
-  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) #2
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
   ret void
   ; Correctly aligned -> no need for libcall (even with attribute)
   ; CHECK-LABEL: memcpy_aligned_must_preserve_tags:
-  ; CHECK: # %bb.0:
-  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
-  ; PURECAP-NEXT: cjr $c17
-  ; HYBRID-NEXT:  jr $ra
-  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
 }
 
 define void @memcpy_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
 entry:
-  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) #2
+  call void @llvm.memcpy.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
   ret void
   ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
   ; CHECK-LABEL: memcpy_underaligned_must_preserve_tags:
-  ; PURECAP: clcbi $c12, %capcall20(memcpy)
-  ; HYBRID: jal	memcpy_c
+  ; PURECAP: ccall memcpy
+  ; HYBRID: call memcpy_c
 }
 
 
@@ -59,8 +66,8 @@ entry:
   call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 1 %dst, ptr addrspace(200) align 16 %src, i64 2048, i1 false)
   ret void
   ; CHECK-LABEL: memmove_too_big_unaligned:
-  ; PURECAP: clcbi $c12, %capcall20(memmove)
-  ; HYBRID: jal	memmove_c
+  ; PURECAP: ccall memmove
+  ; HYBRID: call memmove_c
 }
 
 define void @memmove_aligned(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
@@ -69,32 +76,38 @@ entry:
   ret void
   ; This can be inlined;
   ; CHECK-LABEL: memmove_aligned:
-  ; CHECK: # %bb.0:
-  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
-  ; PURECAP-NEXT: cjr $c17
-  ; HYBRID-NEXT:  jr $ra
-  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
 }
 
 define void @memmove_underaligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
 entry:
-  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) #2
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 8 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
   ret void
   ; The memmove could be inlined but was tagged with nobuiltin -> should call memmove()
   ; CHECK-LABEL: memmove_underaligned_must_preserve_tags:
-  ; PURECAP: clcbi $c12, %capcall20(memmove)
-  ; HYBRID: jal	memmove_c
+  ; PURECAP: ccall memmove
+  ; HYBRID: call memmove_c
 }
 
 define void @memmove_aligned_must_preserve_tags(ptr addrspace(200) %dst, ptr addrspace(200) %src) noinline nounwind {
 entry:
-  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) #2
+  call void @llvm.memmove.p200.p200.i64(ptr addrspace(200) align 16 %dst, ptr addrspace(200) align 16 %src, i64 16, i1 false) must_preserve_cheri_tags
   ret void
   ; Correctly aligned -> no need for libcall (even with attribute)
   ; CHECK-LABEL: memmove_aligned_must_preserve_tags:
-  ; CHECK: # %bb.0:
-  ; CHECK-NEXT: clc $c1, $zero, 0($c4)
-  ; PURECAP-NEXT: cjr $c17
-  ; HYBRID-NEXT:  jr $ra
-  ; CHECK-NEXT: csc $c1, $zero, 0($c3)
+  ; PURECAP: # %bb.0:
+  ; PURECAP-NEXT: clc a1, 0(a1)
+  ; PURECAP-NEXT: csc a1, 0(a0)
+  ; PURECAP-NEXT: cret
+  ; HYBRID: # %bb.0:
+  ; HYBRID-NEXT: lc.cap a1, (a1)
+  ; HYBRID-NEXT: sc.cap a1, (a0)
+  ; HYBRID-NEXT: ret
 }


### PR DESCRIPTION
This test checks the inline-vs-libcall lowering decision for
`addrspace(200) llvm.memcpy/llvm.memmove` as a function of
alignment, size, and the `must_preserve_cheri_tags` attribute,
for both purecap and hybrid.

The scenario is target-independent: introduced with the test in
c1dfd5f176d6 and updated in 23efd5e15294, both fixes live in
SelectionDAG.

The purecap part is already covered by
memcpy-no-preserve-tags-attr.ll and
memcpy-preserve-tags-size-not-multiple.ll, but the hybrid
part is not covered well: the only existing hybrid
`memcpy/memmove` tests (cheri-memfn-call.ll,
cheri-byval-argument-varargs.ll) only check the libcall path.
No existing test emits an inline hybrid cap copy (`lc.cap/sc.cap`)
or uses `must_preserve_cheri_tags` in hybrid mode.

Ported to CHERI-Generic using `!DO NOT AUTOGEN!`. The assertions
are written to preserve the original test's intention for all
platforms.
