### PR TITLE
[CHERIoT][StaticAnalyzer] Treat heap_claim calls with the an allocation capability coming from the caller as escaping.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriotHeapChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriotHeapChecker.cpp
@@ -437,6 +437,18 @@ void CheriotHeapChecker::postHeapClaim(const CallEvent &Call,
   ProgramStateRef State =
       C.getState()->set<HeapPointers>(Sym, HeapPtrState::Claimed);
 
+  // If the allocation capability was also a cross-compartment argument,
+  // then it's possible / likely that the caller will free the claim, so
+  // we treat it as effectively escaped.
+  //
+  // This situation arises commonly where the callee is claiming on behalf
+  // of the caller, with claim release by the caller as an explicit part
+  // of the function contract.
+  SymbolRef AllocCap = Call.getArgSVal(0).getAsLocSymbol();
+  if (AllocCap && C.getState()->contains<HeapPointers>(AllocCap)) {
+    State = C.getState()->set<HeapPointers>(Sym, HeapPtrState::Escaped);
+  }
+
   // Assume that the claim always succeeds.
   BasicValueFactory &BVF = C.getSValBuilder().getBasicValueFactory();
   QualType RT = Call.getResultType();

--- a/clang/test/Analysis/Checkers/CHERI/cheriot-heap.c
+++ b/clang/test/Analysis/Checkers/CHERI/cheriot-heap.c
@@ -313,3 +313,8 @@ void test_41(struct test41_struct* t) {
     unknown_call();
     t->j = 0;
 }
+
+__attribute__((cheri_compartment("test")))
+void test_42(void* a, void* p) {
+    heap_claim(a, p);
+}


### PR DESCRIPTION
This is needed to avoid false positives on the pattern of functions that perform claims on behalf of the caller.
