### PR TITLE
Revert "[CHERI][clang] Allow cheri_ccallback function pointers to decay to normal function pointers, but not vice-versa."

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -11805,11 +11805,8 @@ QualType ASTContext::mergeFunctionTypes(QualType lhs, QualType rhs,
 
   // Compatible functions must have compatible calling conventions
   if (lbaseInfo.getCC() != rbaseInfo.getCC()) {
-    // cheriot: Allow decay of CC_CHERI_LibCall and CC_CHERICCallback to CC_C.
-    bool LHSIsCCC = (lbaseInfo.getCC() == CC_C);
-    bool RHSCanDecayToCCC = (rbaseInfo.getCC() == CC_CHERILibCall ||
-                             rbaseInfo.getCC() == CC_CHERICCallback);
-    if (!(LHSIsCCC && RHSCanDecayToCCC))
+    // cheriot: Allow decay of CC_CHERI_LibCall to CC_C.
+    if (!(lbaseInfo.getCC() == CC_C && rbaseInfo.getCC() == CC_CHERILibCall))
       return {};
   }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -10008,7 +10008,7 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
     return AssignConvertType::Compatible;
   }
 
-  // CHERI callbacks can decay to regular function pointers, but not vice-versa.
+  // CHERI callbacks may only be cast to other cheri callback types
   bool RHSIsCallback = false;
   bool LHSIsCallback = false;
   if (auto RHSPointer = RHSType->getAs<PointerType>())
@@ -10019,7 +10019,7 @@ AssignConvertType Sema::CheckAssignmentConstraints(QualType LHSType,
     if (auto LHSFnPTy = LHSPointer->getPointeeType()->getAs<FunctionType>())
       if (LHSFnPTy->getCallConv() == CC_CHERICCallback)
         LHSIsCallback = true;
-  if (LHSIsCallback && !RHSIsCallback)
+  if (RHSIsCallback != LHSIsCallback)
     return AssignConvertType::Incompatible;
 
   // Conversions to normal pointers.

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1991,10 +1991,8 @@ bool Sema::IsFunctionConversion(QualType FromType, QualType ToType) const {
 
   bool Changed = false;
 
-  // Drop CC_CHERILibCall or CC_CHERICCallback if not present in target type.
-  if ((FromEInfo.getCC() == CC_CHERILibCall ||
-       FromEInfo.getCC() == CC_CHERICCallback) &&
-      ToEInfo.getCC() == CC_C) {
+  // Drop CC_CHERILibCall CCif not present in target type.
+  if (FromEInfo.getCC() == CC_CHERILibCall && ToEInfo.getCC() == CC_C) {
     FromFn =
         Context.adjustFunctionType(FromFn, FromEInfo.withCallingConv(CC_C));
     Changed = true;

--- a/clang/test/Sema/cheri/cheriot-callback.c
+++ b/clang/test/Sema/cheri/cheriot-callback.c
@@ -1,6 +1,6 @@
 // RUN: %riscv32_cheri_cc1 "-triple" "riscv32-unknown-cheriotrtos" "-target-abi" "cheriot" -verify %s
 
-typedef void (*Fn)();
+
 typedef __attribute__((cheriot_ccallback)) void (*Callback)();
 void doesNotHaveAttribute() { }
 void __attribute__((cheriot_ccallback)) hasAttribute() { }
@@ -20,14 +20,8 @@ void test_2() {
 
 __attribute__((cheri_compartment("test")))
 void test_3(int i) {
-    Callback f = i ? &doesNotHaveAttribute : &hasAttribute; // expected-error{{initializing 'Callback' (aka 'void (*)(void) __attribute__((cheri_ccallback))') with an expression of incompatible type 'void (*)()'}}
+    Callback f = i ? &doesNotHaveAttribute : &hasAttribute;
+    // expected-warning@-1{{pointer type mismatch ('void (*)()' and 'void (*)() __attribute__((cheri_ccallback))')}}
+    // expected-error@-2{{initializing 'Callback' (aka 'void (*)(void) __attribute__((cheri_ccallback))') with an expression of incompatible type 'void *'}}
     crossCompartmentCall(f);
-}
-
-Fn test_4() {
-    return doesNotHaveAttribute;
-}
-
-Fn test_5() {
-    return hasAttribute;
 }


### PR DESCRIPTION
This reverts commit 81a6c05705b3fff34560459b990cb273cb1b7c0a.
