### PR TITLE
[CHERI][clang] Defer checking of CHERI compartment annotation name mismatches until CodeGen.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -533,4 +533,12 @@ def err_cir_to_cir_transform_failed : Error<
 def err_cir_verification_failed_pre_passes : Error<
     "CIR module verification error before running CIR-to-CIR passes">,
     DefaultFatal;
+
+// CHERI Compartmentalization
+def err_cheri_implemented_wrong_compartment
+    : Error<"CHERI compartment entry declared for compartment '%0' but "
+            "implemented in '%1' (provided with -cheri-compartment=)">;
+def err_cheri_libcall_implemented_wrong_compartment
+    : Error<"CHERI libcall exported from compilation unit for compartment '%0' "
+            "(provided with -cheri-compartment=)">;
 }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1513,12 +1513,9 @@ def warn_objc_cdirective_format_string :
           "%select{method|CFfunction}2">,
   InGroup<ObjCCStringFormat>, DefaultIgnore;
 
-def err_cheri_ccallee_no_compartment: Error<
-  "CHERI compartment entry points require a compartment name provided with -cheri-compartment=">;
-def err_cheri_implemented_wrong_compartment: Error<
-  "CHERI compartment entry declared for compartment '%0' but implemented in '%1' (provided with -cheri-compartment=)">;
-def err_cheri_libcall_implemented_wrong_compartment: Error<
-  "CHERI libcall exported from compilation unit for compartment '%0' (provided with -cheri-compartment=)">;
+def err_cheri_ccallee_no_compartment
+    : Error<"CHERI compartment entry points require a compartment name "
+            "provided with -cheri-compartment=">;
 def warn_cheri_libcall_no_prototype
     : Warning<
           "CHERI libcall should have a prototype in a header with a matching "

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1008,9 +1008,27 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
     auto *FT =
       dyn_cast<FunctionType>(FD->getType().getDesugaredType(getContext()));
     if (FT) {
-      if (!CGM.getLangOpts().CheriCompartmentName.empty())
+      // Compartment name mismatch errors are intentionally delayed until
+      // CodeGen in order to support clang-tidy, where the command-line
+      // compartment name is often unset.
+      if (!CGM.getLangOpts().CheriCompartmentName.empty()) {
+        if (FD->hasAttr<CHERICompartmentNameAttr>() &&
+            FD->getAttr<CHERICompartmentNameAttr>()->getCompartmentName() !=
+                CGM.getLangOpts().CheriCompartmentName) {
+          CGM.getDiags().Report(FD->getLocation(),
+                                diag::err_cheri_implemented_wrong_compartment)
+              << FD->getAttr<CHERICompartmentNameAttr>()->getCompartmentName()
+              << CGM.getLangOpts().CheriCompartmentName;
+        } else if (FT->getCallConv() == CC_CHERILibCall && !FD->isInlined()) {
+          CGM.getDiags().Report(
+              FD->getLocation(),
+              diag::err_cheri_libcall_implemented_wrong_compartment)
+              << CGM.getLangOpts().CheriCompartmentName;
+        }
+
         Fn->addFnAttr("cheri-compartment",
                       CGM.getLangOpts().CheriCompartmentName);
+      }
       if (FT->getCallConv() == CC_CHERICCallee)
         if (auto *ClsAttr = FD->getAttr<CHERIMethodClassAttr>())
           CGM.EmitSandboxDefinedMethod(ClsAttr->getDefaultClass()->getName(),

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16436,19 +16436,6 @@ Decl *Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Decl *D,
            diag::warn_cheri_libcall_no_prototype);
   }
 
