### PR TITLE
[CHERIoT][clang] Add warnings for compartment call function pointer parameters and return values that lack the cheriot_ccallback attribute.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -199,6 +199,7 @@ def CHERIPrototypesStrict: DiagGroup<"cheri-prototypes-strict">;
 def CheriSubobjectBoundsSuspicous : DiagGroup<"cheri-subobject-bounds-suspicious">;
 def CheriSubobjectBoundsRemarks : DiagGroup<"cheri-subobject-bounds">;
 def CHERICompartmentReturnVoid : DiagGroup<"cheri-compartment-return-void">;
+def CHERIoTCompartmentFnPtrs : DiagGroup<"cheriot-compartment-fn-ptrs">;
 
 def CheriAll : DiagGroup<"cheri",
      [CHERICaps, CHERIBitwiseOps, CHERIMisaligned, CHERIImplicitConversion, CheriSubobjectBoundsSuspicous,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1556,6 +1556,15 @@ def warn_cheri_libcall_no_prototype
           "CHERI libcall should have a prototype in a header with a matching "
           "libcall annotation">,
       InGroup<CHERIPrototypes>;
+def warn_cheriot_error_prone_fn_ptr_arg
+    : Warning<"a function pointer without the cheriot_ccallback attribute as "
+              "a parameter to a compartment call is error-prone">,
+      InGroup<CHERIoTCompartmentFnPtrs>;
+def warn_cheriot_error_prone_fn_ptr_ret
+    : Warning<"a function pointer without the cheriot_ccallback attribute as "
+              "the return value from a compartment call is error-prone">,
+      InGroup<CHERIoTCompartmentFnPtrs>;
+
 def err_cheri_method_class_must_exist: Error<
   "attributes '%0' requires a valid declaration">;
 def err_cheri_method_class_must_have_correct_type: Error<

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12757,6 +12757,33 @@ bool Sema::CheckFunctionDeclaration(Scope *S, FunctionDecl *NewFD,
   if (DeclIsDefn && Context.getTargetInfo().getTriple().isAArch64())
     ARM().CheckSMEFunctionDefAttributes(NewFD);
 
+  // On CHERIoT, function pointers passing between compartments need to be
+  // marked with the cheriot_ccallback attribute to be callable.
+  bool isCheriot = Context.getTargetInfo().getTargetOpts().ABI == "cheriot";
+  const FunctionType *FT = NewFD->getType()->castAs<FunctionType>();
+  if (isCheriot && NewFD->isFirstDecl() &&
+      (FT->getCallConv() == CC_CHERICCall ||
+       FT->getCallConv() == CC_CHERICCallback)) {
+    QualType RetTy = NewFD->getReturnType().getDesugaredType(Context);
+    if (const auto *RetPT = dyn_cast<PointerType>(RetTy)) {
+      const FunctionType *RetFT = dyn_cast<FunctionType>(
+          RetPT->getPointeeType().getDesugaredType(Context));
+      if (RetFT && RetFT->getCallConv() != CC_CHERICCallback)
+        Diag(NewFD->getReturnTypeSourceRange().getBegin(),
+             diag::warn_cheriot_error_prone_fn_ptr_ret);
+    }
+
+    for (const ParmVarDecl *PV : NewFD->parameters()) {
+      QualType PVTy = PV->getType().getDesugaredType(Context);
+      if (const auto *PVPT = dyn_cast<PointerType>(PVTy)) {
+        const FunctionType *PvFnFT = dyn_cast<FunctionType>(
+            PVPT->getPointeeType().getDesugaredType(Context));
+        if (PvFnFT && PvFnFT->getCallConv() != CC_CHERICCallback)
+          Diag(PV->getLocation(), diag::warn_cheriot_error_prone_fn_ptr_arg);
+      }
+    }
+  }
+
   return Redeclaration;
 }
 

--- a/clang/test/Sema/cheri/cheriot-compartment-fn-ptr.c
+++ b/clang/test/Sema/cheri/cheriot-compartment-fn-ptr.c
@@ -1,0 +1,29 @@
+// RUN: %riscv32_cheri_cc1 "-triple" "riscv32-unknown-cheriotrtos" "-target-abi" "cheriot" -verify %s
+
+typedef void (*FnPtr)();
+typedef __attribute__((cheriot_ccallback)) void (*FnPtrWithAttribute)();
+
+
+void foo();
+__attribute__((cheriot_ccallback)) void bar();
+
+__attribute__((cheri_compartment("test")))
+FnPtr test_1() { // expected-warning{{a function pointer without the cheriot_ccallback attribute as the return value from a compartment call is error-prone}}
+    return foo;
+}
+
+__attribute__((cheri_compartment("test")))
+FnPtrWithAttribute test_2() {
+    return bar;
+}
+
+__attribute__((cheri_compartment("test")))
+void test_3(FnPtr f) {} // expected-warning{{a function pointer without the cheriot_ccallback attribute as a parameter to a compartment call is error-prone}}
+
+__attribute__((cheri_compartment("test")))
+void test_4(FnPtrWithAttribute f) {}
+
+__attribute__((cheri_compartment("test")))
+void test_5(FnPtr f); // expected-warning{{a function pointer without the cheriot_ccallback attribute as a parameter to a compartment call is error-prone}}
+__attribute__((cheri_compartment("test")))
+void test_5(FnPtr f) { }


### PR DESCRIPTION
It is not safe to call a function pointer passed across a compartment boundary without this attribute, so we flag a warning in Sema to note that this pattern is error-prone.
