### PR TITLE
[CHERIoT][StaticAnalyzer] Handle CHERIOT_DURING/CHERIOT_HANDLER in CheriotHeapChecker.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriotHeapChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CHERI/CheriotHeapChecker.cpp
@@ -144,6 +144,7 @@ class CheriotHeapChecker
        &CheriotHeapChecker::postCheckTimeoutPointer},
       {{CDM::SimpleFunc, {"timeout_is_valid"}},
        &CheriotHeapChecker::postCheckTimeoutPointer},
+      {{CDM::SimpleFunc, {"setjmp"}}, &CheriotHeapChecker::postSetJmp},
   };
 
   const CallDescriptionSet UnsealingFns{
@@ -174,6 +175,7 @@ public:
   void postHeapFreeAll(const CallEvent &Call, CheckerContext &C) const;
   void postCXXCheckPointer(const CallEvent &Call, CheckerContext &C) const;
   void postCheckTimeoutPointer(const CallEvent &Call, CheckerContext &C) const;
+  void postSetJmp(const CallEvent &Call, CheckerContext &C) const;
 
 private:
   void reportLeak(SymbolRef Sym, CheckerContext &C) const;
@@ -426,6 +428,21 @@ void CheriotHeapChecker::postCheckTimeoutPointer(const CallEvent &Call,
 
   if (StateFalse)
     C.addTransition(StateFalse);
+}
+
+void CheriotHeapChecker::postSetJmp(const CallEvent &Call,
+                                    CheckerContext &C) const {
+  // Assume that setjmp always returns true, i.e. that we are not
+  // analyzing the first return. The primary use case for setjmp
+  // on CHERIoT is implementing the CHERIOT_DURING / CHERIOT_HANDLER
+  // unwinding. In that scenario, all code executed between the
+  // first and second return is guarded by the handler, in which
+  // case we assume that any heap errors that occur during that
+  // region will be properly cleaned up by the handler.
+  ProgramStateRef State = C.getState();
+  State =
+      State->assume(Call.getReturnValue().castAs<DefinedOrUnknownSVal>(), true);
+  C.addTransition(State);
 }
 
 void CheriotHeapChecker::postHeapClaim(const CallEvent &Call,

--- a/clang/test/Analysis/Checkers/CHERI/cheriot-heap.c
+++ b/clang/test/Analysis/Checkers/CHERI/cheriot-heap.c
@@ -9,6 +9,7 @@ char check_pointer(const volatile void* ptr, int space,
                    unsigned int rawPermissions, char checkStackNeeded);
 _Bool heap_address_is_valid(void *);
 void *token_obj_unseal(void*, void*);
+int setjmp(void*, int);
 
 extern void unknown_call(void);
 extern int unknown_global;
@@ -317,4 +318,13 @@ void test_41(struct test41_struct* t) {
 __attribute__((cheri_compartment("test")))
 void test_42(void* a, void* p) {
     heap_claim(a, p);
+}
+
+__attribute__((cheri_compartment("test")))
+void test_43(int* p) {
+    unknown_call();
+    if (!setjmp(0, 1)) {
+        *p = 0;
+    }
+    *p = 0; // expected-warning{{Store through heap pointer 'p' without a valid claim}}
 }


### PR DESCRIPTION
This is achieved by the straight-forward hack of assuming that setjmp always returns non-zero, i.e.
we never analyze the first return from setjmp. Since setjmp is the primitive used to implement
CHERIOT_DURING/CHERIOT_HANDLER, this effective causes the analysis to ignore the body of the
CHERIOT_DURING. This reduces false positives, since we choose to assume that the installed
CHERIOT_HANDLER is responsible for cleanly handling any heap errors present in the guarded region.