-  if (FD->getType()->getAs<FunctionType>()->getCallConv() == CC_CHERILibCall &&
-      !Context.getLangOpts().CheriCompartmentName.empty() && !FD->isInlined())
-    Diag(FD->getLocation(),
-         diag::err_cheri_libcall_implemented_wrong_compartment)
-        << Context.getLangOpts().CheriCompartmentName;
-  else if (FD->hasAttr<CHERICompartmentNameAttr>() &&
-           (FD->getAttr<CHERICompartmentNameAttr>()->getCompartmentName() !=
-            Context.getLangOpts().CheriCompartmentName) &&
-           !FD->isInlined())
-    Diag(FD->getLocation(), diag::err_cheri_implemented_wrong_compartment)
-        << FD->getAttr<CHERICompartmentNameAttr>()->getCompartmentName()
-        << Context.getLangOpts().CheriCompartmentName;
-
   maybeAddDeclWithEffects(FD);
 
   return D;

--- a/clang/test/Sema/cheri/cheri-mcu-compartment-warn-wrong-compartment.c
+++ b/clang/test/Sema/cheri/cheri-mcu-compartment-warn-wrong-compartment.c
@@ -8,17 +8,3 @@ int add(int a, int b) // wrong-compartment-error{{CHERI libcall exported from co
 {
 	return a+b;
 }
-
-__attribute__((cheriot_compartment("example")))
-int shouldBePrototype(void) // libcall-error{{CHERI compartment entry declared for compartment 'example' but implemented in '' (provided with -cheri-compartment=)}} wrong-compartment-error{{CHERI compartment entry declared for compartment 'example' but implemented in 'wrong' (provided with -cheri-compartment=)}}
-{
-	return 1;
-}
-
-__attribute__((cheriot_libcall))
-inline int inlineDefinition(int a, int b)
-// wrong-compartment-error@-1{{CHERI libcall should have a prototype in a header with a matching libcall annotation}}
-// libcall-error@-2{{CHERI libcall should have a prototype in a header with a matching libcall annotation}}
-{
-	return a+b;
-}

--- a/clang/test/Sema/cheri/cheri-mcu-compartment-warns-libcall-prototype-inline.c
+++ b/clang/test/Sema/cheri/cheri-mcu-compartment-warns-libcall-prototype-inline.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 %s -o - -triple riscv32cheriot-unknown-cheriotrtos -emit-llvm -mframe-pointer=none -mcmodel=small -target-abi cheriot -target-feature +xcheriot -Oz -Werror -verify=libcall
+// RUN: %clang_cc1 %s -o - -triple riscv32cheriot-unknown-cheriotrtos -emit-llvm -mframe-pointer=none -mcmodel=small -target-abi cheriot -target-feature +xcheriot -Oz -Werror -verify=wrong-compartment -cheri-compartment=wrong
+
+__attribute__((cheriot_libcall))
+inline int inlineDefinition(int a, int b)
+// wrong-compartment-error@-1{{CHERI libcall should have a prototype in a header with a matching libcall annotation}}
+// libcall-error@-2{{CHERI libcall should have a prototype in a header with a matching libcall annotation}}
+{
+	return a+b;
+}

--- a/clang/test/Sema/cheri/cheri-mcu-compartment-warns-libcall-prototype.c
+++ b/clang/test/Sema/cheri/cheri-mcu-compartment-warns-libcall-prototype.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 %s -o - -triple riscv32cheriot-unknown-cheriotrtos -emit-llvm -mframe-pointer=none -mcmodel=small -target-abi cheriot -target-feature +xcheriot -Oz -Werror -verify=wrong-compartment -cheri-compartment=wrong
+
+__attribute__((cheriot_compartment("example")))
+int shouldBePrototype(void) // libcall-error{{CHERI compartment entry declared for compartment 'example' but implemented in '' (provided with -cheri-compartment=)}} wrong-compartment-error{{CHERI compartment entry declared for compartment 'example' but implemented in 'wrong' (provided with -cheri-compartment=)}}
+{
+	return 1;
+}


### PR DESCRIPTION
The reason for this is to ensure that clang-tidy works even in environments where the CLI
compartment name is not set properly. This is fairly common, since clang-tidy is often run
without recreating the full compilation command.
